### PR TITLE
Fix: Provide feedback when taking/dropping multiple items with invali…

### DIFF
--- a/GameEngine/Item/ItemProcessor/TakeOrDropInteractionProcessor.cs
+++ b/GameEngine/Item/ItemProcessor/TakeOrDropInteractionProcessor.cs
@@ -53,10 +53,10 @@ public class TakeOrDropInteractionProcessor : IVerbProcessor
             case "get":
             case "acquire":
             case "snatch":
-                return await GetItemsToTake(context, action);
+                return await GetItemsToTake(context, action, client);
 
             case "drop":
-                return await GetItemsToDrop(context, action);
+                return await GetItemsToDrop(context, action, client);
         }
 
         return null;
@@ -73,7 +73,7 @@ public class TakeOrDropInteractionProcessor : IVerbProcessor
         IContext context, IGenerationClient client)
     {
         var result = await GetItemsToTake(context,
-            new SimpleIntent { OriginalInput = action.Message, Verb = "take", Noun = action.Noun });
+            new SimpleIntent { OriginalInput = action.Message, Verb = "take", Noun = action.Noun }, client);
 
         if (result is null or NoNounMatchInteractionResult)
         {
@@ -89,7 +89,7 @@ public class TakeOrDropInteractionProcessor : IVerbProcessor
         IContext context, IGenerationClient client)
     {
         var result = await GetItemsToDrop(context,
-            new SimpleIntent { OriginalInput = action.Message, Verb = "drop", Noun = action.Noun });
+            new SimpleIntent { OriginalInput = action.Message, Verb = "drop", Noun = action.Noun }, client);
 
         if (result is null or NoNounMatchInteractionResult)
         {
@@ -101,7 +101,7 @@ public class TakeOrDropInteractionProcessor : IVerbProcessor
         return (result, result.InteractionMessage);
     }
 
-    private async Task<InteractionResult?> GetItemsToDrop(IContext context, SimpleIntent action)
+    private async Task<InteractionResult?> GetItemsToDrop(IContext context, SimpleIntent action, IGenerationClient client)
     {
         if (string.IsNullOrEmpty(action.OriginalInput))
             return null;
@@ -128,10 +128,10 @@ public class TakeOrDropInteractionProcessor : IVerbProcessor
             .Select(itemNoun => (itemNoun, Repository.GetItem(itemNoun)))
             .ToList();
 
-        return new PositiveInteractionResult(DropEverythingProcessor.DropAll(context, itemsWithFeedback));
+        return new PositiveInteractionResult(await DropEverythingProcessor.DropAll(context, itemsWithFeedback, client));
     }
 
-    private async Task<InteractionResult?> GetItemsToTake(IContext context, SimpleIntent action)
+    private async Task<InteractionResult?> GetItemsToTake(IContext context, SimpleIntent action, IGenerationClient client)
     {
         if (string.IsNullOrEmpty(action.OriginalInput))
             return null;
@@ -158,7 +158,7 @@ public class TakeOrDropInteractionProcessor : IVerbProcessor
             .Select(itemNoun => (itemNoun, Repository.GetItem(itemNoun)))
             .ToList();
 
-        return new PositiveInteractionResult(TakeEverythingProcessor.TakeAll(context, itemsWithFeedback));
+        return new PositiveInteractionResult(await TakeEverythingProcessor.TakeAll(context, itemsWithFeedback, client));
     }
 
     public static InteractionResult DropIt(IContext context, IItem? castItem)

--- a/GameEngine/Item/ItemProcessor/TakeOrDropInteractionProcessor.cs
+++ b/GameEngine/Item/ItemProcessor/TakeOrDropInteractionProcessor.cs
@@ -124,11 +124,9 @@ public class TakeOrDropInteractionProcessor : IVerbProcessor
             return DropIt(context, Repository.GetItem(items[0]));
 
         // When dropping multiple items, we need to provide feedback for items that don't exist
-        var itemsWithFeedback = new List<(string noun, IItem? item)>();
-        foreach (var itemNoun in items)
-        {
-            itemsWithFeedback.Add((itemNoun, Repository.GetItem(itemNoun)));
-        }
+        var itemsWithFeedback = items
+            .Select(itemNoun => (itemNoun, Repository.GetItem(itemNoun)))
+            .ToList();
 
         return new PositiveInteractionResult(DropEverythingProcessor.DropAll(context, itemsWithFeedback));
     }
@@ -156,11 +154,9 @@ public class TakeOrDropInteractionProcessor : IVerbProcessor
             return TakeIt(context, Repository.GetItem(items[0]));
 
         // When taking multiple items, we need to provide feedback for items that don't exist
-        var itemsWithFeedback = new List<(string noun, IItem? item)>();
-        foreach (var itemNoun in items)
-        {
-            itemsWithFeedback.Add((itemNoun, Repository.GetItem(itemNoun)));
-        }
+        var itemsWithFeedback = items
+            .Select(itemNoun => (itemNoun, Repository.GetItem(itemNoun)))
+            .ToList();
 
         return new PositiveInteractionResult(TakeEverythingProcessor.TakeAll(context, itemsWithFeedback));
     }

--- a/GameEngine/Item/ItemProcessor/TakeOrDropInteractionProcessor.cs
+++ b/GameEngine/Item/ItemProcessor/TakeOrDropInteractionProcessor.cs
@@ -112,10 +112,10 @@ public class TakeOrDropInteractionProcessor : IVerbProcessor
         // The parser did not see anything in the inventory that seemed like what we asked for
         if (!items.Any())
         {
-            // There is still a chance there is something for us to drop. This can happen when the parser is not 
-            // smart enough to match the noun to the item description. An example of this is the "magnet" which is 
+            // There is still a chance there is something for us to drop. This can happen when the parser is not
+            // smart enough to match the noun to the item description. An example of this is the "magnet" which is
             // (deliberately, as a puzzle) described as "a metal bar, curved into a U-shape" which the parser does not
-            // understand is a magnet. So as a final attempt, let's see if there is a direct noun match.  
+            // understand is a magnet. So as a final attempt, let's see if there is a direct noun match.
             var specificItem = Repository.GetItem(action.Noun);
             return specificItem is not null ? DropIt(context, specificItem) : new NoNounMatchInteractionResult();
         }
@@ -123,8 +123,14 @@ public class TakeOrDropInteractionProcessor : IVerbProcessor
         if (items.Length == 1)
             return DropIt(context, Repository.GetItem(items[0]));
 
-        return new PositiveInteractionResult(DropEverythingProcessor.DropAll(context,
-            items.Select(Repository.GetItem).ToList()));
+        // When dropping multiple items, we need to provide feedback for items that don't exist
+        var itemsWithFeedback = new List<(string noun, IItem? item)>();
+        foreach (var itemNoun in items)
+        {
+            itemsWithFeedback.Add((itemNoun, Repository.GetItem(itemNoun)));
+        }
+
+        return new PositiveInteractionResult(DropEverythingProcessor.DropAll(context, itemsWithFeedback));
     }
 
     private async Task<InteractionResult?> GetItemsToTake(IContext context, SimpleIntent action)
@@ -138,10 +144,10 @@ public class TakeOrDropInteractionProcessor : IVerbProcessor
         // The parser did not see anything in the room description that seemed like what we asked for
         if (!items.Any())
         {
-            // There is still a chance there is something for us to pick up. This can happen when the parser is not 
-            // smart enough to match the noun to the item description. An example of this is the "magnet" which is 
+            // There is still a chance there is something for us to pick up. This can happen when the parser is not
+            // smart enough to match the noun to the item description. An example of this is the "magnet" which is
             // (deliberately, as a puzzle) described as "a metal bar, curved into a U-shape" which the parser does not
-            // understand is a magnet. So as a final attempt, let's see if there is a direct noun match.  
+            // understand is a magnet. So as a final attempt, let's see if there is a direct noun match.
             var specificItem = Repository.GetItem(action.Noun);
             return specificItem is not null ? TakeIt(context, specificItem) : new NoNounMatchInteractionResult();
         }
@@ -149,8 +155,14 @@ public class TakeOrDropInteractionProcessor : IVerbProcessor
         if (items.Length == 1)
             return TakeIt(context, Repository.GetItem(items[0]));
 
-        return new PositiveInteractionResult(TakeEverythingProcessor.TakeAll(context,
-            items.Select(Repository.GetItem).ToList()));
+        // When taking multiple items, we need to provide feedback for items that don't exist
+        var itemsWithFeedback = new List<(string noun, IItem? item)>();
+        foreach (var itemNoun in items)
+        {
+            itemsWithFeedback.Add((itemNoun, Repository.GetItem(itemNoun)));
+        }
+
+        return new PositiveInteractionResult(TakeEverythingProcessor.TakeAll(context, itemsWithFeedback));
     }
 
     public static InteractionResult DropIt(IContext context, IItem? castItem)

--- a/GameEngine/StaticCommand/Implementation/DropEverythingProcessor.cs
+++ b/GameEngine/StaticCommand/Implementation/DropEverythingProcessor.cs
@@ -51,6 +51,15 @@ public class DropEverythingProcessor : IGlobalCommand
                 continue;
             }
 
+            // Check if the item is actually in the inventory
+            if (!context.Items.Contains(item))
+            {
+                var message = await client.GenerateNarration(
+                    new DropSomethingTheyDoNotHave(noun), context.SystemPromptAddendum);
+                sb.AppendLine($"{noun}: {message}");
+                continue;
+            }
+
             if (item is ICanBeTakenAndDropped)
                 sb.AppendLine(
                     $"{item.Name}: {TakeOrDropInteractionProcessor.DropIt(context, item).InteractionMessage}");

--- a/GameEngine/StaticCommand/Implementation/DropEverythingProcessor.cs
+++ b/GameEngine/StaticCommand/Implementation/DropEverythingProcessor.cs
@@ -30,6 +30,12 @@ public class DropEverythingProcessor : IGlobalCommand
         return sb.ToString();
     }
 
+    /// <summary>
+    /// Drops multiple items, providing feedback for each item including those that don't exist or can't be dropped.
+    /// </summary>
+    /// <param name="context">The game context containing the player's inventory and current state.</param>
+    /// <param name="itemsWithNouns">A list of tuples containing the original noun from user input and the corresponding item (null if not found).</param>
+    /// <returns>A formatted string with the result of attempting to drop each item.</returns>
     public static string DropAll(IContext context, List<(string noun, IItem? item)> itemsWithNouns)
     {
         var sb = new StringBuilder();

--- a/GameEngine/StaticCommand/Implementation/DropEverythingProcessor.cs
+++ b/GameEngine/StaticCommand/Implementation/DropEverythingProcessor.cs
@@ -21,11 +21,31 @@ public class DropEverythingProcessor : IGlobalCommand
     public static string DropAll(IContext context, List<IItem?> items)
     {
         var sb = new StringBuilder();
-      
+
         foreach (var nextItem in items.ToList())
             if (nextItem is ICanBeTakenAndDropped)
                 sb.AppendLine(
                     $"{nextItem.Name}: {TakeOrDropInteractionProcessor.DropIt(context, nextItem).InteractionMessage}");
+
+        return sb.ToString();
+    }
+
+    public static string DropAll(IContext context, List<(string noun, IItem? item)> itemsWithNouns)
+    {
+        var sb = new StringBuilder();
+
+        foreach (var (noun, item) in itemsWithNouns)
+        {
+            if (item is null)
+            {
+                sb.AppendLine($"{noun}: You don't have that!");
+                continue;
+            }
+
+            if (item is ICanBeTakenAndDropped)
+                sb.AppendLine(
+                    $"{item.Name}: {TakeOrDropInteractionProcessor.DropIt(context, item).InteractionMessage}");
+        }
 
         return sb.ToString();
     }

--- a/GameEngine/StaticCommand/Implementation/DropEverythingProcessor.cs
+++ b/GameEngine/StaticCommand/Implementation/DropEverythingProcessor.cs
@@ -35,8 +35,9 @@ public class DropEverythingProcessor : IGlobalCommand
     /// </summary>
     /// <param name="context">The game context containing the player's inventory and current state.</param>
     /// <param name="itemsWithNouns">A list of tuples containing the original noun from user input and the corresponding item (null if not found).</param>
+    /// <param name="client">The generation client for AI-generated snarky responses.</param>
     /// <returns>A formatted string with the result of attempting to drop each item.</returns>
-    public static string DropAll(IContext context, List<(string noun, IItem? item)> itemsWithNouns)
+    public static async Task<string> DropAll(IContext context, List<(string noun, IItem? item)> itemsWithNouns, IGenerationClient client)
     {
         var sb = new StringBuilder();
 
@@ -44,7 +45,9 @@ public class DropEverythingProcessor : IGlobalCommand
         {
             if (item is null)
             {
-                sb.AppendLine($"{noun}: You don't have that!");
+                var message = await client.GenerateNarration(
+                    new DropSomethingTheyDoNotHave(noun), context.SystemPromptAddendum);
+                sb.AppendLine($"{noun}: {message}");
                 continue;
             }
 

--- a/GameEngine/StaticCommand/Implementation/TakeEverythingProcessor.cs
+++ b/GameEngine/StaticCommand/Implementation/TakeEverythingProcessor.cs
@@ -53,15 +53,18 @@ public class TakeEverythingProcessor : IGlobalCommand
     /// </summary>
     /// <param name="context">The game context containing the player's inventory and current location.</param>
     /// <param name="itemsWithNouns">A list of tuples containing the original noun from user input and the corresponding item (null if not found).</param>
+    /// <param name="client">The generation client for AI-generated snarky responses.</param>
     /// <returns>A formatted string with the result of attempting to take each item.</returns>
-    public static string TakeAll(IContext context, List<(string noun, IItem? item)> itemsWithNouns)
+    public static async Task<string> TakeAll(IContext context, List<(string noun, IItem? item)> itemsWithNouns, IGenerationClient client)
     {
         var sb = new StringBuilder();
         foreach (var (noun, item) in itemsWithNouns)
         {
             if (item is null)
             {
-                sb.AppendLine($"{noun}: You can't see that here.");
+                var message = await client.GenerateNarration(
+                    new TakeSomethingThatIsNotPortable(noun), context.SystemPromptAddendum);
+                sb.AppendLine($"{noun}: {message}");
                 continue;
             }
 

--- a/GameEngine/StaticCommand/Implementation/TakeEverythingProcessor.cs
+++ b/GameEngine/StaticCommand/Implementation/TakeEverythingProcessor.cs
@@ -68,6 +68,16 @@ public class TakeEverythingProcessor : IGlobalCommand
                 continue;
             }
 
+            // Check if the item is actually available in the current location
+            var itemsInLocation = ((ICanContainItems)context.CurrentLocation).GetAllItemsRecursively;
+            if (!itemsInLocation.Contains(item))
+            {
+                var message = await client.GenerateNarration(
+                    new TakeSomethingThatIsNotPortable(noun), context.SystemPromptAddendum);
+                sb.AppendLine($"{noun}: {message}");
+                continue;
+            }
+
             if (!string.IsNullOrEmpty(item.CannotBeTakenDescription))
             {
                 sb.AppendLine($"{item.Name}: {item.CannotBeTakenDescription}");

--- a/GameEngine/StaticCommand/Implementation/TakeEverythingProcessor.cs
+++ b/GameEngine/StaticCommand/Implementation/TakeEverythingProcessor.cs
@@ -48,6 +48,12 @@ public class TakeEverythingProcessor : IGlobalCommand
         return sb.ToString();
     }
 
+    /// <summary>
+    /// Takes multiple items, providing feedback for each item including those that don't exist or can't be taken.
+    /// </summary>
+    /// <param name="context">The game context containing the player's inventory and current location.</param>
+    /// <param name="itemsWithNouns">A list of tuples containing the original noun from user input and the corresponding item (null if not found).</param>
+    /// <returns>A formatted string with the result of attempting to take each item.</returns>
     public static string TakeAll(IContext context, List<(string noun, IItem? item)> itemsWithNouns)
     {
         var sb = new StringBuilder();

--- a/GameEngine/StaticCommand/Implementation/TakeEverythingProcessor.cs
+++ b/GameEngine/StaticCommand/Implementation/TakeEverythingProcessor.cs
@@ -31,7 +31,7 @@ public class TakeEverythingProcessor : IGlobalCommand
         foreach (var nextItem in items)
         {
             if(nextItem is null) continue;
-            
+
             if (!string.IsNullOrEmpty(nextItem.CannotBeTakenDescription))
             {
                 sb.AppendLine($"{nextItem.Name}: {nextItem.CannotBeTakenDescription}");
@@ -43,6 +43,33 @@ public class TakeEverythingProcessor : IGlobalCommand
 
             sb.AppendLine($"{nextItem.Name}: Taken. ");
             context.ItemPlacedHere(nextItem);
+        }
+
+        return sb.ToString();
+    }
+
+    public static string TakeAll(IContext context, List<(string noun, IItem? item)> itemsWithNouns)
+    {
+        var sb = new StringBuilder();
+        foreach (var (noun, item) in itemsWithNouns)
+        {
+            if (item is null)
+            {
+                sb.AppendLine($"{noun}: You can't see that here.");
+                continue;
+            }
+
+            if (!string.IsNullOrEmpty(item.CannotBeTakenDescription))
+            {
+                sb.AppendLine($"{item.Name}: {item.CannotBeTakenDescription}");
+                continue;
+            }
+
+            if (item is not ICanBeTakenAndDropped)
+                continue;
+
+            sb.AppendLine($"{item.Name}: Taken. ");
+            context.ItemPlacedHere(item);
         }
 
         return sb.ToString();

--- a/UnitTests/EngineTestsBase.cs
+++ b/UnitTests/EngineTestsBase.cs
@@ -14,6 +14,8 @@ namespace UnitTests;
 
 public class EngineTestsBase : EngineTestsBaseCommon<ZorkIContext>
 {
+    protected Mock<IAITakeAndAndDropParser> TakeAndDropParser = new();
+
     /// <summary>
     ///     Returns an instance of the GameEngine class with the specified parser and client.
     ///     If parser is not provided, a default TestParser instance is used.
@@ -27,25 +29,25 @@ public class EngineTestsBase : EngineTestsBaseCommon<ZorkIContext>
 
         Repository.Reset();
 
-        var takeAndDropParser = new Mock<IAITakeAndAndDropParser>();
-        takeAndDropParser.Setup(s => s.GetListOfItemsToDrop(It.IsAny<string>(), It.IsAny<string>()))
+        TakeAndDropParser = new Mock<IAITakeAndAndDropParser>();
+        TakeAndDropParser.Setup(s => s.GetListOfItemsToDrop(It.IsAny<string>(), It.IsAny<string>()))
             .ReturnsAsync((string input, string context) =>
             {
                 var words = input.Split(' ', StringSplitOptions.RemoveEmptyEntries);
                 return words.Length > 1 ? [words[1]] : [];
             });
-        
-        takeAndDropParser.Setup(s => s.GetListOfItemsToTake(It.IsAny<string>(), It.IsAny<string>()))
+
+        TakeAndDropParser.Setup(s => s.GetListOfItemsToTake(It.IsAny<string>(), It.IsAny<string>()))
             .ReturnsAsync((string input, string context) =>
             {
                 var words = input.Split(' ', StringSplitOptions.RemoveEmptyEntries);
                 return words.Length > 1 ? [words[1]] : [];
             });
-        
+
         // Create a mock ParseConversation that mimics the old pattern behavior
         var mockParseConversation = CreateMockParseConversation();
-        
-        var engine = new GameEngine<ZorkI, ZorkIContext>(new ItemProcessorFactory(takeAndDropParser.Object),
+
+        var engine = new GameEngine<ZorkI, ZorkIContext>(new ItemProcessorFactory(TakeAndDropParser.Object),
             Parser, Client.Object, Mock.Of<ISecretsManager>(),
             Mock.Of<ICloudWatchLogger<TurnLog>>(), mockParseConversation.Object);
         

--- a/UnitTests/GlobalCommands/TakeAllDropAllTests.cs
+++ b/UnitTests/GlobalCommands/TakeAllDropAllTests.cs
@@ -75,14 +75,18 @@ public class TakeAllDropAllTests : EngineTestsBase
                 It.IsAny<string>()))
             .ReturnsAsync(new[] { "leaflet", "dragon" });
 
+        // Mock the LLM response for the invalid item
+        Client.Setup(s => s.GenerateNarration(It.IsAny<TakeSomethingThatIsNotPortable>(), It.IsAny<string>()))
+            .ReturnsAsync("I don't see any dragon here!");
+
         Repository.GetItem<Mailbox>().IsOpen = true;
         var response = await target.GetResponse("take leaflet and dragon");
 
         // Should take the leaflet
         response.Should().Contain("leaflet: Taken");
 
-        // Should provide feedback about the dragon not being present
-        response.Should().Contain("dragon: You can't see that here");
+        // Should provide LLM-generated feedback about the dragon not being present
+        response.Should().Contain("dragon: I don't see any dragon here!");
     }
 
     [Test]
@@ -100,12 +104,16 @@ public class TakeAllDropAllTests : EngineTestsBase
                 It.IsAny<string>()))
             .ReturnsAsync(new[] { "leaflet", "dragon" });
 
+        // Mock the LLM response for the invalid item
+        Client.Setup(s => s.GenerateNarration(It.IsAny<DropSomethingTheyDoNotHave>(), It.IsAny<string>()))
+            .ReturnsAsync("You don't have that mythical creature!");
+
         var response = await target.GetResponse("drop leaflet and dragon");
 
         // Should drop the leaflet
         response.Should().Contain("leaflet: Dropped");
 
-        // Should provide feedback about not having the dragon
-        response.Should().Contain("dragon: You don't have that!");
+        // Should provide LLM-generated feedback about not having the dragon
+        response.Should().Contain("dragon: You don't have that mythical creature!");
     }
 }


### PR DESCRIPTION
…d items

When attempting to take/drop multiple items where some don't exist (e.g., "take sword and dragon"), the game now provides clear feedback for items that can't be found instead of silently ignoring them.

Changes:
- Added TakeAll/DropAll overloads that accept tuples of (noun, item) to preserve original item names for feedback
- Modified GetItemsToTake/GetItemsToDrop to build noun-item pairs
- Invalid items now show "You can't see that here" (take) or "You don't have that!" (drop)
- Added unit tests to verify the fix

Fixes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)