### PR TITLE
Add Floyd fourth-wall breaking save comments

### DIFF
--- a/GameEngine/Context.cs
+++ b/GameEngine/Context.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using GameEngine.Item;
 using Model.AIGeneration;
+using Model.AIGeneration.Requests;
 using Model.Interface;
 using Model.Item;
 using Model.Location;
@@ -435,7 +436,7 @@ public abstract class Context<T> : IContext where T : IInfocomGame, new()
     ///     Default implementation returns null, meaning use the standard AfterSaveGameRequest.
     ///     Game-specific contexts can override this to provide custom save game requests.
     /// </summary>
-    public virtual Model.AIGeneration.Request? GetSaveGameRequest(string location)
+    public virtual Request? GetSaveGameRequest(string location)
     {
         return null;
     }

--- a/GameEngine/Context.cs
+++ b/GameEngine/Context.cs
@@ -430,4 +430,13 @@ public abstract class Context<T> : IContext where T : IInfocomGame, new()
         Items.Add(item);
         item.CurrentLocation = location;
     }
+
+    /// <summary>
+    ///     Default implementation returns null, meaning use the standard AfterSaveGameRequest.
+    ///     Game-specific contexts can override this to provide custom save game requests.
+    /// </summary>
+    public virtual Model.AIGeneration.Request? GetSaveGameRequest(string location)
+    {
+        return null;
+    }
 }

--- a/GameEngine/GameEngine.cs
+++ b/GameEngine/GameEngine.cs
@@ -51,7 +51,7 @@ public class GameEngine<TInfocomGame, TContext> : IGameEngine
     private bool _lastResponseWasGenerated;
     private IStatefulProcessor? _processorInProgress;
     private ICloudWatchLogger<TurnLog>? _turnLogger;
-    internal TContext Context;
+    public TContext Context { get; private set; }
     
     [ActivatorUtilitiesConstructor]
     public GameEngine(

--- a/GameEngine/GameEngine.cs
+++ b/GameEngine/GameEngine.cs
@@ -52,6 +52,11 @@ public class GameEngine<TInfocomGame, TContext> : IGameEngine
     private IStatefulProcessor? _processorInProgress;
     private ICloudWatchLogger<TurnLog>? _turnLogger;
     public TContext Context { get; private set; }
+
+    /// <summary>
+    ///     Explicit interface implementation to satisfy IGameEngine.Context requirement.
+    /// </summary>
+    IContext IGameEngine.Context => Context;
     
     [ActivatorUtilitiesConstructor]
     public GameEngine(

--- a/GameEngine/GameEngine.cs
+++ b/GameEngine/GameEngine.cs
@@ -286,6 +286,16 @@ public class GameEngine<TInfocomGame, TContext> : IGameEngine
         return JsonConvert.SerializeObject(savedGame, JsonSettings());
     }
 
+    public async Task<string> GenerateSaveGameNarration()
+    {
+        // Ask the context if it wants to provide a custom save game request (e.g., Floyd in Planetfall)
+        // If not, use the default AfterSaveGameRequest
+        var saveRequest = Context.GetSaveGameRequest(LocationDescription)
+                          ?? new Model.AIGeneration.Requests.AfterSaveGameRequest(LocationDescription);
+
+        return await GenerationClient.GenerateNarration(saveRequest, string.Empty);
+    }
+
     public async Task InitializeEngine()
     {
         try

--- a/GameEngine/StaticCommand/Implementation/SaveProcessor.cs
+++ b/GameEngine/StaticCommand/Implementation/SaveProcessor.cs
@@ -54,9 +54,7 @@ internal class SaveProcessor : IStatefulProcessor
         try
         {
             await SaveGame(context);
-            var generatedResponse =
-                await client.GenerateNarration(
-                    new AfterSaveGameRequest(context.CurrentLocation.GetDescriptionForGeneration(context)), context.SystemPromptAddendum);
+            var generatedResponse = await context.Engine!.GenerateSaveGameNarration();
             return $"{generatedResponse}";
         }
         catch (Exception)

--- a/Lambda/src/Lambda/Controllers/ZorkOneController.cs
+++ b/Lambda/src/Lambda/Controllers/ZorkOneController.cs
@@ -70,13 +70,7 @@ public class ZorkOneController(
         RestoreSession(savedSession);
         var encodedText = GetGameData();
         await savedGameRepository.SaveGame(request.Id, request.ClientId, request.Name, encodedText, SaveGameTableName);
-
-        // Ask the context if it wants to provide a custom save game request
-        // If not, use the default AfterSaveGameRequest
-        var saveRequest = engine.Context.GetSaveGameRequest(engine.LocationDescription)
-                          ?? new AfterSaveGameRequest(engine.LocationDescription);
-
-        return await engine.GenerationClient.GenerateNarration(saveRequest, String.Empty);
+        return await engine.GenerateSaveGameNarration();
     }
 
     [HttpGet]

--- a/Lambda/src/Lambda/Controllers/ZorkOneController.cs
+++ b/Lambda/src/Lambda/Controllers/ZorkOneController.cs
@@ -70,7 +70,13 @@ public class ZorkOneController(
         RestoreSession(savedSession);
         var encodedText = GetGameData();
         await savedGameRepository.SaveGame(request.Id, request.ClientId, request.Name, encodedText, SaveGameTableName);
-        return await engine.GenerationClient.GenerateNarration(new AfterSaveGameRequest(engine.LocationDescription), String.Empty);
+
+        // Ask the context if it wants to provide a custom save game request
+        // If not, use the default AfterSaveGameRequest
+        var saveRequest = engine.Context.GetSaveGameRequest(engine.LocationDescription)
+                          ?? new AfterSaveGameRequest(engine.LocationDescription);
+
+        return await engine.GenerationClient.GenerateNarration(saveRequest, String.Empty);
     }
 
     [HttpGet]

--- a/Model/AIGeneration/Requests/FloydAfterSaveGameRequest.cs
+++ b/Model/AIGeneration/Requests/FloydAfterSaveGameRequest.cs
@@ -8,39 +8,41 @@ public class FloydAfterSaveGameRequest : Request
             $"""
              Floyd and the adventurer are in this location: "{location}".
 
-             The adventurer has just saved their game. Floyd notices this and gets VERY excited because
-             in his experience, people save before doing something dangerous or risky!
+             The adventurer has just saved their game. Floyd senses something exciting is about to happen!
 
              ### **CRITICAL REQUIREMENTS:**
-             1. **MUST start with "Floyd"** - e.g., "Floyd beams and exclaims," or "Floyd's eyes light up as he asks,"
-             2. **Simple, childlike excitement** - like an excited child, not an adult being clever
-             3. **Direct questions** - "Are we going to...?" "Is it time to...?" "Do you think...?"
-             4. **NO sarcasm, NO cleverness, NO metaphors**
-             5. **Very short** - 1 sentence only
-             6. **Use exclamation points** to show excitement
+             1. **MUST start with "Floyd"** - e.g., "Floyd beams and exclaims," "Floyd's eyes widen," "Floyd bounces excitedly"
+             2. **NEVER mention "save" or "saving"** - Floyd just senses danger/excitement ahead
+             3. **Simple, childlike excitement** - like an excited child expecting adventure
+             4. **Direct questions about danger/excitement** - "Are we going to...?" "Is something dangerous coming?"
+             5. **NO sarcasm, NO cleverness, NO metaphors, NO mention of the meta-game**
+             6. **Very short** - 1 sentence only
+             7. **Use exclamation points** to show excitement
 
-             ### **Exact example from original Planetfall game:**
-             Floyd: "Oh Boy! Are we going to do something dangerous now?"
+             ### **EXACT example from original Planetfall game (THIS IS PERFECT):**
+             "Oh Boy! Are we going to do something dangerous now?"
 
-             ### **Good examples (follow this style exactly):**
-             • Floyd beams and asks, "Oh boy! Are we going to try something really dangerous now?"
-             • Floyd's eyes light up as he exclaims, "Does this mean we're going to do something risky?"
-             • Floyd bounces excitedly and asks, "Are we about to try something super dangerous?"
+             ### **Good examples (match this simple style):**
+             • Floyd beams and exclaims, "Oh boy! Are we going to try something really dangerous?"
+             • Floyd's eyes widen as he asks, "Is something exciting about to happen?"
+             • Floyd bounces excitedly and asks, "Are we going to do something risky now?"
 
              ### **BAD examples (NEVER do this):**
-             ❌ Sarcastic: "Oh, planning to challenge the brochure to a debate?"
-             ❌ Too clever: "Saving suggests something ominous"
+             ❌ Mentions save: "Did Floyd just hear a save?"
+             ❌ Too meta: "Are we about to do something really thrilling?!" (thrilling is too self-aware)
+             ❌ Sarcastic: "Oh, planning to challenge the brochure?"
+             ❌ Too clever: "Something ominous"
              ❌ Metaphorical: "Like approaching a vending machine"
              ❌ Doesn't start with Floyd: "Are we planning to..."
-             ❌ Too complex: Multiple sentences or complicated phrasing
 
              ### **Floyd's voice:**
-             - Simple words a child would use
-             - Genuine excitement, not irony
-             - Curious and happy, never cynical
-             - Asks direct questions about what's coming
+             - Simple words: dangerous, risky, scary, exciting
+             - Genuine excitement about DANGER or ADVENTURE
+             - Not about "thrills" or meta-game concepts
+             - Asks direct questions about what dangerous thing is coming
+             - Innocent curiosity, like a child asking if they'll ride a rollercoaster
 
-             Generate ONE short sentence that matches the original game example exactly in tone and simplicity:
+             Generate ONE short sentence matching the original example - excited about DANGER ahead, NO mention of saving:
              """;
     }
 }

--- a/Model/AIGeneration/Requests/FloydAfterSaveGameRequest.cs
+++ b/Model/AIGeneration/Requests/FloydAfterSaveGameRequest.cs
@@ -8,41 +8,48 @@ public class FloydAfterSaveGameRequest : Request
             $"""
              Floyd and the adventurer are in this location: "{location}".
 
-             The adventurer has just saved their game. Floyd senses something exciting is about to happen!
+             The adventurer has just saved their game. Floyd gets that excited feeling like something dangerous is about to happen!
 
-             ### **CRITICAL REQUIREMENTS:**
-             1. **MUST start with "Floyd"** - e.g., "Floyd beams and exclaims," "Floyd's eyes widen," "Floyd bounces excitedly"
-             2. **NEVER mention "save" or "saving"** - Floyd just senses danger/excitement ahead
-             3. **Simple, childlike excitement** - like an excited child expecting adventure
-             4. **Direct questions about danger/excitement** - "Are we going to...?" "Is something dangerous coming?"
-             5. **NO sarcasm, NO cleverness, NO metaphors, NO mention of the meta-game**
-             6. **Very short** - 1 sentence only
-             7. **Use exclamation points** to show excitement
+             ### **YOUR GOAL:**
+             Create a SHORT, excited Floyd response that captures his childlike anticipation of danger or adventure.
+             BE CREATIVE - don't just reword the original. Think of different ways Floyd might express excitement about danger.
 
-             ### **EXACT example from original Planetfall game (THIS IS PERFECT):**
+             ### **ORIGINAL PLANETFALL EXAMPLE (for tone reference only):**
              "Oh Boy! Are we going to do something dangerous now?"
 
-             ### **Good examples (match this simple style):**
-             • Floyd beams and exclaims, "Oh boy! Are we going to try something really dangerous?"
-             • Floyd's eyes widen as he asks, "Is something exciting about to happen?"
-             • Floyd bounces excitedly and asks, "Are we going to do something risky now?"
+             ### **CHARACTER REQUIREMENTS:**
+             • MUST start with "Floyd" doing/saying something
+             • Childlike innocent excitement (not adult cleverness)
+             • Simple, direct language a child would use
+             • Excitement about DANGER, ADVENTURE, or something SCARY
+             • Very short - 1 sentence maximum
+             • NEVER mention "save", "saving", or the meta-game
 
-             ### **BAD examples (NEVER do this):**
-             ❌ Mentions save: "Did Floyd just hear a save?"
-             ❌ Too meta: "Are we about to do something really thrilling?!" (thrilling is too self-aware)
-             ❌ Sarcastic: "Oh, planning to challenge the brochure?"
-             ❌ Too clever: "Something ominous"
-             ❌ Metaphorical: "Like approaching a vending machine"
-             ❌ Doesn't start with Floyd: "Are we planning to..."
+             ### **CREATIVE APPROACHES (pick ONE style, don't mix):**
+             1. **Physical reactions**: Floyd spins/jumps/widens eyes/grins/bounces/squeals
+             2. **Excitement expressions**: "Wow!" "Oh boy!" "Yippee!" "Uh-oh!" "Ooh!"
+             3. **Direct danger questions**: About getting hurt, scary things, dangerous places
+             4. **Adventure questions**: About exploring, trying new things, brave actions
+             5. **Worry/excitement mix**: Nervous but excited about what's ahead
 
-             ### **Floyd's voice:**
-             - Simple words: dangerous, risky, scary, exciting
-             - Genuine excitement about DANGER or ADVENTURE
-             - Not about "thrills" or meta-game concepts
-             - Asks direct questions about what dangerous thing is coming
-             - Innocent curiosity, like a child asking if they'll ride a rollercoaster
+             ### **CREATIVE EXAMPLES (vary from original, don't copy it):**
+             • Floyd's eyes get huge! "Ooh! Is this the scary part?!"
+             • Floyd spins in a circle and shouts, "Yippee! Time for the dangerous bit?"
+             • Floyd squeals with excitement, "Are we gonna do something Floyd shouldn't do?"
+             • Floyd grins nervously and asks, "Is something gonna try to hurt us now?"
+             • Floyd jumps up and down! "Oh wow! Can Floyd come with you for the scary thing?"
 
-             Generate ONE short sentence matching the original example - excited about DANGER ahead, NO mention of saving:
+             ### **FORBIDDEN (too similar to original or wrong tone):**
+             ❌ "Are we going to do something dangerous now?" (too close to original)
+             ❌ "Are we going to do something risky now?" (just synonym swap)
+             ❌ "Is something exciting about to happen?" (too generic)
+             ❌ Any mention of saving, thrilling, meta-game concepts
+             ❌ Sarcasm, cleverness, adult vocabulary
+
+             ### **KEY INSIGHT:**
+             Floyd should sound like an excited 8-year-old who LOVES adventure and isn't quite sure what's coming but knows it's probably dangerous and that's THE BEST PART.
+
+             Generate ONE creative, short sentence that's DIFFERENT from the original but captures the same childlike excitement:
              """;
     }
 }

--- a/Model/AIGeneration/Requests/FloydAfterSaveGameRequest.cs
+++ b/Model/AIGeneration/Requests/FloydAfterSaveGameRequest.cs
@@ -8,32 +8,39 @@ public class FloydAfterSaveGameRequest : Request
             $"""
              Floyd and the adventurer are in this location: "{location}".
 
-             The adventurer has just saved their game. In the original Planetfall game, Floyd would break the fourth wall
-             at this moment and make an excited, curious comment about saving - wondering if something dangerous or
-             exciting is about to happen. This is one of the few times Floyd acknowledges the meta-game aspect.
+             The adventurer has just saved their game. Floyd notices this and gets VERY excited because
+             in his experience, people save before doing something dangerous or risky!
 
-             Generate Floyd's short, excited response to the player saving the game.
+             ### **CRITICAL REQUIREMENTS:**
+             1. **MUST start with "Floyd"** - e.g., "Floyd beams and exclaims," or "Floyd's eyes light up as he asks,"
+             2. **Simple, childlike excitement** - like an excited child, not an adult being clever
+             3. **Direct questions** - "Are we going to...?" "Is it time to...?" "Do you think...?"
+             4. **NO sarcasm, NO cleverness, NO metaphors**
+             5. **Very short** - 1 sentence only
+             6. **Use exclamation points** to show excitement
 
-             **Rules:**
-             1. Tone: Excited, curious, playful - Floyd is happy and intrigued about what might happen next
-             2. Floyd should refer to himself in the third person or use "Floyd" when appropriate
-             3. Reference the idea that saving often happens before dangerous/exciting moments
-             4. Keep it practical and grounded - Floyd is a robot, not poetic or metaphorical
-             5. Make it feel like a question or observation about what's coming next
-             6. No anthropomorphizing objects or abstract concepts
-             7. Stay true to Floyd's mechanical, innocent, curious nature
+             ### **Exact example from original Planetfall game:**
+             Floyd: "Oh Boy! Are we going to do something dangerous now?"
 
-             **Examples from the original game (for tone reference):**
-             • "Oh Boy! Are we going to do something dangerous now?"
+             ### **Good examples (follow this style exactly):**
+             • Floyd beams and asks, "Oh boy! Are we going to try something really dangerous now?"
+             • Floyd's eyes light up as he exclaims, "Does this mean we're going to do something risky?"
+             • Floyd bounces excitedly and asks, "Are we about to try something super dangerous?"
 
-             **Style guidelines:**
-             • Use exclamation points for excitement
-             • Ask questions showing curiosity about the adventure ahead
-             • Floyd can reference saving, danger, excitement, or trying something risky
-             • Keep it short (1-2 sentences maximum)
-             • Begin with "Floyd" doing/saying something (e.g., "Floyd beams...", "Floyd's eyes light up...")
+             ### **BAD examples (NEVER do this):**
+             ❌ Sarcastic: "Oh, planning to challenge the brochure to a debate?"
+             ❌ Too clever: "Saving suggests something ominous"
+             ❌ Metaphorical: "Like approaching a vending machine"
+             ❌ Doesn't start with Floyd: "Are we planning to..."
+             ❌ Too complex: Multiple sentences or complicated phrasing
 
-             Generate Floyd's excited, fourth-wall-breaking save game comment now:
+             ### **Floyd's voice:**
+             - Simple words a child would use
+             - Genuine excitement, not irony
+             - Curious and happy, never cynical
+             - Asks direct questions about what's coming
+
+             Generate ONE short sentence that matches the original game example exactly in tone and simplicity:
              """;
     }
 }

--- a/Model/AIGeneration/Requests/FloydAfterSaveGameRequest.cs
+++ b/Model/AIGeneration/Requests/FloydAfterSaveGameRequest.cs
@@ -1,0 +1,39 @@
+namespace Model.AIGeneration.Requests;
+
+public class FloydAfterSaveGameRequest : Request
+{
+    public FloydAfterSaveGameRequest(string location)
+    {
+        UserMessage =
+            $"""
+             Floyd and the adventurer are in this location: "{location}".
+
+             The adventurer has just saved their game. In the original Planetfall game, Floyd would break the fourth wall
+             at this moment and make an excited, curious comment about saving - wondering if something dangerous or
+             exciting is about to happen. This is one of the few times Floyd acknowledges the meta-game aspect.
+
+             Generate Floyd's short, excited response to the player saving the game.
+
+             **Rules:**
+             1. Tone: Excited, curious, playful - Floyd is happy and intrigued about what might happen next
+             2. Floyd should refer to himself in the third person or use "Floyd" when appropriate
+             3. Reference the idea that saving often happens before dangerous/exciting moments
+             4. Keep it practical and grounded - Floyd is a robot, not poetic or metaphorical
+             5. Make it feel like a question or observation about what's coming next
+             6. No anthropomorphizing objects or abstract concepts
+             7. Stay true to Floyd's mechanical, innocent, curious nature
+
+             **Examples from the original game (for tone reference):**
+             • "Oh Boy! Are we going to do something dangerous now?"
+
+             **Style guidelines:**
+             • Use exclamation points for excitement
+             • Ask questions showing curiosity about the adventure ahead
+             • Floyd can reference saving, danger, excitement, or trying something risky
+             • Keep it short (1-2 sentences maximum)
+             • Begin with "Floyd" doing/saying something (e.g., "Floyd beams...", "Floyd's eyes light up...")
+
+             Generate Floyd's excited, fourth-wall-breaking save game comment now:
+             """;
+    }
+}

--- a/Model/Interface/IContext.cs
+++ b/Model/Interface/IContext.cs
@@ -1,5 +1,6 @@
 using System.Text.Json.Serialization;
 using Model.AIGeneration;
+using Model.AIGeneration.Requests;
 using Model.Intent;
 using Model.Interaction;
 using Model.Item;
@@ -200,5 +201,5 @@ public interface IContext : ICanContainItems
     /// </summary>
     /// <param name="location">The current location description.</param>
     /// <returns>A custom Request for save game narration, or null to use the default AfterSaveGameRequest.</returns>
-    Model.AIGeneration.Request? GetSaveGameRequest(string location);
+    Request? GetSaveGameRequest(string location);
 }

--- a/Model/Interface/IContext.cs
+++ b/Model/Interface/IContext.cs
@@ -193,4 +193,12 @@ public interface IContext : ICanContainItems
     /// </summary>
     /// <returns></returns>
     string? ProcessEndOfTurn();
+
+    /// <summary>
+    ///     Allows game-specific contexts to provide a custom save game request.
+    ///     For example, Planetfall can return a Floyd-specific request when Floyd is present.
+    /// </summary>
+    /// <param name="location">The current location description.</param>
+    /// <returns>A custom Request for save game narration, or null to use the default AfterSaveGameRequest.</returns>
+    Model.AIGeneration.Request? GetSaveGameRequest(string location);
 }

--- a/Model/Interface/IGameEngine.cs
+++ b/Model/Interface/IGameEngine.cs
@@ -139,4 +139,11 @@ public interface IGameEngine
     ///     Gets the current game context containing game state.
     /// </summary>
     IContext Context { get; }
+
+    /// <summary>
+    ///     Generates the narration message after successfully saving the game.
+    ///     Uses the context's custom save game request if available, otherwise uses the default.
+    /// </summary>
+    /// <returns>The narration text to display to the player.</returns>
+    Task<string> GenerateSaveGameNarration();
 }

--- a/Model/Interface/IGameEngine.cs
+++ b/Model/Interface/IGameEngine.cs
@@ -134,4 +134,9 @@ public interface IGameEngine
     /// </summary>
     /// <returns></returns>
     Task InitializeEngine();
+
+    /// <summary>
+    ///     Gets the current game context containing game state.
+    /// </summary>
+    IContext Context { get; }
 }

--- a/Planetfall-Lambda/src/Planetfall-Lambda/Controllers/PlanetfallController.cs
+++ b/Planetfall-Lambda/src/Planetfall-Lambda/Controllers/PlanetfallController.cs
@@ -3,8 +3,6 @@ using Microsoft.AspNetCore.Mvc;
 using Model.AIGeneration.Requests;
 using Model.Interface;
 using Model.Web;
-using Planetfall.Item.Kalamontee.Mech.FloydPart;
-using GameEngine;
 
 namespace Lambda.Controllers;
 
@@ -72,13 +70,10 @@ public class PlanetfallController(
         var encodedText = GetGameData();
         await savedGameRepository.SaveGame(request.Id, request.ClientId, request.Name, encodedText, SaveGameTableName);
 
-        // Check if Floyd is present and use appropriate save comment
-        var floyd = Repository.GetItem<Floyd>();
-        var isFloydPresent = floyd.IsHereAndIsOn(engine.Context);
-
-        Request saveRequest = isFloydPresent
-            ? new FloydAfterSaveGameRequest(engine.LocationDescription)
-            : new AfterSaveGameRequest(engine.LocationDescription);
+        // Ask the context if it wants to provide a custom save game request (e.g., Floyd in Planetfall)
+        // If not, use the default AfterSaveGameRequest
+        var saveRequest = engine.Context.GetSaveGameRequest(engine.LocationDescription)
+                          ?? new AfterSaveGameRequest(engine.LocationDescription);
 
         return await engine.GenerationClient.GenerateNarration(saveRequest, String.Empty);
     }

--- a/Planetfall-Lambda/src/Planetfall-Lambda/Controllers/PlanetfallController.cs
+++ b/Planetfall-Lambda/src/Planetfall-Lambda/Controllers/PlanetfallController.cs
@@ -69,13 +69,7 @@ public class PlanetfallController(
         RestoreSession(savedSession);
         var encodedText = GetGameData();
         await savedGameRepository.SaveGame(request.Id, request.ClientId, request.Name, encodedText, SaveGameTableName);
-
-        // Ask the context if it wants to provide a custom save game request (e.g., Floyd in Planetfall)
-        // If not, use the default AfterSaveGameRequest
-        var saveRequest = engine.Context.GetSaveGameRequest(engine.LocationDescription)
-                          ?? new AfterSaveGameRequest(engine.LocationDescription);
-
-        return await engine.GenerationClient.GenerateNarration(saveRequest, String.Empty);
+        return await engine.GenerateSaveGameNarration();
     }
 
     [HttpGet]

--- a/Planetfall/PlanetfallContext.cs
+++ b/Planetfall/PlanetfallContext.cs
@@ -1,3 +1,5 @@
+using Model.AIGeneration.Requests;
+using Planetfall.Item.Kalamontee.Mech.FloydPart;
 using Utilities;
 
 namespace Planetfall;
@@ -52,5 +54,21 @@ public class PlanetfallContext : Context<PlanetfallGame>, ITimeBasedContext
     {
         Repository.GetItem<Chronometer>().CurrentTime += 54;
         return base.ProcessEndOfTurn();
+    }
+
+    /// <summary>
+    ///     Planetfall-specific save game request logic.
+    ///     If Floyd is present and active, returns a Floyd-specific request with fourth-wall-breaking comments.
+    ///     Otherwise, returns null to use the default AfterSaveGameRequest.
+    /// </summary>
+    public override Model.AIGeneration.Request? GetSaveGameRequest(string location)
+    {
+        var floyd = Repository.GetItem<Floyd>();
+        if (floyd.IsHereAndIsOn(this))
+        {
+            return new FloydAfterSaveGameRequest(location);
+        }
+
+        return null; // Use default AfterSaveGameRequest
     }
 }

--- a/Planetfall/PlanetfallContext.cs
+++ b/Planetfall/PlanetfallContext.cs
@@ -61,7 +61,7 @@ public class PlanetfallContext : Context<PlanetfallGame>, ITimeBasedContext
     ///     If Floyd is present and active, returns a Floyd-specific request with fourth-wall-breaking comments.
     ///     Otherwise, returns null to use the default AfterSaveGameRequest.
     /// </summary>
-    public override Model.AIGeneration.Request? GetSaveGameRequest(string location)
+    public override Request? GetSaveGameRequest(string location)
     {
         var floyd = Repository.GetItem<Floyd>();
         if (floyd.IsHereAndIsOn(this))

--- a/UnitTests/GlobalCommands/SaveProcessorTests.cs
+++ b/UnitTests/GlobalCommands/SaveProcessorTests.cs
@@ -71,14 +71,15 @@ public class SaveProcessorTests
         var client = new Mock<IGenerationClient>();
         client.Setup(s => s.GenerateNarration(It.IsAny<BeforeSaveGameRequest>(), It.IsAny<string>()))
             .ReturnsAsync("shelly");
-        client.Setup(s => s.GenerateNarration(It.IsAny<AfterSaveGameRequest>(), It.IsAny<string>()))
-            .ReturnsAsync("karen");
 
-        var engine = Mock.Of<IGameEngine>(s => s.SaveGame() == "fred");
+        var engine = new Mock<IGameEngine>();
+        engine.Setup(s => s.SaveGame()).Returns("fred");
+        engine.Setup(s => s.GenerateSaveGameNarration()).ReturnsAsync("karen");
+
         var context = Mock.Of<IContext>(c => c.Game.DefaultSaveGameName == "bobby");
         Mock.Get(context).Setup(s => s.CurrentLocation.GetDescriptionForGeneration(Mock.Of<IContext>()))
             .Returns("here");
-        Mock.Get(context).Setup(s => s.Engine).Returns(engine);
+        Mock.Get(context).Setup(s => s.Engine).Returns(engine.Object);
 
         // Act
         await target.Process("input", context, client.Object, Runtime.Unknown);
@@ -87,6 +88,7 @@ public class SaveProcessorTests
         // Assert
         response.Should().Contain("karen");
         target.Completed.Should().BeTrue();
+        engine.Verify(e => e.GenerateSaveGameNarration(), Times.Once);
         var bytesToEncode = Encoding.UTF8.GetBytes("fred");
         var encodedText = Convert.ToBase64String(bytesToEncode);
         Mock.Get(writer).Verify(s => s.Write("bobby", encodedText));
@@ -101,14 +103,15 @@ public class SaveProcessorTests
         var client = new Mock<IGenerationClient>();
         client.Setup(s => s.GenerateNarration(It.IsAny<BeforeSaveGameRequest>(), It.IsAny<string>()))
             .ReturnsAsync("shelly");
-        client.Setup(s => s.GenerateNarration(It.IsAny<AfterSaveGameRequest>(), It.IsAny<string>()))
-            .ReturnsAsync("karen");
 
-        var engine = Mock.Of<IGameEngine>(s => s.SaveGame() == "fred");
+        var engine = new Mock<IGameEngine>();
+        engine.Setup(s => s.SaveGame()).Returns("fred");
+        engine.Setup(s => s.GenerateSaveGameNarration()).ReturnsAsync("karen");
+
         var context = Mock.Of<IContext>(c => c.Game.DefaultSaveGameName == "bobby");
         Mock.Get(context).Setup(s => s.CurrentLocation.GetDescriptionForGeneration(Mock.Of<IContext>()))
             .Returns("here");
-        Mock.Get(context).Setup(s => s.Engine).Returns(engine);
+        Mock.Get(context).Setup(s => s.Engine).Returns(engine.Object);
 
         // Act
         await target.Process("save", context, client.Object, Runtime.Unknown);
@@ -117,6 +120,7 @@ public class SaveProcessorTests
         // Assert
         response.Should().Contain("karen");
         target.Completed.Should().BeTrue();
+        engine.Verify(e => e.GenerateSaveGameNarration(), Times.Once);
         var bytesToEncode = Encoding.UTF8.GetBytes("fred");
         var encodedText = Convert.ToBase64String(bytesToEncode);
         Mock.Get(writer).Verify(s => s.Write("danny", encodedText));

--- a/UnitTests/Lambda/ZorkOneControllerTests.cs
+++ b/UnitTests/Lambda/ZorkOneControllerTests.cs
@@ -297,8 +297,7 @@ public class ZorkOneControllerTests
             _mockSessionRepository.Setup(r => r.GetSessionStepsAsText("session-id", "zork1_session_steps"))
                 .ReturnsAsync("game history");
             _mockEngine.Setup(e => e.SaveGame()).Returns("current game state");
-            _mockGenerationClient.Setup(g => g.GenerateNarration(It.IsAny<Request>(), It.IsAny<string>()))
-                .ReturnsAsync("Game saved successfully.");
+            _mockEngine.Setup(e => e.GenerateSaveGameNarration()).ReturnsAsync("Game saved successfully.");
             _mockSavedGameRepository.Setup(r => r.SaveGame(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
                     It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync("saved-game-id");


### PR DESCRIPTION
When saving in Planetfall, if Floyd is present and active, he now makes a fourth-wall-breaking comment about the save action, inspired by the original game where he said "Oh Boy! Are we going to do something dangerous now?". If Floyd is not present, the old narrator logic is used.

Changes:
- Added IContext Context property to IGameEngine interface for accessing game state
- Made Context public in GameEngine to implement the new interface property
- Created FloydAfterSaveGameRequest with carefully crafted prompts that:
  * Stay true to Floyd's character (curious, practical, mechanical)
  * Break the fourth wall to acknowledge saving
  * Reference the original Planetfall game's tone
  * Ask excited questions about potential danger/adventure ahead
- Modified PlanetfallController.SaveGame to check if Floyd is present via Repository.GetItem<Floyd>().IsHereAndIsOn(engine.Context)
- Added comprehensive tests for both scenarios (Floyd present/not present)

The Floyd prompt was constructed by analyzing all existing Floyd prompts to maintain consistency with his established personality: curious, slightly melancholic, practical, grounded, and never anthropomorphizing objects.