### PR TITLE
feat: Add game sharing functionality allowing users to share saved games via SessionId

### DIFF
--- a/zorkweb.client/src/App.tsx
+++ b/zorkweb.client/src/App.tsx
@@ -8,6 +8,8 @@ import {SessionHandler} from "./SessionHandler.ts";
 import RestoreModal from "./modal/RestoreModal.tsx";
 import {ISavedGame} from "./model/SavedGame.ts";
 import SaveModal from "./modal/SaveModal.tsx";
+import ShareModal from "./modal/ShareModal.tsx";
+import LoadSharedModal from "./modal/LoadSharedModal.tsx";
 import RestartConfirmDialog from "./modal/RestartConfirmDialog.tsx";
 import {useGameContext} from "./GameContext.tsx";
 import VideoDialog from "./modal/VideoModal.tsx";
@@ -21,6 +23,8 @@ function App() {
     const [restartConfirmOpen, setRestartConfirmOpen] = useState<boolean>(false);
     const [restoreDialogOpen, setRestoreDialogOpen] = useState<boolean>(false);
     const [saveDialogOpen, setSaveDialogOpen] = useState<boolean>(false);
+    const [shareDialogOpen, setShareDialogOpen] = useState<boolean>(false);
+    const [loadSharedDialogOpen, setLoadSharedDialogOpen] = useState<boolean>(false);
     const [availableSavedGames, setAvailableSavedGames] = useState<ISavedGame[]>([]);
     const [welcomeDialogOpen, setWelcomeDialogOpen] = useState<boolean>(false);
     const [videoDialogOpen, setVideoDialogOpen] = useState<boolean>(false);
@@ -30,7 +34,7 @@ function App() {
     const sessionId = new SessionHandler();
     const queryClient = new QueryClient();
 
-    const {dialogToOpen, setDialogToOpen, setRestartGame} = useGameContext();
+    const {dialogToOpen, setDialogToOpen, setRestartGame, setOnSharedGameCopied} = useGameContext();
 
     useEffect(() => {
         if (!dialogToOpen) {
@@ -68,6 +72,16 @@ function App() {
                     setReleaseNotesDialogOpen(true);
                     setDialogToOpen(undefined);
                     break;
+                case DialogType.Share:
+                    Mixpanel.track('Open Share Dialog', {});
+                    setShareDialogOpen(true);
+                    setDialogToOpen(undefined);
+                    break;
+                case DialogType.LoadShared:
+                    Mixpanel.track('Open Load Shared Dialog', {});
+                    setLoadSharedDialogOpen(true);
+                    setDialogToOpen(undefined);
+                    break;
                 default:
                     break;
             }
@@ -78,6 +92,12 @@ function App() {
         });
 
     }, [dialogToOpen]);
+
+    useEffect(() => {
+        setOnSharedGameCopied(() => async () => {
+            await getSavedGames();
+        });
+    }, [setOnSharedGameCopied]);
 
     const handleWatchVideo = () => {
         setWelcomeDialogOpen(false);
@@ -141,6 +161,18 @@ function App() {
                                        Mixpanel.track('Close Welcome Dialog', {});
                                    }}/>
 
+                    <ShareModal 
+                        open={shareDialogOpen}
+                        setOpen={setShareDialogOpen}
+                    />
+
+                    <LoadSharedModal
+                        open={loadSharedDialogOpen}
+                        setOpen={setLoadSharedDialogOpen}
+                        onGameCopied={() => {
+                            getSavedGames();
+                        }}
+                    />
 
                 </QueryClientProvider>
             </div>

--- a/zorkweb.client/src/GameContext.tsx
+++ b/zorkweb.client/src/GameContext.tsx
@@ -22,6 +22,9 @@ interface GameContextType {
 
     copyGameTranscript: () => Promise<void>;
     setCopyGameTranscript: (copyFn: () => () => Promise<void>) => void;
+
+    onSharedGameCopied: () => void;
+    setOnSharedGameCopied: (callback: () => void) => void;
 }
 
 // Create the context
@@ -44,6 +47,7 @@ export const GameProvider: React.FC<{ children: React.ReactNode }> = ({children}
     const [restoreGameRequest, setRestoreGameRequest] = useState(undefined as ISavedGame | undefined);
     const [deleteGameRequest, setDeleteGameRequest] = useState(undefined as ISavedGame | undefined);
     const [copyGameTranscript, setCopyGameTranscript] = useState<() => Promise<void>>(() => async () => {});
+    const [onSharedGameCopied, setOnSharedGameCopied] = useState<() => void>(() => () => {});
 
     return (
         <GameContext.Provider
@@ -59,7 +63,9 @@ export const GameProvider: React.FC<{ children: React.ReactNode }> = ({children}
                 deleteGameRequest,
                 setDeleteGameRequest,
                 copyGameTranscript,
-                setCopyGameTranscript
+                setCopyGameTranscript,
+                onSharedGameCopied,
+                setOnSharedGameCopied
             }}>
             {children}
         </GameContext.Provider>

--- a/zorkweb.client/src/__tests__/FunctionsMenu.test.tsx
+++ b/zorkweb.client/src/__tests__/FunctionsMenu.test.tsx
@@ -45,6 +45,8 @@ describe('FunctionsMenu Component', () => {
     expect(screen.getByText('Restart Your Game')).toBeInTheDocument();
     expect(screen.getByText('Restore a Previous Saved Game')).toBeInTheDocument();
     expect(screen.getByText('Save your Game')).toBeInTheDocument();
+    expect(screen.getByText('Share This Game')).toBeInTheDocument();
+    expect(screen.getByText('Load Shared Game')).toBeInTheDocument();
     expect(screen.getByText('Copy Game Transcript')).toBeInTheDocument();
   });
 
@@ -111,6 +113,32 @@ describe('FunctionsMenu Component', () => {
 
     // Check if setDialogToOpen was called with Save
     expect(mockSetDialogToOpen).toHaveBeenCalledWith(DialogType.Save);
+  });
+
+  test('opens Share dialog when "Share This Game" is clicked', () => {
+    render(<FunctionsMenu />);
+
+    // Open the menu
+    fireEvent.click(screen.getByTestId('game-button'));
+
+    // Click the "Share This Game" menu item
+    fireEvent.click(screen.getByText('Share This Game'));
+
+    // Check if setDialogToOpen was called with Share
+    expect(mockSetDialogToOpen).toHaveBeenCalledWith(DialogType.Share);
+  });
+
+  test('opens LoadShared dialog when "Load Shared Game" is clicked', () => {
+    render(<FunctionsMenu />);
+
+    // Open the menu
+    fireEvent.click(screen.getByTestId('game-button'));
+
+    // Click the "Load Shared Game" menu item
+    fireEvent.click(screen.getByText('Load Shared Game'));
+
+    // Check if setDialogToOpen was called with LoadShared
+    expect(mockSetDialogToOpen).toHaveBeenCalledWith(DialogType.LoadShared);
   });
 
   test('calls copyGameTranscript when "Copy Game Transcript" is clicked', () => {

--- a/zorkweb.client/src/__tests__/LoadSharedModal.test.tsx
+++ b/zorkweb.client/src/__tests__/LoadSharedModal.test.tsx
@@ -1,0 +1,219 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import LoadSharedModal from '../modal/LoadSharedModal';
+import { ISharedGame } from '../model/SharedGame';
+
+// Mock SessionHandler
+jest.mock('../SessionHandler', () => ({
+    SessionHandler: jest.fn().mockImplementation(() => ({
+        getClientId: () => 'TARGET123SESSION'
+    }))
+}));
+
+// Mock Server
+const mockGetSharedGames = jest.fn();
+const mockCopySharedGame = jest.fn();
+
+jest.mock('../Server', () => {
+    return jest.fn().mockImplementation(() => ({
+        getSharedGames: mockGetSharedGames,
+        copySharedGame: mockCopySharedGame
+    }));
+});
+
+describe('LoadSharedModal', () => {
+    const mockSetOpen = jest.fn();
+    const mockOnGameCopied = jest.fn();
+
+    const mockSharedGames: ISharedGame[] = [
+        {
+            id: 'game1',
+            name: 'My Adventure',
+            savedOn: new Date('2024-01-15T10:30:00Z')
+        },
+        {
+            id: 'game2', 
+            name: 'Epic Quest (from share)',
+            savedOn: new Date('2024-01-16T14:45:00Z')
+        }
+    ];
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockGetSharedGames.mockClear();
+        mockCopySharedGame.mockClear();
+    });
+
+    test('renders load shared modal correctly', () => {
+        render(
+            <LoadSharedModal 
+                open={true}
+                setOpen={mockSetOpen}
+                onGameCopied={mockOnGameCopied}
+            />
+        );
+
+        expect(screen.getByTestId('load-shared-game-modal')).toBeInTheDocument();
+        expect(screen.getByText('Load Shared Game')).toBeInTheDocument();
+        expect(screen.getByTestId('session-id-input')).toBeInTheDocument();
+        expect(screen.getByText('Enter a Session ID to view and copy available saved games.')).toBeInTheDocument();
+    });
+
+    test('validates session ID input correctly', () => {
+        render(
+            <LoadSharedModal 
+                open={true}
+                setOpen={mockSetOpen}
+                onGameCopied={mockOnGameCopied}
+            />
+        );
+
+        const input = screen.getByTestId('session-id-input').querySelector('input');
+        const loadButton = screen.getByTestId('load-shared-games-button');
+
+        // Test empty input
+        expect(loadButton).toBeDisabled();
+
+        // Test invalid format (too short)
+        fireEvent.change(input!, { target: { value: '123' } });
+        expect(screen.getByText('Session ID must be exactly 15 alphanumeric characters')).toBeInTheDocument();
+        expect(loadButton).toBeDisabled();
+
+        // Test invalid format (special characters)
+        fireEvent.change(input!, { target: { value: '123-456-789-012' } });
+        expect(screen.getByText('Session ID must be exactly 15 alphanumeric characters')).toBeInTheDocument();
+
+        // Test valid format
+        fireEvent.change(input!, { target: { value: 'ABC123DEF456GHI' } });
+        expect(screen.queryByText('Session ID must be exactly 15 alphanumeric characters')).not.toBeInTheDocument();
+        expect(loadButton).toBeEnabled();
+    });
+
+    test('loads shared games successfully', async () => {
+        mockGetSharedGames.mockResolvedValue(mockSharedGames);
+
+        render(
+            <LoadSharedModal 
+                open={true}
+                setOpen={mockSetOpen}
+                onGameCopied={mockOnGameCopied}
+            />
+        );
+
+        const input = screen.getByTestId('session-id-input').querySelector('input');
+        const loadButton = screen.getByTestId('load-shared-games-button');
+
+        fireEvent.change(input!, { target: { value: 'ABC123DEF456GHI' } });
+        fireEvent.click(loadButton);
+
+        expect(screen.getByText('Loading...')).toBeInTheDocument();
+
+        await waitFor(() => {
+            expect(mockGetSharedGames).toHaveBeenCalledWith('ABC123DEF456GHI');
+        });
+
+        expect(screen.getByText('Available Shared Games')).toBeInTheDocument();
+        expect(screen.getByText('My Adventure')).toBeInTheDocument();
+        expect(screen.getByText('Epic Quest (from share)')).toBeInTheDocument();
+    });
+
+    test('shows error when no games found', async () => {
+        mockGetSharedGames.mockResolvedValue([]);
+
+        render(
+            <LoadSharedModal 
+                open={true}
+                setOpen={mockSetOpen}
+                onGameCopied={mockOnGameCopied}
+            />
+        );
+
+        const input = screen.getByTestId('session-id-input').querySelector('input');
+        const loadButton = screen.getByTestId('load-shared-games-button');
+
+        fireEvent.change(input!, { target: { value: 'ABC123DEF456GHI' } });
+        fireEvent.click(loadButton);
+
+        await waitFor(() => {
+            expect(screen.getByText('No saved games found for this Session ID')).toBeInTheDocument();
+        });
+    });
+
+    test('handles API error when loading games', async () => {
+        mockGetSharedGames.mockRejectedValue(new Error('Network error'));
+
+        render(
+            <LoadSharedModal 
+                open={true}
+                setOpen={mockSetOpen}
+                onGameCopied={mockOnGameCopied}
+            />
+        );
+
+        const input = screen.getByTestId('session-id-input').querySelector('input');
+        const loadButton = screen.getByTestId('load-shared-games-button');
+
+        fireEvent.change(input!, { target: { value: 'ABC123DEF456GHI' } });
+        fireEvent.click(loadButton);
+
+        await waitFor(() => {
+            expect(screen.getByText('Failed to load shared games. Please check the Session ID and try again.')).toBeInTheDocument();
+        });
+    });
+
+    test('copies shared game successfully', async () => {
+        mockGetSharedGames.mockResolvedValue(mockSharedGames);
+        mockCopySharedGame.mockResolvedValue('new-game-id');
+
+        render(
+            <LoadSharedModal 
+                open={true}
+                setOpen={mockSetOpen}
+                onGameCopied={mockOnGameCopied}
+            />
+        );
+
+        // First load the games
+        const input = screen.getByTestId('session-id-input').querySelector('input');
+        const loadButton = screen.getByTestId('load-shared-games-button');
+
+        fireEvent.change(input!, { target: { value: 'ABC123DEF456GHI' } });
+        fireEvent.click(loadButton);
+
+        await waitFor(() => {
+            expect(screen.getByText('Available Shared Games')).toBeInTheDocument();
+        });
+
+        // Then copy a game
+        const copyButton = screen.getByTestId('copy-game-game1');
+        fireEvent.click(copyButton);
+
+        expect(screen.getByText('Copying...')).toBeInTheDocument();
+
+        await waitFor(() => {
+            expect(mockCopySharedGame).toHaveBeenCalledWith({
+                sourceSessionId: 'ABC123DEF456GHI',
+                targetSessionId: 'TARGET123SESSION',
+                sourceGameId: 'game1'
+            });
+            expect(mockOnGameCopied).toHaveBeenCalled();
+            expect(mockSetOpen).toHaveBeenCalledWith(false);
+        });
+    });
+
+    test('closes modal and resets state when cancelled', () => {
+        render(
+            <LoadSharedModal 
+                open={true}
+                setOpen={mockSetOpen}
+                onGameCopied={mockOnGameCopied}
+            />
+        );
+
+        const cancelButton = screen.getByText('Cancel');
+        fireEvent.click(cancelButton);
+
+        expect(mockSetOpen).toHaveBeenCalledWith(false);
+    });
+});

--- a/zorkweb.client/src/__tests__/ShareModal.test.tsx
+++ b/zorkweb.client/src/__tests__/ShareModal.test.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ShareModal from '../modal/ShareModal';
+
+// Mock SessionHandler
+jest.mock('../SessionHandler', () => ({
+    SessionHandler: jest.fn().mockImplementation(() => ({
+        getSessionId: () => ['ABC123DEF456GHI', false]
+    }))
+}));
+
+// Mock clipboard API
+Object.assign(navigator, {
+    clipboard: {
+        writeText: jest.fn().mockImplementation(() => Promise.resolve()),
+    },
+});
+
+describe('ShareModal', () => {
+    const mockSetOpen = jest.fn();
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test('renders share modal with session ID', () => {
+        render(
+            <ShareModal 
+                open={true}
+                setOpen={mockSetOpen}
+            />
+        );
+
+        expect(screen.getByTestId('share-game-modal')).toBeInTheDocument();
+        expect(screen.getByText('Share Your Game')).toBeInTheDocument();
+        expect(screen.getByTestId('session-id-display')).toHaveTextContent('ABC123DEF456GHI');
+        expect(screen.getByText('Share your Session ID with others so they can load copies of your saved games.')).toBeInTheDocument();
+    });
+
+    test('copies session ID to clipboard when copy button is clicked', async () => {
+        render(
+            <ShareModal 
+                open={true}
+                setOpen={mockSetOpen}
+            />
+        );
+
+        const copyButton = screen.getByTestId('copy-session-id-button');
+        fireEvent.click(copyButton);
+
+        await waitFor(() => {
+            expect(navigator.clipboard.writeText).toHaveBeenCalledWith('ABC123DEF456GHI');
+        });
+
+        expect(screen.getByText('Session ID copied to clipboard!')).toBeInTheDocument();
+    });
+
+    test('closes modal when close button is clicked', () => {
+        render(
+            <ShareModal 
+                open={true}
+                setOpen={mockSetOpen}
+            />
+        );
+
+        const closeButton = screen.getByText('Close');
+        fireEvent.click(closeButton);
+
+        expect(mockSetOpen).toHaveBeenCalledWith(false);
+    });
+
+    test('does not render modal when open is false', () => {
+        render(
+            <ShareModal 
+                open={false}
+                setOpen={mockSetOpen}
+            />
+        );
+
+        expect(screen.queryByTestId('share-game-modal')).not.toBeInTheDocument();
+    });
+
+    test('handles clipboard copy failure gracefully', async () => {
+        const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+        (navigator.clipboard.writeText as jest.Mock).mockRejectedValueOnce(new Error('Clipboard error'));
+
+        render(
+            <ShareModal 
+                open={true}
+                setOpen={mockSetOpen}
+            />
+        );
+
+        const copyButton = screen.getByTestId('copy-session-id-button');
+        fireEvent.click(copyButton);
+
+        await waitFor(() => {
+            expect(consoleErrorSpy).toHaveBeenCalledWith('Failed to copy session ID:', expect.any(Error));
+        });
+
+        consoleErrorSpy.mockRestore();
+    });
+});

--- a/zorkweb.client/src/menu/FunctionsMenu.tsx
+++ b/zorkweb.client/src/menu/FunctionsMenu.tsx
@@ -8,6 +8,8 @@ import RestartAltIcon from '@mui/icons-material/RestartAlt';
 import RestoreIcon from '@mui/icons-material/Restore';
 import SaveIcon from '@mui/icons-material/Save';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import ShareIcon from '@mui/icons-material/Share';
+import ContentPasteIcon from '@mui/icons-material/ContentPaste';
 import SportsEsportsIcon from '@mui/icons-material/SportsEsports';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import { ListItemIcon, ListItemText } from '@mui/material';
@@ -109,6 +111,26 @@ export default function FunctionsMenu() {
                         <SaveIcon fontSize="small" />
                     </ListItemIcon>
                     <ListItemText>Save your Game</ListItemText>
+                </MenuItem>
+
+                <MenuItem onClick={() => {
+                    setDialogToOpen(DialogType.Share);
+                    handleClose();
+                }}>
+                    <ListItemIcon>
+                        <ShareIcon fontSize="small" />
+                    </ListItemIcon>
+                    <ListItemText>Share This Game</ListItemText>
+                </MenuItem>
+
+                <MenuItem onClick={() => {
+                    setDialogToOpen(DialogType.LoadShared);
+                    handleClose();
+                }}>
+                    <ListItemIcon>
+                        <ContentPasteIcon fontSize="small" />
+                    </ListItemIcon>
+                    <ListItemText>Load Shared Game</ListItemText>
                 </MenuItem>
 
                 <MenuItem onClick={() => {

--- a/zorkweb.client/src/modal/LoadSharedModal.tsx
+++ b/zorkweb.client/src/modal/LoadSharedModal.tsx
@@ -1,0 +1,290 @@
+import Dialog from "@mui/material/Dialog";
+import DialogTitle from "@mui/material/DialogTitle";
+import DialogContent from "@mui/material/DialogContent";
+import DialogActions from "@mui/material/DialogActions";
+import Button from "@mui/material/Button";
+import {Typography, Paper, Box, TextField, Alert, Collapse} from "@mui/material";
+import React, {useState} from "react";
+import ContentPasteIcon from '@mui/icons-material/ContentPaste';
+import moment from 'moment';
+import {ISharedGame} from "../model/SharedGame.ts";
+import {ShareGameRequest} from "../model/ShareGameRequest.ts";
+import {SessionHandler} from "../SessionHandler.ts";
+import Server from "../Server.ts";
+import AccessTimeIcon from '@mui/icons-material/AccessTime';
+import SportsEsportsIcon from '@mui/icons-material/SportsEsports';
+
+interface LoadSharedModalProps {
+    open: boolean;
+    setOpen: (open: boolean) => void;
+    onGameCopied: () => void;
+}
+
+function LoadSharedModal(props: LoadSharedModalProps) {
+    const [sessionIdInput, setSessionIdInput] = useState("");
+    const [sharedGames, setSharedGames] = useState<ISharedGame[]>([]);
+    const [loading, setLoading] = useState(false);
+    const [copying, setCopying] = useState<string | null>(null);
+    const [error, setError] = useState<string>("");
+    const [validationError, setValidationError] = useState<string>("");
+
+    const sessionHandler = new SessionHandler();
+    const server = new Server();
+
+    const validateSessionId = (sessionId: string): boolean => {
+        const regex = /^[A-Za-z0-9]{15}$/;
+        return regex.test(sessionId);
+    };
+
+    const handleSessionIdChange = (value: string) => {
+        setSessionIdInput(value);
+        setValidationError("");
+        setError("");
+        
+        if (value && !validateSessionId(value)) {
+            setValidationError("Session ID must be exactly 15 alphanumeric characters");
+        }
+    };
+
+    const handleLoadSharedGames = async () => {
+        if (!sessionIdInput.trim()) {
+            setValidationError("Please enter a Session ID");
+            return;
+        }
+
+        if (!validateSessionId(sessionIdInput)) {
+            setValidationError("Session ID must be exactly 15 alphanumeric characters");
+            return;
+        }
+
+        setLoading(true);
+        setError("");
+        
+        try {
+            const games = await server.getSharedGames(sessionIdInput);
+            setSharedGames(games);
+            
+            if (games.length === 0) {
+                setError("No saved games found for this Session ID");
+            }
+        } catch (error) {
+            console.error('Error loading shared games:', error);
+            setError("Failed to load shared games. Please check the Session ID and try again.");
+            setSharedGames([]);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const handleCopyGame = async (game: ISharedGame) => {
+        setCopying(game.id);
+        setError("");
+
+        try {
+            const targetSessionId = sessionHandler.getClientId();
+            const request = new ShareGameRequest(sessionIdInput, targetSessionId, game.id);
+            
+            await server.copySharedGame(request);
+            props.onGameCopied();
+            handleClose();
+        } catch (error) {
+            console.error('Error copying shared game:', error);
+            setError("Failed to copy the shared game. Please try again.");
+        } finally {
+            setCopying(null);
+        }
+    };
+
+    const handleClose = () => {
+        props.setOpen(false);
+        setSessionIdInput("");
+        setSharedGames([]);
+        setError("");
+        setValidationError("");
+        setLoading(false);
+        setCopying(null);
+    };
+
+    const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+        if (event.key === 'Enter' && !validationError && sessionIdInput.trim()) {
+            handleLoadSharedGames();
+        }
+    };
+
+    return (
+        <Dialog
+            data-testid="load-shared-game-modal"
+            maxWidth="md"
+            open={props.open}
+            fullWidth={true}
+            aria-labelledby="load-shared-dialog-title"
+            PaperProps={{
+                style: {
+                    borderRadius: '12px',
+                    overflow: 'hidden'
+                }
+            }}
+        >
+            <DialogTitle
+                id="load-shared-dialog-title"
+                className="bg-gradient-to-r from-green-600 to-green-700"
+                sx={{
+                    color: 'white',
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 1,
+                    py: 2
+                }}
+            >
+                <ContentPasteIcon fontSize="large"/>
+                <Typography variant="h5" component="span" fontWeight="bold">
+                    Load Shared Game
+                </Typography>
+            </DialogTitle>
+
+            <DialogContent sx={{pt: 3, pb: 1}}>
+                <Paper
+                    elevation={2}
+                    sx={{
+                        p: 3,
+                        mb: 3,
+                        borderRadius: '8px',
+                        bgcolor: 'background.paper'
+                    }}
+                >
+                    <Typography variant="body1" sx={{mb: 3, color: 'grey.700'}}>
+                        Enter a Session ID to view and copy available saved games.
+                    </Typography>
+
+                    <Box sx={{display: 'flex', alignItems: 'flex-start', gap: 2, mb: 2}}>
+                        <TextField
+                            autoFocus
+                            label="Session ID"
+                            variant="outlined"
+                            fullWidth
+                            value={sessionIdInput}
+                            onChange={(e) => handleSessionIdChange(e.target.value)}
+                            onKeyDown={handleKeyDown}
+                            error={!!validationError}
+                            helperText={validationError || "15 alphanumeric characters"}
+                            inputProps={{
+                                maxLength: 15,
+                                style: { fontFamily: 'monospace', fontSize: '1.1rem' }
+                            }}
+                            data-testid="session-id-input"
+                        />
+                        <Button
+                            variant="contained"
+                            onClick={handleLoadSharedGames}
+                            disabled={loading || !sessionIdInput.trim() || !!validationError}
+                            sx={{
+                                borderRadius: '20px',
+                                px: 3,
+                                py: 1.5,
+                                bgcolor: 'green.600',
+                                '&:hover': {
+                                    bgcolor: 'green.700'
+                                }
+                            }}
+                            data-testid="load-shared-games-button"
+                        >
+                            {loading ? 'Loading...' : 'Load Games'}
+                        </Button>
+                    </Box>
+
+                    <Collapse in={!!error}>
+                        <Alert severity="error" sx={{mb: 2}}>
+                            {error}
+                        </Alert>
+                    </Collapse>
+                </Paper>
+
+                {sharedGames.length > 0 && (
+                    <Box sx={{maxHeight: '40vh', overflow: 'auto'}}>
+                        <Typography variant="h6" fontWeight="bold" sx={{mb: 2, color: 'grey.800'}}>
+                            Available Shared Games
+                        </Typography>
+                        
+                        <Box sx={{display: 'flex', flexDirection: 'column', gap: 2}}>
+                            {sharedGames.map((game) => (
+                                <Paper
+                                    key={game.id}
+                                    elevation={2}
+                                    sx={{
+                                        p: 2,
+                                        borderRadius: '8px',
+                                        transition: 'all 0.2s',
+                                        '&:hover': {
+                                            transform: 'translateY(-2px)',
+                                            boxShadow: 4
+                                        }
+                                    }}
+                                    data-testid="shared-game-item"
+                                >
+                                    <Box sx={{
+                                        display: 'flex',
+                                        justifyContent: 'space-between',
+                                        alignItems: 'center'
+                                    }}>
+                                        <Box sx={{display: 'flex', flexDirection: 'column', gap: 1, flex: 1}}>
+                                            <Typography variant="h6" fontWeight="bold" sx={{color: 'grey.800'}}>
+                                                {game.name}
+                                            </Typography>
+
+                                            <Box sx={{display: 'flex', alignItems: 'center', color: 'text.secondary'}}>
+                                                <AccessTimeIcon fontSize="small" sx={{mr: 1}}/>
+                                                <Typography variant="body2">
+                                                    {moment(game.savedOn).format('MMMM Do, h:mm a')}
+                                                </Typography>
+                                            </Box>
+                                        </Box>
+
+                                        <Button
+                                            variant="outlined"
+                                            disabled={copying === game.id}
+                                            onClick={() => handleCopyGame(game)}
+                                            sx={{
+                                                borderRadius: '20px',
+                                                px: 2,
+                                                borderColor: 'green.600',
+                                                color: 'green.700',
+                                                '&:hover': {
+                                                    borderColor: 'green.700',
+                                                    bgcolor: 'green.50'
+                                                }
+                                            }}
+                                            data-testid={`copy-game-${game.id}`}
+                                        >
+                                            {copying === game.id ? 'Copying...' : 'Copy Game'}
+                                        </Button>
+                                    </Box>
+                                </Paper>
+                            ))}
+                        </Box>
+                    </Box>
+                )}
+            </DialogContent>
+
+            <DialogActions sx={{p: 2, bgcolor: 'grey.100'}}>
+                <Button
+                    onClick={handleClose}
+                    variant="outlined"
+                    sx={{
+                        borderRadius: '20px',
+                        px: 3,
+                        borderColor: 'grey.600',
+                        color: 'grey.800',
+                        '&:hover': {
+                            borderColor: 'grey.800',
+                            bgcolor: 'grey.100'
+                        }
+                    }}
+                >
+                    Cancel
+                </Button>
+            </DialogActions>
+        </Dialog>
+    );
+}
+
+export default LoadSharedModal;

--- a/zorkweb.client/src/modal/ShareModal.tsx
+++ b/zorkweb.client/src/modal/ShareModal.tsx
@@ -1,0 +1,164 @@
+import Dialog from "@mui/material/Dialog";
+import DialogTitle from "@mui/material/DialogTitle";
+import DialogContent from "@mui/material/DialogContent";
+import DialogActions from "@mui/material/DialogActions";
+import Button from "@mui/material/Button";
+import {Typography, Paper, Box, IconButton, Snackbar, Alert} from "@mui/material";
+import React, {useState} from "react";
+import ShareIcon from '@mui/icons-material/Share';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import {SessionHandler} from "../SessionHandler.ts";
+
+interface ShareModalProps {
+    open: boolean;
+    setOpen: (open: boolean) => void;
+}
+
+function ShareModal(props: ShareModalProps) {
+    const [copySuccess, setCopySuccess] = useState(false);
+    const sessionHandler = new SessionHandler();
+    const sessionId = sessionHandler.getSessionId()[0];
+
+    const handleCopySessionId = async () => {
+        try {
+            await navigator.clipboard.writeText(sessionId);
+            setCopySuccess(true);
+        } catch (err) {
+            console.error('Failed to copy session ID:', err);
+        }
+    };
+
+    const handleClose = () => {
+        props.setOpen(false);
+        setCopySuccess(false);
+    };
+
+    return (
+        <>
+            <Dialog
+                data-testid="share-game-modal"
+                maxWidth="sm"
+                open={props.open}
+                fullWidth={true}
+                aria-labelledby="share-dialog-title"
+                PaperProps={{
+                    style: {
+                        borderRadius: '12px',
+                        overflow: 'hidden'
+                    }
+                }}
+            >
+                <DialogTitle
+                    id="share-dialog-title"
+                    className="bg-gradient-to-r from-blue-600 to-blue-700"
+                    sx={{
+                        color: 'white',
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: 1,
+                        py: 2
+                    }}
+                >
+                    <ShareIcon fontSize="large"/>
+                    <Typography variant="h5" component="span" fontWeight="bold">
+                        Share Your Game
+                    </Typography>
+                </DialogTitle>
+
+                <DialogContent sx={{pt: 3, pb: 1}}>
+                    <Paper
+                        elevation={2}
+                        sx={{
+                            p: 3,
+                            borderRadius: '8px',
+                            bgcolor: 'background.paper',
+                            textAlign: 'center'
+                        }}
+                    >
+                        <Typography variant="body1" sx={{mb: 3, color: 'grey.700'}}>
+                            Share your Session ID with others so they can load copies of your saved games.
+                        </Typography>
+
+                        <Box 
+                            sx={{
+                                display: 'flex',
+                                alignItems: 'center',
+                                gap: 1,
+                                p: 2,
+                                bgcolor: 'grey.100',
+                                borderRadius: '8px',
+                                border: '2px solid',
+                                borderColor: 'grey.300'
+                            }}
+                        >
+                            <Typography 
+                                variant="h6" 
+                                sx={{
+                                    fontFamily: 'monospace',
+                                    fontSize: '1.2rem',
+                                    color: 'grey.800',
+                                    flex: 1,
+                                    userSelect: 'all'
+                                }}
+                                data-testid="session-id-display"
+                            >
+                                {sessionId}
+                            </Typography>
+                            <IconButton
+                                onClick={handleCopySessionId}
+                                sx={{
+                                    bgcolor: 'primary.main',
+                                    color: 'white',
+                                    '&:hover': {
+                                        bgcolor: 'primary.dark'
+                                    }
+                                }}
+                                data-testid="copy-session-id-button"
+                            >
+                                <ContentCopyIcon />
+                            </IconButton>
+                        </Box>
+
+                        <Typography variant="body2" sx={{mt: 2, color: 'grey.600'}}>
+                            Click the copy button to copy your Session ID to clipboard
+                        </Typography>
+                    </Paper>
+                </DialogContent>
+
+                <DialogActions sx={{p: 2, bgcolor: 'grey.100'}}>
+                    <Button
+                        onClick={handleClose}
+                        variant="contained"
+                        sx={{
+                            borderRadius: '20px',
+                            px: 3,
+                            bgcolor: 'primary.main',
+                            '&:hover': {
+                                bgcolor: 'primary.dark'
+                            }
+                        }}
+                    >
+                        Close
+                    </Button>
+                </DialogActions>
+            </Dialog>
+
+            <Snackbar
+                open={copySuccess}
+                autoHideDuration={3000}
+                onClose={() => setCopySuccess(false)}
+                anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+            >
+                <Alert 
+                    onClose={() => setCopySuccess(false)} 
+                    severity="success" 
+                    sx={{ width: '100%' }}
+                >
+                    Session ID copied to clipboard!
+                </Alert>
+            </Snackbar>
+        </>
+    );
+}
+
+export default ShareModal;

--- a/zorkweb.client/src/model/DialogType.ts
+++ b/zorkweb.client/src/model/DialogType.ts
@@ -4,7 +4,9 @@ enum DialogType {
     Welcome = "Welcome",
     Restore = "Restore",
     Restart = "Restart",
-    ReleaseNotes = "ReleaseNotes"
+    ReleaseNotes = "ReleaseNotes",
+    Share = "Share",
+    LoadShared = "LoadShared"
 }
 
 export default DialogType;

--- a/zorkweb.client/src/model/ShareGameRequest.ts
+++ b/zorkweb.client/src/model/ShareGameRequest.ts
@@ -1,0 +1,17 @@
+export interface IShareGameRequest {
+    sourceSessionId: string;
+    targetSessionId: string;
+    sourceGameId: string;
+}
+
+export class ShareGameRequest implements IShareGameRequest {
+    sourceSessionId: string;
+    targetSessionId: string;
+    sourceGameId: string;
+
+    constructor(sourceSessionId: string, targetSessionId: string, sourceGameId: string) {
+        this.sourceSessionId = sourceSessionId;
+        this.targetSessionId = targetSessionId;
+        this.sourceGameId = sourceGameId;
+    }
+}

--- a/zorkweb.client/src/model/SharedGame.ts
+++ b/zorkweb.client/src/model/SharedGame.ts
@@ -1,0 +1,17 @@
+export interface ISharedGame {
+    id: string;
+    name: string;
+    savedOn: Date;
+}
+
+export class SharedGame implements ISharedGame {
+    id: string;
+    name: string;
+    savedOn: Date;
+
+    constructor(id: string, name: string, savedOn: Date) {
+        this.id = id;
+        this.name = name;
+        this.savedOn = savedOn;
+    }
+}

--- a/zorkweb.client/tests/gameSharing.spec.ts
+++ b/zorkweb.client/tests/gameSharing.spec.ts
@@ -1,0 +1,338 @@
+/**
+ * Zork Game Sharing Tests
+ * 
+ * These tests verify the functionality of the new game sharing features:
+ * - Share This Game (shows session ID for sharing)
+ * - Load Shared Game (load games from another session)
+ * 
+ * NOTE: API Mocking
+ * To avoid dependency on the backend API (which may not always be running),
+ * these tests use Playwright's route interception to mock API responses.
+ * This allows the tests to run reliably without requiring the actual backend.
+ */
+
+import { test, expect } from '@playwright/test';
+import { closeWelcomeModal, handleZorkOneRoute, handleGetSavedGamesRoute } from './testHelpers';
+
+test.describe('Game Sharing Features', () => {
+    
+    // Set up API mocking before each test
+    test.beforeEach(async ({ page }) => {
+        // Intercept requests to the API endpoints
+        await page.route('http://localhost:5000/ZorkOne', handleZorkOneRoute);
+        
+        // Mock saved games endpoint
+        await page.route('http://localhost:5000/ZorkOne/saveGame?*', async (route) => {
+            if (route.request().method() === 'GET') {
+                await handleGetSavedGamesRoute(route);
+            } else {
+                await route.continue();
+            }
+        });
+        
+        // Mock shared games endpoints
+        await page.route('http://localhost:5000/ZorkOne/shareGame/*', async (route) => {
+            const method = route.request().method();
+            const url = route.request().url();
+            
+            if (method === 'GET') {
+                // Mock getSharedGames response
+                await route.fulfill({
+                    status: 200,
+                    contentType: 'application/json',
+                    body: JSON.stringify([
+                        {
+                            id: "shared-game-1",
+                            name: "Underground Adventure",
+                            savedOn: "2023-12-01T10:30:00Z"
+                        },
+                        {
+                            id: "shared-game-2", 
+                            name: "Treasure Hunt Save",
+                            savedOn: "2023-12-01T15:45:00Z"
+                        }
+                    ])
+                });
+            } else if (method === 'POST') {
+                // Mock copySharedGame response
+                await route.fulfill({
+                    status: 200,
+                    contentType: 'application/json',
+                    body: JSON.stringify({ success: true })
+                });
+            } else {
+                await route.continue();
+            }
+        });
+    });
+
+    test('Share This Game - opens share modal and displays session ID', async ({ page }) => {
+        // Close the welcome modal
+        await closeWelcomeModal(page);
+
+        // Wait for the Game button to be visible
+        await page.waitForSelector('[data-testid="game-button"]', { state: 'visible' });
+
+        // Click the Game button to open the menu
+        await page.locator('[data-testid="game-button"]').click();
+
+        // Verify the game menu is open
+        await expect(page.locator('#game-menu')).toBeVisible();
+
+        // Click "Share This Game" menu item
+        await page.locator('#game-menu li:has-text("Share This Game")').click();
+
+        // Verify the share modal opens
+        await expect(page.locator('[data-testid="share-game-modal"]')).toBeVisible();
+
+        // Verify modal title
+        const modalTitle = page.locator('[data-testid="share-game-modal"] h2:has-text("Share Your Game")');
+        await expect(modalTitle).toBeVisible();
+
+        // Verify session ID is displayed
+        const sessionIdDisplay = page.locator('[data-testid="session-id-display"]');
+        await expect(sessionIdDisplay).toBeVisible();
+        
+        // Verify session ID format (15 alphanumeric characters)
+        const sessionIdText = await sessionIdDisplay.textContent();
+        expect(sessionIdText).toMatch(/^[A-Za-z0-9]{15}$/);
+
+        // Verify copy button is present
+        const copyButton = page.locator('[data-testid="copy-session-id-button"]');
+        await expect(copyButton).toBeVisible();
+
+        // Test copy functionality (mock clipboard)
+        await page.evaluate(() => {
+            navigator.clipboard = {
+                writeText: async (text: string) => Promise.resolve()
+            };
+        });
+
+        // Click copy button
+        await copyButton.click();
+
+        // Verify success message appears
+        await expect(page.locator('div[role="alert"]:has-text("Session ID copied to clipboard!")')).toBeVisible();
+
+        // Close the modal
+        await page.locator('[data-testid="share-game-modal"] button:has-text("Close")').click();
+
+        // Verify modal is closed
+        await expect(page.locator('[data-testid="share-game-modal"]')).not.toBeVisible();
+    });
+
+    test('Load Shared Game - opens modal and allows browsing shared games', async ({ page }) => {
+        // Close the welcome modal
+        await closeWelcomeModal(page);
+
+        // Wait for the Game button to be visible
+        await page.waitForSelector('[data-testid="game-button"]', { state: 'visible' });
+
+        // Click the Game button to open the menu
+        await page.locator('[data-testid="game-button"]').click();
+
+        // Verify the game menu is open
+        await expect(page.locator('#game-menu')).toBeVisible();
+
+        // Click "Load Shared Game" menu item
+        await page.locator('#game-menu li:has-text("Load Shared Game")').click();
+
+        // Verify the load shared modal opens
+        await expect(page.locator('[data-testid="load-shared-game-modal"]')).toBeVisible();
+
+        // Verify modal title
+        const modalTitle = page.locator('[data-testid="load-shared-game-modal"] h2:has-text("Load Shared Game")');
+        await expect(modalTitle).toBeVisible();
+
+        // Verify session ID input field is present
+        const sessionIdInput = page.locator('[data-testid="session-id-input"]');
+        await expect(sessionIdInput).toBeVisible();
+
+        // Test entering a valid session ID
+        await sessionIdInput.fill('ABC123DEF456789');
+
+        // Verify load games button is enabled
+        const loadGamesButton = page.locator('[data-testid="load-shared-games-button"]');
+        await expect(loadGamesButton).toBeEnabled();
+
+        // Click load games button
+        await loadGamesButton.click();
+
+        // Wait for shared games to load and display
+        await expect(page.locator('[data-testid="shared-game-item"]')).toHaveCount(2);
+
+        // Verify first shared game is displayed correctly
+        const firstGame = page.locator('[data-testid="shared-game-item"]').first();
+        await expect(firstGame).toContainText('Underground Adventure');
+        await expect(firstGame).toContainText('December 1st, 10:30 am');
+
+        // Verify second shared game is displayed correctly
+        const secondGame = page.locator('[data-testid="shared-game-item"]').nth(1);
+        await expect(secondGame).toContainText('Treasure Hunt Save');
+        await expect(secondGame).toContainText('December 1st, 3:45 pm');
+
+        // Test copying a shared game
+        const copyGameButton = firstGame.locator('button:has-text("Copy Game")');
+        await expect(copyGameButton).toBeVisible();
+        await copyGameButton.click();
+
+        // The modal should close after successful copy (this would normally reload saved games)
+        await expect(page.locator('[data-testid="load-shared-game-modal"]')).not.toBeVisible();
+    });
+
+    test('Load Shared Game - validates session ID format', async ({ page }) => {
+        // Close the welcome modal
+        await closeWelcomeModal(page);
+
+        // Open the Load Shared Game modal
+        await page.locator('[data-testid="game-button"]').click();
+        await page.locator('#game-menu li:has-text("Load Shared Game")').click();
+
+        const sessionIdInput = page.locator('[data-testid="session-id-input"]');
+        const loadGamesButton = page.locator('[data-testid="load-shared-games-button"]');
+
+        // Test empty input
+        await expect(loadGamesButton).toBeDisabled();
+
+        // Test invalid format - too short
+        await sessionIdInput.fill('ABC123');
+        await expect(page.locator('p:has-text("Session ID must be exactly 15 alphanumeric characters")')).toBeVisible();
+        await expect(loadGamesButton).toBeDisabled();
+
+        // Test invalid format - too long
+        await sessionIdInput.fill('ABC123DEF456789XX');
+        await expect(page.locator('p:has-text("Session ID must be exactly 15 alphanumeric characters")')).toBeVisible();
+        await expect(loadGamesButton).toBeDisabled();
+
+        // Test invalid characters
+        await sessionIdInput.fill('ABC-123-DEF-456');
+        await expect(page.locator('p:has-text("Session ID must be exactly 15 alphanumeric characters")')).toBeVisible();
+        await expect(loadGamesButton).toBeDisabled();
+
+        // Test valid format
+        await sessionIdInput.fill('ABC123DEF456789');
+        await expect(page.locator('p:has-text("Session ID must be exactly 15 alphanumeric characters")')).not.toBeVisible();
+        await expect(loadGamesButton).toBeEnabled();
+
+        // Close the modal
+        await page.locator('[data-testid="load-shared-game-modal"] button:has-text("Cancel")').click();
+        await expect(page.locator('[data-testid="load-shared-game-modal"]')).not.toBeVisible();
+    });
+
+    test('Load Shared Game - handles no games found scenario', async ({ page }) => {
+        // Close the welcome modal
+        await closeWelcomeModal(page);
+
+        // Mock empty shared games response for this test
+        await page.route('http://localhost:5000/ZorkOne/shareGame/*', async (route) => {
+            if (route.request().method() === 'GET') {
+                await route.fulfill({
+                    status: 200,
+                    contentType: 'application/json',
+                    body: JSON.stringify([]) // Empty array
+                });
+            } else {
+                await route.continue();
+            }
+        });
+
+        // Open the Load Shared Game modal
+        await page.locator('[data-testid="game-button"]').click();
+        await page.locator('#game-menu li:has-text("Load Shared Game")').click();
+
+        // Enter a valid session ID
+        const sessionIdInput = page.locator('[data-testid="session-id-input"]');
+        await sessionIdInput.fill('ABC123DEF456789');
+
+        // Click load games button
+        const loadGamesButton = page.locator('[data-testid="load-shared-games-button"]');
+        await loadGamesButton.click();
+
+        // Verify error message is displayed
+        await expect(page.locator('[role="alert"]:has-text("No saved games found for this Session ID")')).toBeVisible();
+
+        // Verify no game items are displayed
+        await expect(page.locator('[data-testid="shared-game-item"]')).toHaveCount(0);
+
+        // Close the modal
+        await page.locator('[data-testid="load-shared-game-modal"] button:has-text("Cancel")').click();
+    });
+
+    test('Load Shared Game - handles API error scenario', async ({ page }) => {
+        // Close the welcome modal
+        await closeWelcomeModal(page);
+
+        // Mock API error for this test
+        await page.route('http://localhost:5000/ZorkOne/shareGame/*', async (route) => {
+            if (route.request().method() === 'GET') {
+                await route.fulfill({
+                    status: 404,
+                    contentType: 'application/json',
+                    body: JSON.stringify({ error: 'Session not found' })
+                });
+            } else {
+                await route.continue();
+            }
+        });
+
+        // Open the Load Shared Game modal
+        await page.locator('[data-testid="game-button"]').click();
+        await page.locator('#game-menu li:has-text("Load Shared Game")').click();
+
+        // Enter a valid session ID
+        const sessionIdInput = page.locator('[data-testid="session-id-input"]');
+        await sessionIdInput.fill('ABC123DEF456789');
+
+        // Click load games button
+        const loadGamesButton = page.locator('[data-testid="load-shared-games-button"]');
+        await loadGamesButton.click();
+
+        // Verify error message is displayed
+        await expect(page.locator('[role="alert"]:has-text("Failed to load shared games. Please check the Session ID and try again.")')).toBeVisible();
+
+        // Close the modal
+        await page.locator('[data-testid="load-shared-game-modal"] button:has-text("Cancel")').click();
+    });
+
+    test('Load Shared Game - supports keyboard navigation', async ({ page }) => {
+        // Close the welcome modal
+        await closeWelcomeModal(page);
+
+        // Open the Load Shared Game modal
+        await page.locator('[data-testid="game-button"]').click();
+        await page.locator('#game-menu li:has-text("Load Shared Game")').click();
+
+        // Enter a valid session ID
+        const sessionIdInput = page.locator('[data-testid="session-id-input"]');
+        await sessionIdInput.fill('ABC123DEF456789');
+
+        // Test pressing Enter to load games
+        await sessionIdInput.press('Enter');
+
+        // Wait for shared games to load
+        await expect(page.locator('[data-testid="shared-game-item"]')).toHaveCount(2);
+
+        // Verify games are displayed
+        await expect(page.locator('[data-testid="shared-game-item"]').first()).toContainText('Underground Adventure');
+    });
+
+    test('Game menu shows correct count of items including sharing options', async ({ page }) => {
+        // Close the welcome modal
+        await closeWelcomeModal(page);
+
+        // Click the Game button
+        await page.locator('[data-testid="game-button"]').click();
+
+        // Verify the game menu has 6 items (including the new sharing options)
+        const menuItems = page.locator('#game-menu li');
+        await expect(menuItems).toHaveCount(6);
+
+        // Verify all menu items are present
+        await expect(page.locator('#game-menu li:has-text("Restart Your Game")')).toBeVisible();
+        await expect(page.locator('#game-menu li:has-text("Restore a Previous Saved Game")')).toBeVisible();
+        await expect(page.locator('#game-menu li:has-text("Save your Game")')).toBeVisible();
+        await expect(page.locator('#game-menu li:has-text("Share This Game")')).toBeVisible();
+        await expect(page.locator('#game-menu li:has-text("Load Shared Game")')).toBeVisible();
+        await expect(page.locator('#game-menu li:has-text("Copy Game Transcript")')).toBeVisible();
+    });
+});

--- a/zorkweb.client/tests/menus.spec.ts
+++ b/zorkweb.client/tests/menus.spec.ts
@@ -82,7 +82,7 @@ test.describe('Game Menus', () => {
 
         // Verify that the menu contains expected items
         const menuItems = page.locator('#game-menu li');
-        await expect(menuItems).toHaveCount(4); // There are 4 menu items in the FunctionsMenu component
+        await expect(menuItems).toHaveCount(6); // There are 6 menu items in the FunctionsMenu component including sharing options
 
         // Verify a specific menu item is present
         const restartGameItem = page.locator('#game-menu li:has-text("Restart Your Game")');

--- a/zorkweb.client/tests/testHelpers.ts
+++ b/zorkweb.client/tests/testHelpers.ts
@@ -123,3 +123,38 @@ export async function handleGetSavedGamesRoute(route: Route) {
         body: JSON.stringify(mockResponses.savedGames)
     });
 }
+
+/**
+ * Helper function to handle the getSharedGames endpoint route
+ * This function intercepts requests to the shareGame GET endpoint and returns mock shared games
+ */
+export async function handleGetSharedGamesRoute(route: Route) {
+    await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+            {
+                id: "shared-game-1",
+                name: "Underground Adventure",
+                savedOn: "2023-12-01T10:30:00Z"
+            },
+            {
+                id: "shared-game-2",
+                name: "Treasure Hunt Save",
+                savedOn: "2023-12-01T15:45:00Z"
+            }
+        ])
+    });
+}
+
+/**
+ * Helper function to handle the copySharedGame endpoint route
+ * This function intercepts requests to the shareGame POST endpoint and returns success response
+ */
+export async function handleCopySharedGameRoute(route: Route) {
+    await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true })
+    });
+}


### PR DESCRIPTION
Implements issue #134 - Share a saved game

## Summary
- Users can now share their SessionId to allow others to copy their saved games
- Recipients can load shared games which automatically get "(from share)" appended to title
- Full backend and frontend implementation with comprehensive error handling
- Added two new menu items in Game menu: "Share This Game" and "Load Shared Game"

## Technical Changes
- Backend: Extended ISavedGameRepository, added DynamoDB sharing methods, new API endpoints
- Frontend: New modals, updated menu, extended context and server integration
- Tests: Comprehensive unit test coverage for new components and methods

Generated with [Claude Code](https://claude.ai/code)