### PR TITLE
Add ConversationChecker class

### DIFF
--- a/GameEngine/ConversationChecker.cs
+++ b/GameEngine/ConversationChecker.cs
@@ -1,0 +1,100 @@
+namespace GameEngine;
+
+using Model.Item;
+using Model.Interface;
+using System.Linq;
+
+internal static class ConversationChecker
+{
+    internal static async Task<string?> CheckForConversation(
+        string input,
+        IContext context,
+        IGenerationClient client)
+    {
+        var talkables = new List<ICanBeTalkedTo>();
+
+        talkables.AddRange(context.Items.OfType<ICanBeTalkedTo>());
+        if (context.CurrentLocation is ICanContainItems container)
+            talkables.AddRange(container.Items.OfType<ICanBeTalkedTo>());
+
+        foreach (var talkable in talkables)
+        {
+            if (talkable is not IItem item)
+                continue;
+
+            foreach (var noun in item.NounsForMatching)
+            {
+                var lowerInput = input.ToLowerInvariant();
+                var lowerNoun = noun.ToLowerInvariant();
+
+                if (lowerInput.StartsWith(lowerNoun + ","))
+                {
+                    var text = input.Substring(noun.Length + 1).Trim();
+                    return await talkable.OnBeingTalkedTo(text, context, client);
+                }
+
+                foreach (var verb in Verbs.SayVerbs)
+                {
+                    var verbLower = verb.ToLowerInvariant();
+
+                    // verb noun
+                    var prefix = verbLower + " " + lowerNoun;
+                    if (lowerInput.StartsWith(prefix))
+                    {
+                        var text = input.Substring(prefix.Length).TrimStart(' ', '.', ',', ':').Trim();
+                        text = StripOuterQuotes(text);
+                        return await talkable.OnBeingTalkedTo(text, context, client);
+                    }
+
+                    // verb [to|at] noun
+                    foreach (var prep in new[] { "to", "at" })
+                    {
+                        var prefixWithPrep = verbLower + " " + prep + " " + lowerNoun;
+                        if (lowerInput.StartsWith(prefixWithPrep))
+                        {
+                            var text = input.Substring(prefixWithPrep.Length).TrimStart(' ', '.', ',', ':').Trim();
+                            text = StripOuterQuotes(text);
+                            return await talkable.OnBeingTalkedTo(text, context, client);
+                        }
+                    }
+                }
+
+                // verb text [to|at] noun  (say "hi" to bob)
+                var words = lowerInput.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+                if (words.Length >= 2)
+                {
+                    var firstWord = words[0];
+                    var lastWord = words[^1].TrimEnd('.', '!', '?', '\'', '"');
+
+                    if (Verbs.SayVerbs.Any(v => string.Equals(v, firstWord, StringComparison.OrdinalIgnoreCase)) &&
+                        string.Equals(lastWord, lowerNoun, StringComparison.OrdinalIgnoreCase))
+                    {
+                        var middleWords = words.Skip(1).Take(words.Length - 2).ToList();
+                        if (middleWords.Count > 0 && (middleWords[^1] == "to" || middleWords[^1] == "at"))
+                            middleWords.RemoveAt(middleWords.Count - 1);
+
+                        var text = string.Join(" ", middleWords).TrimStart(' ', '.', ',', ':').Trim();
+                        text = StripOuterQuotes(text);
+                        return await talkable.OnBeingTalkedTo(text, context, client);
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static string StripOuterQuotes(string text)
+    {
+        if (text.Length >= 2)
+        {
+            if ((text.StartsWith("\"") && text.EndsWith("\"")) ||
+                (text.StartsWith("'") && text.EndsWith("'")))
+            {
+                return text[1..^1];
+            }
+        }
+
+        return text;
+    }
+}

--- a/GameEngine/GameEngine.cs
+++ b/GameEngine/GameEngine.cs
@@ -216,6 +216,11 @@ public class GameEngine<TInfocomGame, TContext> : IGameEngine
             return await ProcessActorsAndContextEndOfTurn(contextPrepend, resultMessage);
         }
 
+        // Is the player talking to someone?
+        var conversation = await ConversationChecker.CheckForConversation(_currentInput!, Context, GenerationClient);
+        if (conversation is not null)
+            return await ProcessActorsAndContextEndOfTurn(contextPrepend, conversation);
+
         // 6. ------- Complex parsed commands. These require a parser to break them down into their noun(s) and verb.
 
         // if the user referenced an object using "it", let's see if we can handle that.
@@ -488,6 +493,7 @@ public class GameEngine<TInfocomGame, TContext> : IGameEngine
         var result = await generationClient.GenerateNarration(request, context.SystemPromptAddendum);
         return result + Environment.NewLine;
     }
+
 
     private async Task<string> GetGeneratedNoCommandResponse()
     {

--- a/Model/Item/ICanBeTalkedTo.cs
+++ b/Model/Item/ICanBeTalkedTo.cs
@@ -1,8 +1,19 @@
 using Model.Interface;
+using Model.AIGeneration;
 
 namespace Model.Item;
 
 /// <summary>
 /// Marker interface for items that can be the target of a conversation.
 /// </summary>
-public interface ICanBeTalkedTo : IInteractionTarget;
+public interface ICanBeTalkedTo : IInteractionTarget
+{
+    /// <summary>
+    /// Invoked when the player attempts to talk to this character.
+    /// </summary>
+    /// <param name="text">The text the player spoke.</param>
+    /// <param name="context">The current game context.</param>
+    /// <param name="client">Generation client for producing dialog.</param>
+    /// <returns>The response text from the character.</returns>
+    Task<string> OnBeingTalkedTo(string text, IContext context, IGenerationClient client);
+}

--- a/Model/Verbs.cs
+++ b/Model/Verbs.cs
@@ -21,5 +21,5 @@ public static class Verbs
     public static readonly string[] ThrowVerbs = ["throw", "toss", "launch", "hurl", "fling", "heave", "chuck", "lob"];
 
     public static readonly string[] SayVerbs =
-        ["say", "yell", "shout", "utter", "scream", "mumble", "whisper", "speak", "declare", "state", "announce"];
+        ["say", "yell", "shout", "utter", "scream", "mumble", "whisper", "speak", "declare", "state", "announce", "tell"];
 }

--- a/Planetfall/Item/Feinstein/Ambassador.cs
+++ b/Planetfall/Item/Feinstein/Ambassador.cs
@@ -90,4 +90,9 @@ internal class Ambassador : QuirkyCompanion, ICanBeExamined, ICanBeTalkedTo
     {
         StartWithItemInside<Celery>();
     }
+
+    public Task<string> OnBeingTalkedTo(string text, IContext context, IGenerationClient client)
+    {
+        return Task.FromResult(string.Empty);
+    }
 }

--- a/Planetfall/Item/Feinstein/Blather.cs
+++ b/Planetfall/Item/Feinstein/Blather.cs
@@ -106,4 +106,9 @@ internal class Blather : QuirkyCompanion, IAmANamedPerson, ITurnBasedActor, ICan
     {
 
     }
+
+    public Task<string> OnBeingTalkedTo(string text, IContext context, IGenerationClient client)
+    {
+        return Task.FromResult(string.Empty);
+    }
 }

--- a/Planetfall/Item/Kalamontee/Mech/Floyd.cs
+++ b/Planetfall/Item/Kalamontee/Mech/Floyd.cs
@@ -260,6 +260,11 @@ public class Floyd : QuirkyCompanion, IAmANamedPerson, ICanHoldItems, ICanBeGive
     {
         ItemBeingHeld = null;
     }
+
+    public Task<string> OnBeingTalkedTo(string text, IContext context, IGenerationClient client)
+    {
+        return Task.FromResult(string.Empty);
+    }
 }
 
 // TODO: Floyd gives you a nudge with his foot and giggles. "You sure look silly sleeping on the floor," he says.

--- a/UnitTests/TalkToCharacterTests.cs
+++ b/UnitTests/TalkToCharacterTests.cs
@@ -1,0 +1,131 @@
+using GameEngine.Item;
+using Model.AIGeneration;
+using Model.Interface;
+using Model.Item;
+using Model.Location;
+
+namespace UnitTests;
+
+public class TalkToCharacterTests : EngineTestsBase
+{
+    internal class TestTalker : ItemBase, ICanBeTalkedTo
+    {
+        public bool WasCalled { get; private set; }
+        public string? ReceivedText { get; private set; }
+
+        public override string[] NounsForMatching => ["bob"];
+
+        public override string GenericDescription(ILocation? currentLocation) => string.Empty;
+
+        public Task<string> OnBeingTalkedTo(string text, IContext context, IGenerationClient client)
+        {
+            WasCalled = true;
+            ReceivedText = text;
+            return Task.FromResult("ok");
+        }
+    }
+
+    [Test]
+    public async Task CommaSeparatedFormat_TalksToCharacter()
+    {
+        var engine = GetTarget();
+        var talker = Repository.GetItem<TestTalker>();
+        (engine.Context.CurrentLocation as ICanContainItems)!.ItemPlacedHere(talker);
+
+        await engine.GetResponse("bob, hello there");
+
+        talker.WasCalled.Should().BeTrue();
+        talker.ReceivedText.Should().Be("hello there");
+    }
+
+    [Test]
+    public async Task SayVerbFormat_TalksToCharacter()
+    {
+        var engine = GetTarget();
+        var talker = Repository.GetItem<TestTalker>();
+        (engine.Context.CurrentLocation as ICanContainItems)!.ItemPlacedHere(talker);
+
+        await engine.GetResponse("say to bob. 'hi'");
+
+        talker.WasCalled.Should().BeTrue();
+        talker.ReceivedText.Should().Be("hi");
+    }
+
+    [Test]
+    public async Task YellAtFormat_TalksToCharacter()
+    {
+        var engine = GetTarget();
+        var talker = Repository.GetItem<TestTalker>();
+        (engine.Context.CurrentLocation as ICanContainItems)!.ItemPlacedHere(talker);
+
+        await engine.GetResponse("yell at bob get out");
+
+        talker.WasCalled.Should().BeTrue();
+        talker.ReceivedText.Should().Be("get out");
+    }
+
+    [Test]
+    public async Task YellToFormat_TalksToCharacter()
+    {
+        var engine = GetTarget();
+        var talker = Repository.GetItem<TestTalker>();
+        (engine.Context.CurrentLocation as ICanContainItems)!.ItemPlacedHere(talker);
+
+        await engine.GetResponse("yell to bob you stink");
+
+        talker.WasCalled.Should().BeTrue();
+        talker.ReceivedText.Should().Be("you stink");
+    }
+
+    [Test]
+    public async Task TellFormat_TalksToCharacter()
+    {
+        var engine = GetTarget();
+        var talker = Repository.GetItem<TestTalker>();
+        (engine.Context.CurrentLocation as ICanContainItems)!.ItemPlacedHere(talker);
+
+        await engine.GetResponse("tell bob hello");
+
+        talker.WasCalled.Should().BeTrue();
+        talker.ReceivedText.Should().Be("hello");
+    }
+
+    [Test]
+    public async Task SayTextToFormat_TalksToCharacter()
+    {
+        var engine = GetTarget();
+        var talker = Repository.GetItem<TestTalker>();
+        (engine.Context.CurrentLocation as ICanContainItems)!.ItemPlacedHere(talker);
+
+        await engine.GetResponse("say 'hi' to bob");
+
+        talker.WasCalled.Should().BeTrue();
+        talker.ReceivedText.Should().Be("hi");
+    }
+
+    [Test]
+    public async Task SayTextToFormat_DoubleQuotes_TalksToCharacter()
+    {
+        var engine = GetTarget();
+        var talker = Repository.GetItem<TestTalker>();
+        (engine.Context.CurrentLocation as ICanContainItems)!.ItemPlacedHere(talker);
+
+        await engine.GetResponse("say \"hi\" to bob");
+
+        talker.WasCalled.Should().BeTrue();
+        talker.ReceivedText.Should().Be("hi");
+    }
+
+    [Test]
+    public async Task SayTextToFormat_NoQuotes_TalksToCharacter()
+    {
+        var engine = GetTarget();
+        var talker = Repository.GetItem<TestTalker>();
+        (engine.Context.CurrentLocation as ICanContainItems)!.ItemPlacedHere(talker);
+
+        await engine.GetResponse("say hi to bob");
+
+        talker.WasCalled.Should().BeTrue();
+        talker.ReceivedText.Should().Be("hi");
+    }
+}


### PR DESCRIPTION
## Summary
- pull conversation detection logic out of GameEngine
- call new `ConversationChecker` to parse talk commands
- strip outer quotes from speech text before invoking callbacks
- adjust tests to expect stripped speech text for variations like `say "hi" to bob`

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68857abd3154832c8972c7bd1a5eaa3b