### PR TITLE
Add talkable NPC marker

### DIFF
--- a/Model/Item/ICanBeTalkedTo.cs
+++ b/Model/Item/ICanBeTalkedTo.cs
@@ -1,0 +1,8 @@
+using Model.Interface;
+
+namespace Model.Item;
+
+/// <summary>
+/// Marker interface for items that can be the target of a conversation.
+/// </summary>
+public interface ICanBeTalkedTo : IInteractionTarget;

--- a/Planetfall/Item/Feinstein/Ambassador.cs
+++ b/Planetfall/Item/Feinstein/Ambassador.cs
@@ -1,8 +1,9 @@
 ﻿using Model.AIGeneration;
+using Model.Item;
 
 namespace Planetfall.Item.Feinstein;
 
-internal class Ambassador : QuirkyCompanion, ICanBeExamined
+internal class Ambassador : QuirkyCompanion, ICanBeExamined, ICanBeTalkedTo
 {
     public override string[] NounsForMatching => ["ambassador", "alien"];
 

--- a/Planetfall/Item/Feinstein/Blather.cs
+++ b/Planetfall/Item/Feinstein/Blather.cs
@@ -1,8 +1,9 @@
 ﻿using Model.AIGeneration;
+using Model.Item;
 
 namespace Planetfall.Item.Feinstein;
 
-internal class Blather : QuirkyCompanion, IAmANamedPerson, ITurnBasedActor
+internal class Blather : QuirkyCompanion, IAmANamedPerson, ITurnBasedActor, ICanBeTalkedTo
 {
     [UsedImplicitly]
     public int TurnsOnDeckNine { get; set; }

--- a/Planetfall/Item/Kalamontee/Mech/Floyd.cs
+++ b/Planetfall/Item/Kalamontee/Mech/Floyd.cs
@@ -2,11 +2,12 @@ using GameEngine.IntentEngine;
 using Model.AIGeneration;
 using Newtonsoft.Json;
 using Planetfall.Item.Kalamontee.Admin;
+using Model.Item;
 using Utilities;
 
 namespace Planetfall.Item.Kalamontee.Mech;
 
-public class Floyd : QuirkyCompanion, IAmANamedPerson, ICanHoldItems, ICanBeGivenThings
+public class Floyd : QuirkyCompanion, IAmANamedPerson, ICanHoldItems, ICanBeGivenThings, ICanBeTalkedTo
 {
     private readonly GiveSomethingToSomeoneDecisionEngine<Floyd> _giveHimSomethingEngine = new();
 


### PR DESCRIPTION
## Summary
- add new `ICanBeTalkedTo` marker interface
- mark Floyd, Blather and Ambassador with the new interface

## Testing
- `dotnet test --no-build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden due to environment restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_688577eef808832c937a184e1139cfaf