### PR TITLE
Add Mural item to ProjConOffice in Planetfall

### DIFF
--- a/Planetfall.Tests/MuralTests.cs
+++ b/Planetfall.Tests/MuralTests.cs
@@ -1,0 +1,66 @@
+using FluentAssertions;
+using Planetfall.Item.Lawanda;
+using Planetfall.Location.Lawanda;
+
+namespace Planetfall.Tests;
+
+public class MuralTests : EngineTestsBase
+{
+    [Test]
+    public async Task ExamineMural_ShouldReturnDescription()
+    {
+        var target = GetTarget();
+        StartHere<ProjConOffice>();
+
+        var response = await target.GetResponse("examine mural");
+
+        response.Should().Contain("gaudy work of orange and purple abstract shapes");
+        response.Should().Contain("Burstini Bonz");
+        response.Should().Contain("ripple now and then");
+    }
+
+    [Test]
+    public async Task TakeMural_ShouldIndicateFirmlyAttached()
+    {
+        var target = GetTarget();
+        StartHere<ProjConOffice>();
+
+        var response = await target.GetResponse("take mural");
+
+        response.Should().Contain("firmly attached to the wall");
+    }
+
+    [Test]
+    public async Task PunchMural_ShouldReturnCivilResponse()
+    {
+        var target = GetTarget();
+        StartHere<ProjConOffice>();
+
+        var response = await target.GetResponse("punch mural");
+
+        response.Should().Contain("My sentiments also, but let's be civil");
+    }
+
+    [Test]
+    public async Task ProjConOffice_ShouldMentionMuralInDescription()
+    {
+        var target = GetTarget();
+        StartHere<ProjConOffice>();
+
+        var response = await target.GetResponse("look");
+
+        response.Should().Contain("garish mural");
+    }
+
+    [Test]
+    public async Task ProjConOffice_MuralShouldBePresent()
+    {
+        var target = GetTarget();
+        var location = StartHere<ProjConOffice>();
+
+        var mural = GetItem<Mural>();
+
+        mural.CurrentLocation.Should().Be(location);
+        location.Items.Should().Contain(mural);
+    }
+}

--- a/Planetfall/Item/Lawanda/Mural.cs
+++ b/Planetfall/Item/Lawanda/Mural.cs
@@ -1,0 +1,27 @@
+using Model.AIGeneration;
+using Model.Interface;
+
+namespace Planetfall.Item.Lawanda;
+
+public class Mural : ItemBase, ICanBeExamined
+{
+    public override string[] NounsForMatching => ["mural"];
+
+    public override string CannotBeTakenDescription => "The mural is firmly attached to the wall. ";
+
+    public string ExaminationDescription =>
+        "It's a gaudy work of orange and purple abstract shapes, reminiscent of the early works " +
+        "of Burstini Bonz. It doesn't appear to fit the decor of the room at all. The mural seems to ripple " +
+        "now and then, as though a breeze were blowing behind it.";
+
+    public override async Task<InteractionResult?> RespondToSimpleInteraction(SimpleIntent action, IContext context,
+        IGenerationClient client, IItemProcessorFactory itemProcessorFactory)
+    {
+        if (action.Match(Verbs.KillVerbs, NounsForMatching))
+        {
+            return new PositiveInteractionResult("My sentiments also, but let's be civil.");
+        }
+
+        return await base.RespondToSimpleInteraction(action, context, client, itemProcessorFactory);
+    }
+}

--- a/Planetfall/Location/Lawanda/ProjConOffice.cs
+++ b/Planetfall/Location/Lawanda/ProjConOffice.cs
@@ -1,9 +1,10 @@
 using GameEngine.Location;
 using Model.AIGeneration;
+using Planetfall.Item.Lawanda;
 
 namespace Planetfall.Location.Lawanda;
 
-internal class ProjConOffice : LocationWithNoStartingItems
+internal class ProjConOffice : LocationBase
 {
     public override string Name => "ProjCon Office";
 
@@ -15,6 +16,11 @@ internal class ProjConOffice : LocationWithNoStartingItems
         };
     }
 
+    public override void Init()
+    {
+        StartWithItem<Mural>();
+    }
+
     public override async Task<InteractionResult> RespondToSimpleInteraction(SimpleIntent action, IContext context,
         IGenerationClient client, IItemProcessorFactory itemProcessorFactory)
     {
@@ -24,12 +30,6 @@ internal class ProjConOffice : LocationWithNoStartingItems
         if (action.MatchNoun(["logo"]))
             return new PositiveInteractionResult(
                 "The logo shows a flame burning over a sleep chamber of some type. Under that is the phrase \"Prajekt Kuntrool.\"");
-
-        if (action.MatchNoun(["mural"]))
-            return new PositiveInteractionResult(
-                "It's a gaudy work of orange and purple abstract shapes, reminiscent of the early works " +
-                "of Burstini Bonz. It doesn't appear to fit the decor of the room at all. The mural seems to ripple " +
-                "now and then, as though a breeze were blowing behind it.");
 
         return await base.RespondToSimpleInteraction(action, context, client, itemProcessorFactory);
     }


### PR DESCRIPTION
Implements the Mural item as requested in issue #176.

## Changes
- Created new Mural item class that can be examined but not taken
- Added special "destroy" verb handling with the response: "My sentiments also, but let's be civil."
- Updated ProjConOffice to include the Mural as a starting item
- Moved mural interaction logic from location to the item itself

Closes #176

---
Generated with [Claude Code](https://claude.ai/code)