### PR TITLE
Add locked door to Brig location

### DIFF
--- a/Planetfall.Tests/BrigCellDoorTests.cs
+++ b/Planetfall.Tests/BrigCellDoorTests.cs
@@ -1,0 +1,53 @@
+using FluentAssertions;
+using GameEngine;
+using Planetfall.Item.Feinstein;
+using Planetfall.Location.Feinstein;
+
+namespace Planetfall.Tests;
+
+public class BrigCellDoorTests : EngineTestsBase
+{
+    [Test]
+    public async Task CannotOpenDoor_ReturnsNoWayJose()
+    {
+        var target = GetTarget();
+        target.Context.CurrentLocation = Repository.GetLocation<Brig>();
+
+        var response = await target.GetResponse("open door");
+        response.Should().Contain("No way, Jose.");
+    }
+
+    [Test]
+    public async Task CannotOpenCellDoor_ReturnsNoWayJose()
+    {
+        var target = GetTarget();
+        target.Context.CurrentLocation = Repository.GetLocation<Brig>();
+
+        var response = await target.GetResponse("open cell door");
+        response.Should().Contain("No way, Jose.");
+    }
+
+    [Test]
+    public void CellDoor_ExistsInBrig()
+    {
+        var brig = Repository.GetLocation<Brig>();
+        brig.HasItem<CellDoor>().Should().BeTrue();
+    }
+
+    [Test]
+    public void CellDoor_IsNotOpen()
+    {
+        var door = Repository.GetItem<CellDoor>();
+        door.IsOpen.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task CannotGoSouth_DoorLocked()
+    {
+        var target = GetTarget();
+        target.Context.CurrentLocation = Repository.GetLocation<Brig>();
+
+        var response = await target.GetResponse("S");
+        response.Should().Contain("The cell door is locked");
+    }
+}

--- a/Planetfall/Item/Feinstein/CellDoor.cs
+++ b/Planetfall/Item/Feinstein/CellDoor.cs
@@ -1,0 +1,33 @@
+namespace Planetfall.Item.Feinstein;
+
+public class CellDoor : ItemBase, IOpenAndClose
+{
+    public override string[] NounsForMatching =>
+        ["cell door", "door"];
+
+    public bool IsOpen { get; set; }
+
+    public string NowOpen(ILocation currentLocation)
+    {
+        return string.Empty;
+    }
+
+    public string NowClosed(ILocation currentLocation)
+    {
+        return string.Empty;
+    }
+
+    public string AlreadyClosed => "It is closed! ";
+    public string AlreadyOpen => "It's already open! ";
+    public bool HasEverBeenOpened { get; set; }
+
+    public string CannotBeOpenedDescription(IContext context)
+    {
+        return "No way, Jose.";
+    }
+
+    public string OnClosing(IContext context)
+    {
+        return string.Empty;
+    }
+}

--- a/Planetfall/Item/Feinstein/CellDoor.cs
+++ b/Planetfall/Item/Feinstein/CellDoor.cs
@@ -26,6 +26,16 @@ public class CellDoor : ItemBase, IOpenAndClose
         return "No way, Jose.";
     }
 
+    public override string? CannotBeClosedDescription(IContext context)
+    {
+        return null;
+    }
+
+    public override string OnOpening(IContext context)
+    {
+        return string.Empty;
+    }
+
     public string OnClosing(IContext context)
     {
         return string.Empty;

--- a/Planetfall/Location/Feinstein/Brig.cs
+++ b/Planetfall/Location/Feinstein/Brig.cs
@@ -17,8 +17,6 @@ internal class Brig : LocationBase
         };
     }
 
-    // TODO: Cell door. 
-
     protected override string GetContextBasedDescription(IContext context)
     {
         return "You are in the Feinstein's brig. Graffiti cover the walls. The cell door to the south is locked. ";
@@ -27,5 +25,6 @@ internal class Brig : LocationBase
     public override void Init()
     {
         StartWithItem<Graffiti>();
+        StartWithItem<CellDoor>();
     }
 }

--- a/UnitTests/TestParser.cs
+++ b/UnitTests/TestParser.cs
@@ -238,7 +238,14 @@ public class TestParser : IntentParser
                 Noun = "blue door",
                 Verb = "close"
             });
-        
+
+        if (input is "open cell door")
+            return Task.FromResult<IntentBase>(new SimpleIntent
+            {
+                Noun = "cell door",
+                Verb = "open"
+            });
+
         if (input is "cross the rainbow")
             return Task.FromResult<IntentBase>(new SimpleIntent
             {


### PR DESCRIPTION
Implemented a CellDoor item for the Brig that cannot be opened, returning "No way, Jose." when the player attempts to open it. The door implements the IOpenAndClose interface and provides the custom "No way, Jose." message through the CannotBeOpenedDescription method.

Changes:
- Created CellDoor.cs item in Planetfall/Item/Feinstein/
- Updated Brig.cs to include the CellDoor in Init()
- Added comprehensive unit tests in BrigCellDoorTests.cs
- Removed TODO comment from Brig location