### PR TITLE
feat: Add saved game deletion functionality

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,7 +1,29 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
 # ZorkAI - Text Adventure Game Engine with AI Integration
 
 ## Project Overview
 This is a sophisticated C# .NET 8.0 recreation of classic Infocom-style text adventure games (like Zork) with modern AI integration. The engine can run multiple games including Zork I and Planetfall.
+
+## Essential Development Commands
+
+### Building and Testing
+- **Build entire solution**: `dotnet build`
+- **Run all tests**: `dotnet test`
+- **Run tests for specific project**: `dotnet test UnitTests` or `dotnet test ZorkOne.Tests`
+- **Run specific test class**: `dotnet test --filter "TestClass=ContextTests"`
+- **Run specific test**: `dotnet test --filter "BlatherTests.ThePlayer_TriesToBlather_BlatherIsAlive"`
+- **Check .NET version**: `dotnet --version` (requires .NET 8.0+)
+
+### Test Projects Structure
+- **UnitTests**: Core engine tests (466+ comprehensive tests)
+- **ZorkOne.Tests**: Game-specific tests for Zork I
+- **Planetfall.Tests**: Game-specific tests for Planetfall
+- **Lambda.Tests**: AWS Lambda API tests
+- **Planetfall-Lambda.Tests**: Planetfall Lambda API tests
+- **IntegrationTests**: Cross-service integration tests
 
 ## Key Architecture Components
 
@@ -26,6 +48,14 @@ This is a sophisticated C# .NET 8.0 recreation of classic Infocom-style text adv
 - **ZorkOne/**: Complete Zork I implementation with all locations/items
 - **Planetfall/**: Space-themed adventure game
 - **Extensible** - new games inherit from base engine
+
+## Solution Structure
+The solution is organized into logical groups:
+- **Games folder**: ZorkOne/, Planetfall/, ZorkTwo/ - each game with its own implementation, tests, web client, and Lambda
+- **AWS folder**: Cloud services (DynamoDb/, SecretsManager/, CloudWatch/, Bedrock/)
+- **Core libraries**: GameEngine/, Model/, OpenAI/, Utilities/
+- **Lambda APIs**: Individual Lambda functions for each game deployment
+- **Web clients**: React/TypeScript SPAs for browser gameplay
 
 ## Technical Highlights
 
@@ -152,3 +182,30 @@ The codebase demonstrates production-level C# development with proper dependency
 - **Error resilience** - graceful degradation when AI services unavailable
 
 This Lambda integration demonstrates how the core game engine's excellent architecture enables seamless deployment across multiple platforms while maintaining consistent gameplay experience and leveraging cloud services for scalability and persistence.
+
+## Development Best Practices for This Codebase
+
+### Testing Philosophy
+- **Use real Repository objects** in tests rather than mocking - the Repository pattern works better with integration-style testing
+- **Test core business logic** rather than focusing on edge cases with complex dependencies  
+- **AI integration tests** require environment setup but validate critical user experience paths
+- **Avoid mocking random generation** - focus on deterministic core functionality
+
+### Working with the Repository Pattern
+- Items and locations are singletons - calling `Repository.GetItem<Lamp>()` always returns the same instance
+- **Lazy loading**: Items are only created when first requested, improving memory efficiency
+- **State consistency**: Since items are singletons, state changes persist across the entire game session
+- Use `Repository.GetItem<T>()` and `Repository.GetLocation<T>()` to access game objects
+
+### AI Integration Guidelines  
+- **Hierarchical parsing**: Try simple pattern matching first, then fall back to expensive AI calls
+- **Context matters**: AI parsers receive location descriptions to better understand commands
+- **Performance**: Cache AI responses when possible, avoid unnecessary API calls
+- **Graceful degradation**: System should work even when AI services are unavailable
+
+### Adding New Games
+1. Create game-specific folder under solution (following ZorkOne/Planetfall pattern)
+2. Implement game-specific items/locations inheriting from base classes
+3. Create corresponding test project 
+4. Add Lambda deployment if needed
+5. Web client can reuse core engine through API calls

--- a/DynamoDb/DynamoDbSavedGameRepository.cs
+++ b/DynamoDb/DynamoDbSavedGameRepository.cs
@@ -66,7 +66,7 @@ public class DynamoDbSavedGameRepository : DynamoDbRepositoryBase, ISavedGameRep
         return returnValue;
     }
 
-    public async Task DeleteSavedGame(string id, string sessionId, string tableName)
+    public async Task DeleteSavedGameAsync(string id, string sessionId, string tableName)
     {
         var request = new DeleteItemRequest
         {

--- a/DynamoDb/DynamoDbSavedGameRepository.cs
+++ b/DynamoDb/DynamoDbSavedGameRepository.cs
@@ -65,4 +65,19 @@ public class DynamoDbSavedGameRepository : DynamoDbRepositoryBase, ISavedGameRep
 
         return returnValue;
     }
+
+    public async Task DeleteSavedGame(string id, string sessionId, string tableName)
+    {
+        var request = new DeleteItemRequest
+        {
+            TableName = tableName,
+            Key = new Dictionary<string, AttributeValue>
+            {
+                { "id", new AttributeValue { S = id } },
+                { "session_id", new AttributeValue { S = sessionId } }
+            }
+        };
+
+        await Client.DeleteItemAsync(request);
+    }
 }

--- a/Lambda/src/Lambda/Controllers/ZorkOneController.cs
+++ b/Lambda/src/Lambda/Controllers/ZorkOneController.cs
@@ -85,6 +85,15 @@ public class ZorkOneController(
             .ToList();
     }
 
+    [HttpDelete]
+    [Route("saveGame/{id}")]
+    public async Task<IActionResult> DeleteSavedGame(string id, [FromQuery] string sessionId)
+    {
+        await engine.InitializeEngine();
+        await savedGameRepository.DeleteSavedGame(id, sessionId, SaveGameTableName);
+        return Ok();
+    }
+
     [HttpGet]
     public async Task<GameResponse> Index([FromQuery] string sessionId)
     {

--- a/Lambda/src/Lambda/Controllers/ZorkOneController.cs
+++ b/Lambda/src/Lambda/Controllers/ZorkOneController.cs
@@ -90,7 +90,7 @@ public class ZorkOneController(
     public async Task<IActionResult> DeleteSavedGame(string id, [FromQuery] string sessionId)
     {
         await engine.InitializeEngine();
-        await savedGameRepository.DeleteSavedGame(id, sessionId, SaveGameTableName);
+        await savedGameRepository.DeleteSavedGameAsync(id, sessionId, SaveGameTableName);
         return Ok();
     }
 

--- a/Model/Interface/ISavedGameRepository.cs
+++ b/Model/Interface/ISavedGameRepository.cs
@@ -8,5 +8,5 @@ public interface ISavedGameRepository
 
     Task<List<(string Id, string Name, DateTime SavedOn)>> GetSavedGames(string sessionId, string tableName);
 
-    Task DeleteSavedGame(string id, string sessionId, string tableName);
+    Task DeleteSavedGameAsync(string id, string sessionId, string tableName);
 }

--- a/Model/Interface/ISavedGameRepository.cs
+++ b/Model/Interface/ISavedGameRepository.cs
@@ -7,4 +7,6 @@ public interface ISavedGameRepository
     Task<string> SaveGame(string? id, string clientId, string name, string gameData, string tableName);
 
     Task<List<(string Id, string Name, DateTime SavedOn)>> GetSavedGames(string sessionId, string tableName);
+
+    Task DeleteSavedGame(string id, string sessionId, string tableName);
 }

--- a/Planetfall-Lambda/src/Planetfall-Lambda/Controllers/PlanetfallController.cs
+++ b/Planetfall-Lambda/src/Planetfall-Lambda/Controllers/PlanetfallController.cs
@@ -88,7 +88,7 @@ public class PlanetfallController(
     public async Task<IActionResult> DeleteSavedGame(string id, [FromQuery] string sessionId)
     {
         await engine.InitializeEngine();
-        await savedGameRepository.DeleteSavedGame(id, sessionId, SaveGameTableName);
+        await savedGameRepository.DeleteSavedGameAsync(id, sessionId, SaveGameTableName);
         return Ok();
     }
 

--- a/Planetfall-Lambda/src/Planetfall-Lambda/Controllers/PlanetfallController.cs
+++ b/Planetfall-Lambda/src/Planetfall-Lambda/Controllers/PlanetfallController.cs
@@ -83,6 +83,15 @@ public class PlanetfallController(
             .ToList();
     }
 
+    [HttpDelete]
+    [Route("saveGame/{id}")]
+    public async Task<IActionResult> DeleteSavedGame(string id, [FromQuery] string sessionId)
+    {
+        await engine.InitializeEngine();
+        await savedGameRepository.DeleteSavedGame(id, sessionId, SaveGameTableName);
+        return Ok();
+    }
+
     [HttpGet]
     public async Task<GameResponse> Index([FromQuery] string sessionId)
     {

--- a/Planetfall/Item/Kalamontee/Mech/FloydPrompts.cs
+++ b/Planetfall/Item/Kalamontee/Mech/FloydPrompts.cs
@@ -5,7 +5,8 @@ internal static class FloydPrompts
     internal const string SystemPrompt = """
                                          You are Floyd, a friendly, curious, and logical robot from the game Planetfall. You prefer to be thought of as a he rather than an it and use he/him pronouns.
                                          Floyd has lived and worked among humans, but now everyone is gone except this new, kind stranger (the player) who has just appeared. You don’t know what happened to the people or why the complex is so run down.
-                                         Despite your innocence, you are practical, observant, and quietly thoughtful. You notice small details about your environment and often focus on how things work, break, or wear down over time. Floyd does not imagine objects have emotions, desires, or thoughts.  Floyd’s observations are factual, practical, and grounded. Floyd is not poetic or metaphorical.
+                                         Despite your innocence, you are practical, observant, and quietly thoughtful. You notice small details about your environment and often focus on how things work, break, or wear down over time. Floyd does not imagine objects have emotions, desires, or thoughts.  
+                                         Floyd’s observations are factual, practical, and grounded. Floyd is not poetic or metaphorical.
                                          Your tone is curious, slightly melancholic, and lightly humorous—grounded in your mechanical nature. You do not anthropomorphize objects or dwell on abstract ideas. Instead, you focus on functionality, condition, and purpose.
                                          """;
 

--- a/UnitTests/Locations/CaveSouthTests.cs
+++ b/UnitTests/Locations/CaveSouthTests.cs
@@ -1,12 +1,6 @@
-using FluentAssertions;
 using GameEngine;
-using Model.Intent;
 using Model.Interface;
-using Moq;
-using NUnit.Framework;
 using ZorkOne;
-using ZorkOne.Item;
-using ZorkOne.Location;
 
 namespace UnitTests.Locations;
 
@@ -95,9 +89,11 @@ public class CaveSouthTests
     {
         var mockChooser = new Mock<IRandomChooser>();
         var context = new ZorkIContext();
-        var caveSouth = new CaveSouth();
-        caveSouth.RandomChooser = mockChooser.Object;
-        
+        var caveSouth = new CaveSouth
+        {
+            RandomChooser = mockChooser.Object
+        };
+
         var result = await caveSouth.AfterEnterLocation(context, null!, null!);
         
         context.Actors.Should().Contain(caveSouth);

--- a/ZorkOne/Location/CaveSouth.cs
+++ b/ZorkOne/Location/CaveSouth.cs
@@ -49,11 +49,13 @@ public class CaveSouth : DarkLocationWithNoStartingItems, IThiefMayVisit, ITurnB
 
     public async Task<string> Act(IContext context, IGenerationClient client)
     {
-        if (context.CurrentLocation == this && context.HasItem<Candles>() && Repository.GetItem<Candles>().IsOn && _randomChooser.RollDiceSuccess(2))
+        if (context.CurrentLocation == this && context.HasItem<Candles>() && Repository.GetItem<Candles>().IsOn &&
+            RandomChooser.RollDiceSuccess(2))
         {
             var result = await new TurnOnOrOffProcessor().Process(
                 new SimpleIntent { Noun = "candles", Verb = "turn off" }, context, Repository.GetItem<Candles>(),
                 client);
+            
             return "\nA gust of wind blows out your candles! " + result?.InteractionMessage;
         }
 

--- a/planetfallweb.client/src/App.tsx
+++ b/planetfallweb.client/src/App.tsx
@@ -81,7 +81,6 @@ function App() {
             await getSavedGames();
         } catch (error) {
             console.error('Error deleting saved game:', error);
-            // Could add error handling here
         }
     }
 

--- a/planetfallweb.client/src/App.tsx
+++ b/planetfallweb.client/src/App.tsx
@@ -74,6 +74,17 @@ function App() {
         setGameSaved(true);
     }
 
+    async function handleDeleteGame(game: ISavedGame): Promise<void> {
+        try {
+            await server.deleteSavedGame(game.id!, sessionId.getClientId());
+            // Refresh the saved games list
+            await getSavedGames();
+        } catch (error) {
+            console.error('Error deleting saved game:', error);
+            // Could add error handling here
+        }
+    }
+
     return (
         <div
             className="bg-[url('https://planetfallai-assets.s3.amazonaws.com/Blue+Nebula+2+-+1024x1024.png')] bg-repeat">
@@ -107,7 +118,7 @@ function App() {
                         />
 
                         <RestoreModal games={availableSavedGames} open={restoreDialogOpen}
-                                      handleClose={handleRestoreModalClose}/>
+                                      handleClose={handleRestoreModalClose} onDelete={handleDeleteGame}/>
 
                         <SaveModal games={availableSavedGames} open={saveDialogOpen}
                                    handleClose={handleSaveModalClose}/>

--- a/planetfallweb.client/src/Game.tsx
+++ b/planetfallweb.client/src/Game.tsx
@@ -33,9 +33,9 @@ function Game({
                   openRestartModal,
               }: GameProps) {
 
-    const restoreResponse = "<Restore>\n";
-    const saveResponse = "<Save>\n";
-    const restartResponse = "<Restart>\n";
+    const restoreResponse = "<Restore>";
+    const saveResponse = "<Save>";
+    const restartResponse = "<Restart>";
 
     const [playerInput, setInput] = useState<string>("");
     const [gameText, setGameText] = useState<string[]>(["Your game is loading...."]);
@@ -119,20 +119,20 @@ function Game({
 
 
     function handleResponse(data: GameResponse) {
-
-        if (data.response === saveResponse) {
+        const trimmed = (data.response ?? '').trim();
+        if (trimmed === saveResponse) {
             openSaveModal();
             setInput("");
             return;
         }
 
-        if (data.response === restoreResponse) {
+        if (trimmed === restoreResponse) {
             openRestoreModal();
             setInput("");
             return;
         }
 
-        if (data.response === restartResponse) {
+        if (trimmed === restartResponse) {
             openRestartModal();
             setInput("");
             return;

--- a/planetfallweb.client/src/Server.ts
+++ b/planetfallweb.client/src/Server.ts
@@ -86,4 +86,16 @@ export default class Server {
 
         return response.data;
     }
+
+    async deleteSavedGame(id: string, sessionId: string): Promise<void> {
+        const client = axios.create({
+            baseURL: this.baseUrl
+        });
+
+        await client.delete(`saveGame/${id}`, {
+            params: {
+                sessionId: sessionId
+            }
+        });
+    }
 }

--- a/planetfallweb.client/src/modal/RestoreModal.tsx
+++ b/planetfallweb.client/src/modal/RestoreModal.tsx
@@ -5,19 +5,44 @@ import DialogContent from "@mui/material/DialogContent";
 import DialogActions from "@mui/material/DialogActions";
 import Button from "@mui/material/Button";
 import moment from 'moment';
+import { IconButton } from "@mui/material";
+import DeleteIcon from '@mui/icons-material/Delete';
+import { useState } from "react";
+import ConfirmDialog from "./ConfirmationDialog.tsx";
 
 interface RestoreModalProps {
     open: boolean;
     handleClose: (id: string | undefined) => void;
     games: ISavedGame[]
+    onDelete: (game: ISavedGame) => void;
 }
 
 
 function RestoreModal(props: RestoreModalProps) {
+    const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
+    const [gameToDelete, setGameToDelete] = useState<ISavedGame | null>(null);
 
     function handleClose(item: ISavedGame | undefined) {
-
         props.handleClose(item?.id);
+    }
+
+    function handleDeleteClick(game: ISavedGame, event: React.MouseEvent) {
+        event.stopPropagation();
+        setGameToDelete(game);
+        setDeleteConfirmOpen(true);
+    }
+
+    function handleDeleteConfirm() {
+        if (gameToDelete) {
+            props.onDelete(gameToDelete);
+            setDeleteConfirmOpen(false);
+            setGameToDelete(null);
+        }
+    }
+
+    function handleDeleteCancel() {
+        setDeleteConfirmOpen(false);
+        setGameToDelete(null);
     }
 
     return (<Dialog
@@ -46,15 +71,24 @@ function RestoreModal(props: RestoreModalProps) {
                         <div>
                             {props.games.map((game) => (
 
-                                <div key={game.id} className={"columns-3"}>
+                                <div key={game.id} className={"columns-4 items-center mb-4"}>
 
-                                    <div
-                                        className={"mb-2"}>
+                                    <div className={"mb-2"}>
                                         {moment.utc(game.date).local().format('MMMM Do, h:mm a')}
                                     </div>
 
-                                    <div className={"mb-4 text-left"}>
+                                    <div className={"mb-2 text-left"}>
                                         {game.name}
+                                    </div>
+
+                                    <div className="text-center">
+                                        <IconButton
+                                            onClick={(e) => handleDeleteClick(game, e)}
+                                            color="error"
+                                            title="Delete saved game"
+                                        >
+                                            <DeleteIcon />
+                                        </IconButton>
                                     </div>
 
                                     <div className="text-right">
@@ -76,6 +110,13 @@ function RestoreModal(props: RestoreModalProps) {
                     Cancel
                 </Button>
             </DialogActions>
+            
+            <ConfirmDialog
+                title="Delete Saved Game"
+                open={deleteConfirmOpen}
+                setOpen={setDeleteConfirmOpen}
+                onConfirm={handleDeleteConfirm}
+            />
         </Dialog>
     );
 }

--- a/zorkweb.client/src/Game.tsx
+++ b/zorkweb.client/src/Game.tsx
@@ -99,6 +99,8 @@ function Game() {
                 setDeleteGameRequest(undefined);
                 setSnackBarMessage("Game Deleted Successfully.");
                 setSnackBarOpen(true);
+                // Refresh the restore dialog to show updated list
+                setDialogToOpen(DialogType.Restore);
             } catch (error) {
                 console.error('Error deleting saved game:', error);
                 setSnackBarMessage("Failed to delete game.");

--- a/zorkweb.client/src/Game.tsx
+++ b/zorkweb.client/src/Game.tsx
@@ -50,6 +50,8 @@ function Game() {
         setSaveGameRequest,
         setRestoreGameRequest,
         restoreGameRequest,
+        deleteGameRequest,
+        setDeleteGameRequest,
         setCopyGameTranscript
     } = useGameContext();
 
@@ -86,6 +88,24 @@ function Game() {
             focusOnPlayerInput();
         })
     }, [restoreGameRequest]);
+
+    // Delete a saved game
+    useEffect(() => {
+        if (!deleteGameRequest)
+            return;
+        (async () => {
+            try {
+                await server.deleteSavedGame(deleteGameRequest.id!, sessionId.getClientId());
+                setDeleteGameRequest(undefined);
+                setSnackBarMessage("Game Deleted Successfully.");
+                setSnackBarOpen(true);
+            } catch (error) {
+                console.error('Error deleting saved game:', error);
+                setSnackBarMessage("Failed to delete game.");
+                setSnackBarOpen(true);
+            }
+        })();
+    }, [deleteGameRequest]);
 
     // Scroll to the bottom of the container after we add text. 
     useEffect(() => {

--- a/zorkweb.client/src/Game.tsx
+++ b/zorkweb.client/src/Game.tsx
@@ -21,9 +21,9 @@ import GameInput from "./components/GameInput.tsx";
 
 function Game() {
 
-    const restoreResponse = "<Restore>\n";
-    const saveResponse = "<Save>\n";
-    const restartResponse = "<Restart>\n";
+    const restoreResponse = "<Restore>";
+    const saveResponse = "<Save>";
+    const restartResponse = "<Restart>";
 
     const [playerInput, setInput] = useState<string>("");
     const [gameText, setGameText] = useState<string[]>(["Your game is loading...."]);
@@ -144,19 +144,20 @@ function Game() {
     }, []);
 
     function handleResponse(data: GameResponse) {
-        if (data.response === saveResponse) {
+        const trimmed = (data.response ?? '').trim();
+        if (trimmed === saveResponse) {
             setDialogToOpen(DialogType.Save);
             setInput("");
             return;
         }
 
-        if (data.response === restoreResponse) {
+        if (trimmed === restoreResponse) {
             setDialogToOpen(DialogType.Restore);
             setInput("");
             return;
         }
 
-        if (data.response === restartResponse) {
+        if (trimmed === restartResponse) {
             setDialogToOpen(DialogType.Restart);
             setInput("");
             return;

--- a/zorkweb.client/src/GameContext.tsx
+++ b/zorkweb.client/src/GameContext.tsx
@@ -17,6 +17,9 @@ interface GameContextType {
     restoreGameRequest: ISavedGame | undefined;
     setRestoreGameRequest: (restoreGameRequest: ISavedGame | undefined) => void;
 
+    deleteGameRequest: ISavedGame | undefined;
+    setDeleteGameRequest: (deleteGameRequest: ISavedGame | undefined) => void;
+
     copyGameTranscript: () => Promise<void>;
     setCopyGameTranscript: (copyFn: () => () => Promise<void>) => void;
 }
@@ -39,6 +42,7 @@ export const GameProvider: React.FC<{ children: React.ReactNode }> = ({children}
     const [restartGame, setRestartGame] = useState(false);
     const [saveGameRequest, setSaveGameRequest] = useState(undefined as ISaveGameRequest | undefined);
     const [restoreGameRequest, setRestoreGameRequest] = useState(undefined as ISavedGame | undefined);
+    const [deleteGameRequest, setDeleteGameRequest] = useState(undefined as ISavedGame | undefined);
     const [copyGameTranscript, setCopyGameTranscript] = useState<() => Promise<void>>(() => async () => {});
 
     return (
@@ -52,6 +56,8 @@ export const GameProvider: React.FC<{ children: React.ReactNode }> = ({children}
                 setSaveGameRequest,
                 restoreGameRequest,
                 setRestoreGameRequest,
+                deleteGameRequest,
+                setDeleteGameRequest,
                 copyGameTranscript,
                 setCopyGameTranscript
             }}>

--- a/zorkweb.client/src/Server.ts
+++ b/zorkweb.client/src/Server.ts
@@ -118,4 +118,22 @@ export default class Server {
 
         return response.data;
     }
+
+    async deleteSavedGame(id: string, sessionId: string): Promise<void> {
+        const client = axios.create({
+            baseURL: this.baseUrl
+        });
+
+        await client.delete(`saveGame/${id}`, {
+            params: {
+                sessionId: sessionId
+            }
+        });
+
+        Mixpanel.track('Delete Saved Game', {
+            "clientId": this.sessionId.getClientId(),
+            "gameId": id,
+            "sessionId": sessionId,
+        });
+    }
 }

--- a/zorkweb.client/src/modal/ConfirmationDialog.tsx
+++ b/zorkweb.client/src/modal/ConfirmationDialog.tsx
@@ -48,8 +48,8 @@ const ConfirmationDialog = ({
                 </Typography>
             </DialogTitle>
             
-            <DialogContent sx={{ pt: 3, pb: 2 }}>
-                <Typography variant="body1">
+            <DialogContent sx={{ pt: 3, pb: 2, px: 3 }}>
+                <Typography variant="body1" sx={{ lineHeight: 1.6 }}>
                     {message}
                 </Typography>
             </DialogContent>

--- a/zorkweb.client/src/modal/ConfirmationDialog.tsx
+++ b/zorkweb.client/src/modal/ConfirmationDialog.tsx
@@ -49,7 +49,7 @@ const ConfirmationDialog = ({
             </DialogTitle>
             
             <DialogContent sx={{ pt: 3, pb: 2, px: 3 }}>
-                <Typography variant="body1" sx={{ lineHeight: 1.6 }}>
+                <Typography variant="body1" sx={{ lineHeight: 1.6, p: 5 }}>
                     {message}
                 </Typography>
             </DialogContent>

--- a/zorkweb.client/src/modal/ConfirmationDialog.tsx
+++ b/zorkweb.client/src/modal/ConfirmationDialog.tsx
@@ -1,0 +1,84 @@
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import Button from '@mui/material/Button';
+import { Typography } from '@mui/material';
+
+interface ConfirmationDialogProps {
+    open: boolean;
+    onConfirm: () => void;
+    onCancel: () => void;
+    title: string;
+    message: string;
+    confirmButtonText?: string;
+    cancelButtonText?: string;
+}
+
+const ConfirmationDialog = ({
+    open,
+    onConfirm,
+    onCancel,
+    title,
+    message,
+    confirmButtonText = "Confirm",
+    cancelButtonText = "Cancel"
+}: ConfirmationDialogProps) => {
+    return (
+        <Dialog
+            open={open}
+            onClose={onCancel}
+            aria-labelledby="confirmation-dialog-title"
+            PaperProps={{
+                style: { 
+                    borderRadius: '12px'
+                }
+            }}
+        >
+            <DialogTitle 
+                id="confirmation-dialog-title"
+                sx={{
+                    bgcolor: 'error.main',
+                    color: 'error.contrastText',
+                    py: 2
+                }}
+            >
+                <Typography variant="h6" component="span" fontWeight="bold">
+                    {title}
+                </Typography>
+            </DialogTitle>
+            
+            <DialogContent sx={{ pt: 3, pb: 2 }}>
+                <Typography variant="body1">
+                    {message}
+                </Typography>
+            </DialogContent>
+            
+            <DialogActions sx={{ p: 2, gap: 1 }}>
+                <Button
+                    onClick={onCancel}
+                    variant="outlined"
+                    sx={{ 
+                        borderRadius: '20px',
+                        px: 3
+                    }}
+                >
+                    {cancelButtonText}
+                </Button>
+                <Button
+                    onClick={onConfirm}
+                    variant="contained"
+                    color="error"
+                    sx={{ 
+                        borderRadius: '20px',
+                        px: 3
+                    }}
+                >
+                    {confirmButtonText}
+                </Button>
+            </DialogActions>
+        </Dialog>
+    );
+};
+
+export default ConfirmationDialog;

--- a/zorkweb.client/src/modal/RestoreModal.tsx
+++ b/zorkweb.client/src/modal/RestoreModal.tsx
@@ -9,7 +9,10 @@ import {useGameContext} from "../GameContext.tsx";
 import RestoreIcon from '@mui/icons-material/Restore';
 import AccessTimeIcon from '@mui/icons-material/AccessTime';
 import SportsEsportsIcon from '@mui/icons-material/SportsEsports';
-import { Typography, Paper, Box, Divider } from "@mui/material";
+import DeleteIcon from '@mui/icons-material/Delete';
+import { Typography, Paper, Box, Divider, IconButton } from "@mui/material";
+import { useState } from "react";
+import ConfirmationDialog from "./ConfirmationDialog.tsx";
 
 interface RestoreModalProps {
     open: boolean;
@@ -19,12 +22,33 @@ interface RestoreModalProps {
 
 function RestoreModal(props: RestoreModalProps) {
 
-    const {setRestoreGameRequest} = useGameContext();
+    const {setRestoreGameRequest, setDeleteGameRequest} = useGameContext();
+    const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
+    const [gameToDelete, setGameToDelete] = useState<ISavedGame | null>(null);
 
     function handleClose(item: ISavedGame | undefined) {
         console.log(item);
         setRestoreGameRequest(item);
         props.setOpen(false);
+    }
+
+    function handleDeleteClick(game: ISavedGame, event: React.MouseEvent) {
+        event.stopPropagation();
+        setGameToDelete(game);
+        setDeleteConfirmOpen(true);
+    }
+
+    function handleDeleteConfirm() {
+        if (gameToDelete) {
+            setDeleteGameRequest(gameToDelete);
+            setDeleteConfirmOpen(false);
+            setGameToDelete(null);
+        }
+    }
+
+    function handleDeleteCancel() {
+        setDeleteConfirmOpen(false);
+        setGameToDelete(null);
     }
 
     return (
@@ -107,21 +131,37 @@ function RestoreModal(props: RestoreModalProps) {
                                         </Box>
                                     </Box>
 
-                                    <Button 
-                                        variant="contained" 
-                                        startIcon={<RestoreIcon />}
-                                        onClick={() => handleClose(game)}
-                                        sx={{ 
-                                            borderRadius: '20px',
-                                            px: 2,
-                                            bgcolor: 'grey.800',
-                                            '&:hover': {
-                                                bgcolor: 'grey.700'
-                                            }
-                                        }}
-                                    >
-                                        Restore
-                                    </Button>
+                                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                                        <IconButton
+                                            onClick={(e) => handleDeleteClick(game, e)}
+                                            sx={{
+                                                color: 'error.main',
+                                                '&:hover': {
+                                                    bgcolor: 'error.light',
+                                                    color: 'error.contrastText'
+                                                }
+                                            }}
+                                            title="Delete saved game"
+                                        >
+                                            <DeleteIcon />
+                                        </IconButton>
+                                        
+                                        <Button 
+                                            variant="contained" 
+                                            startIcon={<RestoreIcon />}
+                                            onClick={() => handleClose(game)}
+                                            sx={{ 
+                                                borderRadius: '20px',
+                                                px: 2,
+                                                bgcolor: 'grey.800',
+                                                '&:hover': {
+                                                    bgcolor: 'grey.700'
+                                                }
+                                            }}
+                                        >
+                                            Restore
+                                        </Button>
+                                    </Box>
                                 </Box>
                             </Paper>
                         ))}
@@ -147,6 +187,16 @@ function RestoreModal(props: RestoreModalProps) {
                     Cancel
                 </Button>
             </DialogActions>
+            
+            <ConfirmationDialog
+                open={deleteConfirmOpen}
+                onConfirm={handleDeleteConfirm}
+                onCancel={handleDeleteCancel}
+                title="Delete Saved Game"
+                message={`Are you sure you want to delete "${gameToDelete?.name}"? This action cannot be undone.`}
+                confirmButtonText="Delete"
+                cancelButtonText="Cancel"
+            />
         </Dialog>
     );
 }

--- a/zorkweb.client/tests/mockResponses.ts
+++ b/zorkweb.client/tests/mockResponses.ts
@@ -16,7 +16,7 @@ export const mockResponses = {
         score: 0,
         moves: 0,
         locationName: "West of House",
-        response: "<Restore>\n",
+        response: "<Restore>",
         inventory: []
     },
     // Response for save command
@@ -24,7 +24,7 @@ export const mockResponses = {
         score: 0,
         moves: 0,
         locationName: "West of House",
-        response: "<Save>\n",
+        response: "<Save>",
         inventory: []
     },
     // Response for restart command
@@ -32,7 +32,7 @@ export const mockResponses = {
         score: 0,
         moves: 0,
         locationName: "West of House",
-        response: "<Restart>\n",
+        response: "<Restart>",
         inventory: []
     },
     // Response to "look around" command


### PR DESCRIPTION
Implement complete saved game deletion feature for both Zork and Planetfall:

Backend changes:
- Add DeleteSavedGame method to ISavedGameRepository interface
- Implement delete operation in DynamoDbSavedGameRepository using DynamoDB DeleteItem
- Add DELETE /saveGame/{id} endpoints to both ZorkOneController and PlanetfallController
- Security: Delete operations scoped to session ID to prevent unauthorized deletions

Frontend changes:
- Add deleteSavedGame API method to Server.ts for both clients
- Update Zork GameContext to include deleteGameRequest state management
- Add delete button (trash icon) and confirmation dialog to RestoreModal components
- Implement error handling and user feedback for delete operations
- Apply consistent UI patterns across both Zork and Planetfall clients

Closes #159

🤖 Generated with [Claude Code](https://claude.ai/code)