### PR TITLE
Diagnose and Health

### DIFF
--- a/Planetfall/GlobalCommand/DiagnoseProcessor.cs
+++ b/Planetfall/GlobalCommand/DiagnoseProcessor.cs
@@ -1,4 +1,5 @@
 ﻿using Model.AIGeneration;
+using Utilities;
 
 namespace Planetfall.GlobalCommand;
 

--- a/Planetfall/GlobalCommand/DiagnoseProcessor.cs
+++ b/Planetfall/GlobalCommand/DiagnoseProcessor.cs
@@ -9,10 +9,10 @@ public class DiagnoseProcessor : IGlobalCommand
         if (context is not PlanetfallContext pc)
             throw new Exception("Context is not a PlanetfallContext");
 
-        // TODO: Tired
-        // TODO: Hungry
+        var response = pc.SicknessDescription + "\n" +
+                       pc.Tired.GetDescription() + "\n" +
+                       pc.Hunger.GetDescription();
 
-        var response = pc.SicknessDescription;
         return Task.FromResult(response);
     }
 }


### PR DESCRIPTION
Implemented TODO items to include player's hunger level and tiredness level in the DIAGNOSE command output. Now when players use DIAGNOSE, they will see their complete status including:
- Sickness description
- Tired level (WellRested → Tired → VeryTired → Exhausted → AboutToDrop)
- Hunger level (WellFed → Hungry → Famished)

This provides players with better visibility into their character's overall condition during gameplay.