### PR TITLE
Fix mess hall table search result text

### DIFF
--- a/Planetfall.Tests/MessHallPadlockedDoorTests.cs
+++ b/Planetfall.Tests/MessHallPadlockedDoorTests.cs
@@ -100,4 +100,19 @@ public class MessHallPadlockedDoorTests : EngineTestsBase
         var response = await target.GetResponse("N");
         response.Should().Contain("Storage West");
     }
+
+    [Test]
+    public async Task LookUnderTable_ShowsJokeMessage()
+    {
+        var target = GetTarget();
+        target.Context.CurrentLocation = Repository.GetLocation<MessHall>();
+
+        var response = await target.GetResponse("look under table");
+
+        response.Should().Contain("Wow!!! Under the table are three keys");
+        response.Should().Contain("a sack of food");
+        response.Should().Contain("a reactor elevator access pass");
+        response.Should().Contain("just kidding");
+        response.Should().Contain("Actually, there's nothing there.");
+    }
 }

--- a/Planetfall/Location/Kalamontee/MessHall.cs
+++ b/Planetfall/Location/Kalamontee/MessHall.cs
@@ -1,5 +1,7 @@
 using GameEngine.Location;
 using Model.AIGeneration;
+using Model.Intent;
+using Model.Item;
 using Planetfall.Item.Kalamontee;
 using Planetfall.Item.Kalamontee.Admin;
 
@@ -8,6 +10,16 @@ namespace Planetfall.Location.Kalamontee;
 internal class MessHall : LocationBase
 {
     public override string Name => "Mess Hall";
+
+    public override async Task<InteractionResult> RespondToSimpleInteraction(SimpleIntent action, IContext context,
+        IGenerationClient client, IItemProcessorFactory itemProcessorFactory)
+    {
+        if (action.Match(["look"], ["table"]) && action.OriginalInput != null && action.OriginalInput.Contains("under"))
+            return new PositiveInteractionResult(
+                "Wow!!! Under the table are three keys, a sack of food, a reactor elevator access pass, just kidding. Actually, there's nothing there. ");
+
+        return await base.RespondToSimpleInteraction(action, context, client, itemProcessorFactory);
+    }
 
     protected override Dictionary<Direction, MovementParameters> Map(IContext context)
     {

--- a/Planetfall/Location/Kalamontee/MessHall.cs
+++ b/Planetfall/Location/Kalamontee/MessHall.cs
@@ -14,7 +14,7 @@ internal class MessHall : LocationBase
     {
         if (action.Match(["look"], ["table"]) && action.OriginalInput != null && action.OriginalInput.Contains("under"))
             return new PositiveInteractionResult(
-                "Wow!!! Under the table are three keys, a sack of food, a reactor elevator access pass, just kidding. Actually, there's nothing there. ");
+                "Wow!!! Under the table are three keys, a sack of food, a reactor elevator access pass, just kidding. Actually, there's nothing there.");
 
         return await base.RespondToSimpleInteraction(action, context, client, itemProcessorFactory);
     }

--- a/Planetfall/Location/Kalamontee/MessHall.cs
+++ b/Planetfall/Location/Kalamontee/MessHall.cs
@@ -1,7 +1,5 @@
 using GameEngine.Location;
 using Model.AIGeneration;
-using Model.Intent;
-using Model.Item;
 using Planetfall.Item.Kalamontee;
 using Planetfall.Item.Kalamontee.Admin;
 

--- a/UnitTests/TestParser.cs
+++ b/UnitTests/TestParser.cs
@@ -269,6 +269,14 @@ public class TestParser : IntentParser
                 OriginalInput = "look under rug"
             });
 
+        if (input is "look under table")
+            return Task.FromResult<IntentBase>(new SimpleIntent
+            {
+                Noun = "table",
+                Verb = "look",
+                OriginalInput = "look under table"
+            });
+
         if (input is "wait" or "z")
             return Task.FromResult<IntentBase>(new GlobalCommandIntent { Command = new WaitProcessor() });
 


### PR DESCRIPTION
Implements humorous response when player tries 'look under table' in the Mess Hall. Follows the same pattern as other locations (RadiationLab, BioLockEast) that handle 'look' with prepositions.

Changes:
- MessHall.cs: Override RespondToSimpleInteraction to handle 'look under table'
- MessHallPadlockedDoorTests.cs: Add LookUnderTable_ShowsJokeMessage test

The joke message teases finding valuable items but reveals there's actually nothing there.