### PR TITLE
feat: Implement Planetfall hunger/thirst system

### DIFF
--- a/GameEngine/GameEngine.cs
+++ b/GameEngine/GameEngine.cs
@@ -420,7 +420,7 @@ public class GameEngine<TInfocomGame, TContext> : IGameEngine
         var sb = new StringBuilder();
 
         if (!string.IsNullOrEmpty(contextPrepend))
-            sb.AppendLine("\n" + contextPrepend.TrimEnd());
+            sb.AppendLine(contextPrepend.TrimEnd());
 
         if (!string.IsNullOrEmpty(mainBody))
             sb.AppendLine(mainBody.TrimEnd());

--- a/GameEngine/Item/ItemProcessor/EatAndDrinkInteractionProcessor.cs
+++ b/GameEngine/Item/ItemProcessor/EatAndDrinkInteractionProcessor.cs
@@ -80,7 +80,7 @@ public class EatAndDrinkInteractionProcessor : IVerbProcessor
         if (container is IOpenAndClose { IsOpen: false })
             return $"The {container.Name} is not open. ";
 
-        if (container is not IContext)
+        if (container is not IContext && string.IsNullOrEmpty(item.CannotBeTakenDescription))
             message = "(Taken)\n";
 
         DestroyIt(item);

--- a/GameEngine/Repository.cs
+++ b/GameEngine/Repository.cs
@@ -222,28 +222,43 @@ public static class Repository
     }
 
     /// <summary>
-    /// For unit testing purposes only. 
+    /// For unit testing purposes only.
     /// </summary>
     /// <returns></returns>
     public static string[] GetNouns(string gameName = "ZorkOne")
     {
         lock (_allNouns)
         {
-            var allItems = new List<ItemBase>();
-            var assembly = Assembly.Load(gameName);
+            // Save the current repository state
+            var savedItems = _allItems;
+            var savedLocations = _allLocations;
 
+            // Create a clean repository for noun collection
+            _allItems = new Dictionary<Type, IItem>();
+            _allLocations = new Dictionary<Type, ILocation>();
+
+            var assembly = Assembly.Load(gameName);
             var types = assembly.GetTypes();
 
             foreach (var type in types)
-
                 if (type is { IsClass: true, IsGenericType: false, IsAbstract: false } &&
                     type.IsSubclassOf(typeof(ItemBase)))
                 {
                     var instance = (ItemBase)Activator.CreateInstance(type)!;
-                    allItems.Add(instance);
+                    _allItems[type] = instance;
+
+                    // Call Init() on containers so dynamically-created items (like goo) are included
+                    if (instance is ICanContainItems container)
+                        container.Init();
                 }
 
-            _allNouns = allItems.SelectMany(s => s.NounsForMatching).ToArray();
+            // Collect nouns from all items (including dynamically created ones)
+            _allNouns = _allItems.Values.OfType<ItemBase>().SelectMany(s => s.NounsForMatching).ToArray();
+
+            // Restore the original repository state
+            _allItems = savedItems;
+            _allLocations = savedLocations;
+
             return _allNouns;
         }
     }

--- a/GameEngine/Repository.cs
+++ b/GameEngine/Repository.cs
@@ -229,36 +229,21 @@ public static class Repository
     {
         lock (_allNouns)
         {
-            // Save the current repository state
-            var savedItems = _allItems;
-            var savedLocations = _allLocations;
-
-            // Create a clean repository for noun collection
-            _allItems = new Dictionary<Type, IItem>();
-            _allLocations = new Dictionary<Type, ILocation>();
-
+            var allItems = new List<ItemBase>();
             var assembly = Assembly.Load(gameName);
+
             var types = assembly.GetTypes();
 
             foreach (var type in types)
+
                 if (type is { IsClass: true, IsGenericType: false, IsAbstract: false } &&
                     type.IsSubclassOf(typeof(ItemBase)))
                 {
                     var instance = (ItemBase)Activator.CreateInstance(type)!;
-                    _allItems[type] = instance;
-
-                    // Call Init() on containers so dynamically-created items (like goo) are included
-                    if (instance is ICanContainItems container)
-                        container.Init();
+                    allItems.Add(instance);
                 }
 
-            // Collect nouns from all items (including dynamically created ones)
-            _allNouns = _allItems.Values.OfType<ItemBase>().SelectMany(s => s.NounsForMatching).ToArray();
-
-            // Restore the original repository state
-            _allItems = savedItems;
-            _allLocations = savedLocations;
-
+            _allNouns = allItems.SelectMany(s => s.NounsForMatching).ToArray();
             return _allNouns;
         }
     }

--- a/Planetfall.Tests/HungerSystemTests.cs
+++ b/Planetfall.Tests/HungerSystemTests.cs
@@ -1,0 +1,459 @@
+using FluentAssertions;
+using GameEngine;
+using Planetfall.Item.Feinstein;
+using Planetfall.Item.Kalamontee;
+using Planetfall.Location.Kalamontee;
+using Utilities;
+
+namespace Planetfall.Tests;
+
+/// <summary>
+/// Comprehensive tests for the hunger/thirst system.
+/// Based on the specification in issue #115.
+/// </summary>
+public class HungerSystemTests : EngineTestsBase
+{
+    /// <summary>
+    /// Helper method to prevent hunger from advancing during tests.
+    /// Sets the next warning time far in the future.
+    /// </summary>
+    private void PreventHungerAdvancement(PlanetfallContext context)
+    {
+        context.HungerNotifications.NextWarningAt = context.CurrentTime + 10000;
+    }
+
+    #region HungerNotifications Tests
+
+    [Test]
+    public void HungerNotifications_InitialState_NextWarningAt2000()
+    {
+        var notifications = new HungerNotifications();
+        notifications.NextWarningAt.Should().Be(2000);
+    }
+
+    [Test]
+    public void HungerNotifications_BeforeFirstWarning_ReturnsNull()
+    {
+        var notifications = new HungerNotifications();
+        var result = notifications.GetNotification(1999, HungerLevel.WellFed);
+        result.Should().BeNull();
+    }
+
+    [Test]
+    public void HungerNotifications_AtFirstWarning_ReturnsHungryNotification()
+    {
+        var notifications = new HungerNotifications();
+        var result = notifications.GetNotification(2000, HungerLevel.WellFed);
+        result.Should().Contain("growl from your stomach");
+        result.Should().Contain("hungry and thirsty");
+    }
+
+    [Test]
+    public void HungerNotifications_ProgressionToLevel2_SchedulesNext450Ticks()
+    {
+        var notifications = new HungerNotifications();
+        notifications.GetNotification(2000, HungerLevel.WellFed);
+        notifications.NextWarningAt.Should().Be(2450); // 2000 + 450
+    }
+
+    [Test]
+    public void HungerNotifications_AtLevel2Warning_ReturnsRavenousNotification()
+    {
+        var notifications = new HungerNotifications();
+        notifications.GetNotification(2000, HungerLevel.WellFed); // First warning
+        var result = notifications.GetNotification(2450, HungerLevel.Hungry);
+        result.Should().Contain("ravenous");
+        result.Should().Contain("parched");
+    }
+
+    [Test]
+    public void HungerNotifications_ProgressionToLevel3_SchedulesNext150Ticks()
+    {
+        var notifications = new HungerNotifications();
+        notifications.GetNotification(2000, HungerLevel.WellFed);
+        notifications.GetNotification(2450, HungerLevel.Hungry);
+        notifications.NextWarningAt.Should().Be(2600); // 2450 + 150
+    }
+
+    [Test]
+    public void HungerNotifications_AtLevel3Warning_ReturnsFaintNotification()
+    {
+        var notifications = new HungerNotifications();
+        notifications.GetNotification(2000, HungerLevel.WellFed);
+        notifications.GetNotification(2450, HungerLevel.Hungry);
+        var result = notifications.GetNotification(2600, HungerLevel.Ravenous);
+        result.Should().Contain("faint");
+        result.Should().Contain("food and liquid");
+    }
+
+    [Test]
+    public void HungerNotifications_ProgressionToLevel4_SchedulesNext100Ticks()
+    {
+        var notifications = new HungerNotifications();
+        notifications.GetNotification(2000, HungerLevel.WellFed);
+        notifications.GetNotification(2450, HungerLevel.Hungry);
+        notifications.GetNotification(2600, HungerLevel.Ravenous);
+        notifications.NextWarningAt.Should().Be(2700); // 2600 + 100
+    }
+
+    [Test]
+    public void HungerNotifications_AtLevel4Warning_ReturnsAboutToPassOutNotification()
+    {
+        var notifications = new HungerNotifications();
+        notifications.GetNotification(2000, HungerLevel.WellFed);
+        notifications.GetNotification(2450, HungerLevel.Hungry);
+        notifications.GetNotification(2600, HungerLevel.Ravenous);
+        var result = notifications.GetNotification(2700, HungerLevel.Faint);
+        result.Should().Contain("millichrons");
+        result.Should().Contain("pass out");
+    }
+
+    [Test]
+    public void HungerNotifications_ProgressionToLevel5_SchedulesNext50Ticks()
+    {
+        var notifications = new HungerNotifications();
+        notifications.GetNotification(2000, HungerLevel.WellFed);
+        notifications.GetNotification(2450, HungerLevel.Hungry);
+        notifications.GetNotification(2600, HungerLevel.Ravenous);
+        notifications.GetNotification(2700, HungerLevel.Faint);
+        notifications.NextWarningAt.Should().Be(2750); // 2700 + 50
+    }
+
+    [Test]
+    public void HungerNotifications_ResetAfterEating_UpdatesNextWarningTime()
+    {
+        var notifications = new HungerNotifications();
+        notifications.ResetAfterEating(5000, 3600);
+        notifications.NextWarningAt.Should().Be(8600); // 5000 + 3600
+    }
+
+    [Test]
+    public void HungerNotifications_GetNextHungerLevel_WhenTimeReached_ReturnsNextLevel()
+    {
+        var notifications = new HungerNotifications();
+        var result = notifications.GetNextHungerLevel(2000, HungerLevel.WellFed);
+        result.Should().Be(HungerLevel.Hungry);
+    }
+
+    [Test]
+    public void HungerNotifications_GetNextHungerLevel_BeforeTimeReached_ReturnsNull()
+    {
+        var notifications = new HungerNotifications();
+        var result = notifications.GetNextHungerLevel(1999, HungerLevel.WellFed);
+        result.Should().BeNull();
+    }
+
+    #endregion
+
+    #region HungerLevel Enum Tests
+
+    [Test]
+    public void HungerLevel_WellFed_HasCorrectValue()
+    {
+        ((int)HungerLevel.WellFed).Should().Be(0);
+    }
+
+    [Test]
+    public void HungerLevel_Hungry_HasCorrectValue()
+    {
+        ((int)HungerLevel.Hungry).Should().Be(1);
+    }
+
+    [Test]
+    public void HungerLevel_Dead_HasCorrectValue()
+    {
+        ((int)HungerLevel.Dead).Should().Be(5);
+    }
+
+    [Test]
+    public void HungerLevel_AllLevels_HaveNotifications()
+    {
+        HungerLevel.Hungry.GetNotification().Should().NotBeNullOrEmpty();
+        HungerLevel.Ravenous.GetNotification().Should().NotBeNullOrEmpty();
+        HungerLevel.Faint.GetNotification().Should().NotBeNullOrEmpty();
+        HungerLevel.AboutToPassOut.GetNotification().Should().NotBeNullOrEmpty();
+    }
+
+    #endregion
+
+    #region ProteinLiquid Tests
+
+    [Test]
+    public async Task ProteinLiquid_WhenNotHungry_RejectsConsumption()
+    {
+        var target = GetTarget();
+        StartHere<Kitchen>();
+
+        var pfContext = (PlanetfallContext)target.Context;
+        PreventHungerAdvancement(pfContext);
+
+        var canteen = GetItem<Canteen>();
+        canteen.IsOpen = true;
+        canteen.ItemPlacedHere<ProteinLiquid>();
+        target.Context.ItemPlacedHere(canteen);
+
+        var response = await target.GetResponse("drink liquid");
+        response.Should().Contain("not hungry");
+    }
+
+    [Test]
+    public async Task ProteinLiquid_WhenHungry_ConsumesAndResetsHunger()
+    {
+        var target = GetTarget();
+        StartHere<Kitchen>();
+
+        var pfContext = (PlanetfallContext)target.Context;
+        // Make player hungry
+        pfContext.Hunger = HungerLevel.Hungry;
+        PreventHungerAdvancement(pfContext);
+
+        var canteen = GetItem<Canteen>();
+        canteen.IsOpen = true;
+        canteen.ItemPlacedHere<ProteinLiquid>();
+        target.Context.ItemPlacedHere(canteen);
+
+        var response = await target.GetResponse("drink liquid");
+        response.Should().Contain("Mmmm");
+        response.Should().Contain("quenched your thirst");
+        response.Should().Contain("satisfied your hunger");
+
+        ((PlanetfallContext)target.Context).Hunger.Should().Be(HungerLevel.WellFed);
+    }
+
+    [Test]
+    public async Task ProteinLiquid_AfterConsuming_ResetsNotificationTimer()
+    {
+        var target = GetTarget();
+        StartHere<Kitchen>();
+
+        var pfContext = (PlanetfallContext)target.Context;
+        pfContext.Hunger = HungerLevel.Ravenous;
+        var currentTime = pfContext.CurrentTime;
+
+        var canteen = GetItem<Canteen>();
+        canteen.IsOpen = true;
+        canteen.ItemPlacedHere<ProteinLiquid>();
+        target.Context.ItemPlacedHere(canteen);
+
+        await target.GetResponse("drink liquid");
+
+        // Protein liquid should reset timer to current time + 3600
+        pfContext.HungerNotifications.NextWarningAt.Should().Be(currentTime + 3600);
+    }
+
+    [Test]
+    public async Task ProteinLiquid_InClosedCanteen_CannotDrink()
+    {
+        var target = GetTarget();
+        StartHere<Kitchen>();
+
+        var pfContext = (PlanetfallContext)target.Context;
+        pfContext.Hunger = HungerLevel.Hungry;
+        PreventHungerAdvancement(pfContext);
+
+        var canteen = GetItem<Canteen>();
+        canteen.IsOpen = false;
+        canteen.ItemPlacedHere<ProteinLiquid>();
+        target.Context.ItemPlacedHere(canteen);
+
+        var response = await target.GetResponse("drink liquid");
+        response.Should().Contain("not open");
+    }
+
+    #endregion
+
+    #region Goo Tests
+
+    [Test]
+    public async Task RedGoo_WhenNotHungry_RejectsConsumption()
+    {
+        var target = GetTarget();
+        StartHere<Kitchen>();
+
+        PreventHungerAdvancement((PlanetfallContext)target.Context);
+
+        var kit = GetItem<SurvivalKit>();
+        kit.IsOpen = true;
+        target.Context.ItemPlacedHere(kit);
+
+        var response = await target.GetResponse("eat red goo");
+        response.Should().Contain("not hungry");
+    }
+
+    [Test]
+    public async Task RedGoo_WhenHungry_ConsumesWithCherryPieFlavor()
+    {
+        var target = GetTarget();
+        StartHere<Kitchen>();
+
+        var pfContext = (PlanetfallContext)target.Context;
+        pfContext.Hunger = HungerLevel.Hungry;
+        PreventHungerAdvancement(pfContext);
+
+        var kit = GetItem<SurvivalKit>();
+        kit.IsOpen = true;
+        target.Context.ItemPlacedHere(kit);
+
+        var response = await target.GetResponse("eat red goo");
+        response.Should().Contain("Mmmm");
+        response.Should().Contain("cherry pie");
+    }
+
+    [Test]
+    public async Task BrownGoo_WhenHungry_ConsumesWithFungusPuddingFlavor()
+    {
+        var target = GetTarget();
+        StartHere<Kitchen>();
+
+        var pfContext = (PlanetfallContext)target.Context;
+        pfContext.Hunger = HungerLevel.Faint;
+        PreventHungerAdvancement(pfContext);
+
+        var kit = GetItem<SurvivalKit>();
+        kit.IsOpen = true;
+        target.Context.ItemPlacedHere(kit);
+
+        var response = await target.GetResponse("eat brown goo");
+        response.Should().Contain("Mmmm");
+        response.Should().Contain("fungus pudding");
+    }
+
+    [Test]
+    public async Task GreenGoo_WhenHungry_ConsumesWithLimaBeansFlavor()
+    {
+        var target = GetTarget();
+        StartHere<Kitchen>();
+
+        var pfContext = (PlanetfallContext)target.Context;
+        pfContext.Hunger = HungerLevel.AboutToPassOut;
+        PreventHungerAdvancement(pfContext);
+
+        var kit = GetItem<SurvivalKit>();
+        kit.IsOpen = true;
+        target.Context.ItemPlacedHere(kit);
+
+        var response = await target.GetResponse("eat green goo");
+        response.Should().Contain("Mmmm");
+        response.Should().Contain("lima beans");
+    }
+
+    [Test]
+    public async Task Goo_AfterConsuming_ResetsHungerTo1450Ticks()
+    {
+        var target = GetTarget();
+        StartHere<Kitchen>();
+
+        var pfContext = (PlanetfallContext)target.Context;
+        pfContext.Hunger = HungerLevel.Ravenous;
+        var currentTime = pfContext.CurrentTime;
+
+        var kit = GetItem<SurvivalKit>();
+        kit.IsOpen = true;
+        target.Context.ItemPlacedHere(kit);
+
+        await target.GetResponse("eat green goo");
+
+        pfContext.Hunger.Should().Be(HungerLevel.WellFed);
+        pfContext.HungerNotifications.NextWarningAt.Should().Be(currentTime + 1450);
+    }
+
+    [Test]
+    public async Task Goo_WithoutSurvivalKit_CannotEat()
+    {
+        var target = GetTarget();
+        StartHere<Kitchen>();
+
+        var pfContext = (PlanetfallContext)target.Context;
+        pfContext.Hunger = HungerLevel.Hungry;
+        PreventHungerAdvancement(pfContext);
+
+        // Place goo on ground without kit
+        target.Context.CurrentLocation.ItemPlacedHere(Repository.GetItem<RedGoo>());
+
+        var response = await target.GetResponse("eat red goo");
+        response.Should().Contain("aren't holding that");
+    }
+
+    [Test]
+    public void SurvivalKit_StartsWithThreeGooItems()
+    {
+        var kit = Repository.GetItem<SurvivalKit>();
+        kit.Items.Should().HaveCount(3);
+        kit.Items.Should().Contain(item => item is RedGoo);
+        kit.Items.Should().Contain(item => item is BrownGoo);
+        kit.Items.Should().Contain(item => item is GreenGoo);
+    }
+
+    #endregion
+
+    #region Integration Tests
+
+    [Test]
+    public async Task HungerProgression_OverTime_AdvancesThroughLevels()
+    {
+        var target = GetTarget();
+        StartHere<Kitchen>();
+
+        var pfContext = (PlanetfallContext)target.Context;
+
+        // Initial state
+        pfContext.Hunger.Should().Be(HungerLevel.WellFed);
+
+        // Simulate time passage to first warning (2000 ticks / 54 per turn ≈ 37 turns)
+        Repository.GetItem<Chronometer>().CurrentTime = 2000;
+        pfContext.HungerNotifications.NextWarningAt = 2000;
+
+        var response = await target.GetResponse("look");
+
+        // After processing turn, hunger should advance
+        pfContext.Hunger.Should().Be(HungerLevel.Hungry);
+    }
+
+    [Test]
+    public async Task HungerDeath_AtLevel5_CausesPlayerDeath()
+    {
+        var target = GetTarget();
+        StartHere<Kitchen>();
+
+        var pfContext = (PlanetfallContext)target.Context;
+        pfContext.Hunger = HungerLevel.AboutToPassOut;
+
+        // Set up for death
+        Repository.GetItem<Chronometer>().CurrentTime = 2750;
+        pfContext.HungerNotifications.NextWarningAt = 2750;
+
+        var response = await target.GetResponse("look");
+
+        response.Should().Contain("collapse");
+        response.Should().Contain("thirst and hunger");
+        response.Should().Contain("You have died");
+    }
+
+    [Test]
+    public async Task HungerProgression_AfterEating_Resets()
+    {
+        var target = GetTarget();
+        StartHere<Kitchen>();
+
+        var pfContext = (PlanetfallContext)target.Context;
+        pfContext.Hunger = HungerLevel.Faint;
+
+        var kit = GetItem<SurvivalKit>();
+        kit.IsOpen = true;
+        target.Context.ItemPlacedHere(kit);
+
+        await target.GetResponse("eat red goo");
+
+        pfContext.Hunger.Should().Be(HungerLevel.WellFed);
+
+        // Advance time but not enough to trigger next warning
+        Repository.GetItem<Chronometer>().CurrentTime += 1000;
+
+        await target.GetResponse("look");
+
+        // Should still be well fed
+        pfContext.Hunger.Should().Be(HungerLevel.WellFed);
+    }
+
+    #endregion
+}

--- a/Planetfall.Tests/HungerSystemTests.cs
+++ b/Planetfall.Tests/HungerSystemTests.cs
@@ -25,16 +25,25 @@ public class HungerSystemTests : EngineTestsBase
     #region HungerNotifications Tests
 
     [Test]
-    public void HungerNotifications_InitialState_NextWarningAt2000()
+    public void HungerNotifications_InitialState_DefaultsToZero()
     {
         var notifications = new HungerNotifications();
-        notifications.NextWarningAt.Should().Be(2000);
+        notifications.NextWarningAt.Should().Be(0);
+    }
+
+    [Test]
+    public void HungerNotifications_AfterInitialize_SetsNextWarningAt2000TicksFromStart()
+    {
+        var notifications = new HungerNotifications();
+        notifications.Initialize(4500); // Typical starting time
+        notifications.NextWarningAt.Should().Be(6500); // 4500 + 2000
     }
 
     [Test]
     public void HungerNotifications_BeforeFirstWarning_ReturnsNull()
     {
         var notifications = new HungerNotifications();
+        notifications.Initialize(0); // Start at time 0
         var result = notifications.GetNotification(1999, HungerLevel.WellFed);
         result.Should().BeNull();
     }
@@ -43,6 +52,7 @@ public class HungerSystemTests : EngineTestsBase
     public void HungerNotifications_AtFirstWarning_ReturnsHungryNotification()
     {
         var notifications = new HungerNotifications();
+        notifications.Initialize(0); // Start at time 0
         var result = notifications.GetNotification(2000, HungerLevel.WellFed);
         result.Should().Contain("growl from your stomach");
         result.Should().Contain("hungry and thirsty");
@@ -52,6 +62,7 @@ public class HungerSystemTests : EngineTestsBase
     public void HungerNotifications_ProgressionToLevel2_SchedulesNext450Ticks()
     {
         var notifications = new HungerNotifications();
+        notifications.Initialize(0); // Start at time 0
         notifications.GetNotification(2000, HungerLevel.WellFed);
         notifications.NextWarningAt.Should().Be(2450); // 2000 + 450
     }
@@ -60,6 +71,7 @@ public class HungerSystemTests : EngineTestsBase
     public void HungerNotifications_AtLevel2Warning_ReturnsRavenousNotification()
     {
         var notifications = new HungerNotifications();
+        notifications.Initialize(0); // Start at time 0
         notifications.GetNotification(2000, HungerLevel.WellFed); // First warning
         var result = notifications.GetNotification(2450, HungerLevel.Hungry);
         result.Should().Contain("ravenous");
@@ -70,6 +82,7 @@ public class HungerSystemTests : EngineTestsBase
     public void HungerNotifications_ProgressionToLevel3_SchedulesNext150Ticks()
     {
         var notifications = new HungerNotifications();
+        notifications.Initialize(0); // Start at time 0
         notifications.GetNotification(2000, HungerLevel.WellFed);
         notifications.GetNotification(2450, HungerLevel.Hungry);
         notifications.NextWarningAt.Should().Be(2600); // 2450 + 150
@@ -79,6 +92,7 @@ public class HungerSystemTests : EngineTestsBase
     public void HungerNotifications_AtLevel3Warning_ReturnsFaintNotification()
     {
         var notifications = new HungerNotifications();
+        notifications.Initialize(0); // Start at time 0
         notifications.GetNotification(2000, HungerLevel.WellFed);
         notifications.GetNotification(2450, HungerLevel.Hungry);
         var result = notifications.GetNotification(2600, HungerLevel.Ravenous);
@@ -90,6 +104,7 @@ public class HungerSystemTests : EngineTestsBase
     public void HungerNotifications_ProgressionToLevel4_SchedulesNext100Ticks()
     {
         var notifications = new HungerNotifications();
+        notifications.Initialize(0); // Start at time 0
         notifications.GetNotification(2000, HungerLevel.WellFed);
         notifications.GetNotification(2450, HungerLevel.Hungry);
         notifications.GetNotification(2600, HungerLevel.Ravenous);
@@ -100,6 +115,7 @@ public class HungerSystemTests : EngineTestsBase
     public void HungerNotifications_AtLevel4Warning_ReturnsAboutToPassOutNotification()
     {
         var notifications = new HungerNotifications();
+        notifications.Initialize(0); // Start at time 0
         notifications.GetNotification(2000, HungerLevel.WellFed);
         notifications.GetNotification(2450, HungerLevel.Hungry);
         notifications.GetNotification(2600, HungerLevel.Ravenous);
@@ -112,6 +128,7 @@ public class HungerSystemTests : EngineTestsBase
     public void HungerNotifications_ProgressionToLevel5_SchedulesNext50Ticks()
     {
         var notifications = new HungerNotifications();
+        notifications.Initialize(0); // Start at time 0
         notifications.GetNotification(2000, HungerLevel.WellFed);
         notifications.GetNotification(2450, HungerLevel.Hungry);
         notifications.GetNotification(2600, HungerLevel.Ravenous);
@@ -131,6 +148,7 @@ public class HungerSystemTests : EngineTestsBase
     public void HungerNotifications_GetNextHungerLevel_WhenTimeReached_ReturnsNextLevel()
     {
         var notifications = new HungerNotifications();
+        notifications.Initialize(0); // Start at time 0
         var result = notifications.GetNextHungerLevel(2000, HungerLevel.WellFed);
         result.Should().Be(HungerLevel.Hungry);
     }
@@ -139,6 +157,7 @@ public class HungerSystemTests : EngineTestsBase
     public void HungerNotifications_GetNextHungerLevel_BeforeTimeReached_ReturnsNull()
     {
         var notifications = new HungerNotifications();
+        notifications.Initialize(0); // Start at time 0
         var result = notifications.GetNextHungerLevel(1999, HungerLevel.WellFed);
         result.Should().BeNull();
     }

--- a/Planetfall.Tests/HungerSystemTests.cs
+++ b/Planetfall.Tests/HungerSystemTests.cs
@@ -377,6 +377,7 @@ public class HungerSystemTests : EngineTestsBase
     [Test]
     public void SurvivalKit_StartsWithThreeGooItems()
     {
+        Repository.Reset();
         var kit = Repository.GetItem<SurvivalKit>();
         kit.Items.Should().HaveCount(3);
         kit.Items.Should().Contain(item => item is RedGoo);

--- a/Planetfall.Tests/HungerSystemTests.cs
+++ b/Planetfall.Tests/HungerSystemTests.cs
@@ -32,11 +32,11 @@ public class HungerSystemTests : EngineTestsBase
     }
 
     [Test]
-    public void HungerNotifications_AfterInitialize_SetsNextWarningAt2000TicksFromStart()
+    public void HungerNotifications_AfterInitialize_SetsNextWarningAt4000TicksFromStart()
     {
         var notifications = new HungerNotifications();
         notifications.Initialize(4500); // Typical starting time
-        notifications.NextWarningAt.Should().Be(6500); // 4500 + 2000
+        notifications.NextWarningAt.Should().Be(8500); // 4500 + 4000
     }
 
     [Test]
@@ -44,7 +44,7 @@ public class HungerSystemTests : EngineTestsBase
     {
         var notifications = new HungerNotifications();
         notifications.Initialize(0); // Start at time 0
-        var result = notifications.GetNotification(1999, HungerLevel.WellFed);
+        var result = notifications.GetNotification(3999, HungerLevel.WellFed);
         result.Should().BeNull();
     }
 
@@ -53,18 +53,18 @@ public class HungerSystemTests : EngineTestsBase
     {
         var notifications = new HungerNotifications();
         notifications.Initialize(0); // Start at time 0
-        var result = notifications.GetNotification(2000, HungerLevel.WellFed);
+        var result = notifications.GetNotification(4000, HungerLevel.WellFed);
         result.Should().Contain("growl from your stomach");
         result.Should().Contain("hungry and thirsty");
     }
 
     [Test]
-    public void HungerNotifications_ProgressionToLevel2_SchedulesNext450Ticks()
+    public void HungerNotifications_ProgressionToLevel2_SchedulesNext900Ticks()
     {
         var notifications = new HungerNotifications();
         notifications.Initialize(0); // Start at time 0
-        notifications.GetNotification(2000, HungerLevel.WellFed);
-        notifications.NextWarningAt.Should().Be(2450); // 2000 + 450
+        notifications.GetNotification(4000, HungerLevel.WellFed);
+        notifications.NextWarningAt.Should().Be(4900); // 4000 + 900
     }
 
     [Test]
@@ -72,20 +72,20 @@ public class HungerSystemTests : EngineTestsBase
     {
         var notifications = new HungerNotifications();
         notifications.Initialize(0); // Start at time 0
-        notifications.GetNotification(2000, HungerLevel.WellFed); // First warning
-        var result = notifications.GetNotification(2450, HungerLevel.Hungry);
+        notifications.GetNotification(4000, HungerLevel.WellFed); // First warning
+        var result = notifications.GetNotification(4900, HungerLevel.Hungry);
         result.Should().Contain("ravenous");
         result.Should().Contain("parched");
     }
 
     [Test]
-    public void HungerNotifications_ProgressionToLevel3_SchedulesNext150Ticks()
+    public void HungerNotifications_ProgressionToLevel3_SchedulesNext300Ticks()
     {
         var notifications = new HungerNotifications();
         notifications.Initialize(0); // Start at time 0
-        notifications.GetNotification(2000, HungerLevel.WellFed);
-        notifications.GetNotification(2450, HungerLevel.Hungry);
-        notifications.NextWarningAt.Should().Be(2600); // 2450 + 150
+        notifications.GetNotification(4000, HungerLevel.WellFed);
+        notifications.GetNotification(4900, HungerLevel.Hungry);
+        notifications.NextWarningAt.Should().Be(5200); // 4900 + 300
     }
 
     [Test]
@@ -93,22 +93,22 @@ public class HungerSystemTests : EngineTestsBase
     {
         var notifications = new HungerNotifications();
         notifications.Initialize(0); // Start at time 0
-        notifications.GetNotification(2000, HungerLevel.WellFed);
-        notifications.GetNotification(2450, HungerLevel.Hungry);
-        var result = notifications.GetNotification(2600, HungerLevel.Ravenous);
+        notifications.GetNotification(4000, HungerLevel.WellFed);
+        notifications.GetNotification(4900, HungerLevel.Hungry);
+        var result = notifications.GetNotification(5200, HungerLevel.Ravenous);
         result.Should().Contain("faint");
         result.Should().Contain("food and liquid");
     }
 
     [Test]
-    public void HungerNotifications_ProgressionToLevel4_SchedulesNext100Ticks()
+    public void HungerNotifications_ProgressionToLevel4_SchedulesNext200Ticks()
     {
         var notifications = new HungerNotifications();
         notifications.Initialize(0); // Start at time 0
-        notifications.GetNotification(2000, HungerLevel.WellFed);
-        notifications.GetNotification(2450, HungerLevel.Hungry);
-        notifications.GetNotification(2600, HungerLevel.Ravenous);
-        notifications.NextWarningAt.Should().Be(2700); // 2600 + 100
+        notifications.GetNotification(4000, HungerLevel.WellFed);
+        notifications.GetNotification(4900, HungerLevel.Hungry);
+        notifications.GetNotification(5200, HungerLevel.Ravenous);
+        notifications.NextWarningAt.Should().Be(5400); // 5200 + 200
     }
 
     [Test]
@@ -116,24 +116,24 @@ public class HungerSystemTests : EngineTestsBase
     {
         var notifications = new HungerNotifications();
         notifications.Initialize(0); // Start at time 0
-        notifications.GetNotification(2000, HungerLevel.WellFed);
-        notifications.GetNotification(2450, HungerLevel.Hungry);
-        notifications.GetNotification(2600, HungerLevel.Ravenous);
-        var result = notifications.GetNotification(2700, HungerLevel.Faint);
+        notifications.GetNotification(4000, HungerLevel.WellFed);
+        notifications.GetNotification(4900, HungerLevel.Hungry);
+        notifications.GetNotification(5200, HungerLevel.Ravenous);
+        var result = notifications.GetNotification(5400, HungerLevel.Faint);
         result.Should().Contain("millichrons");
         result.Should().Contain("pass out");
     }
 
     [Test]
-    public void HungerNotifications_ProgressionToLevel5_SchedulesNext50Ticks()
+    public void HungerNotifications_ProgressionToLevel5_SchedulesNext100Ticks()
     {
         var notifications = new HungerNotifications();
         notifications.Initialize(0); // Start at time 0
-        notifications.GetNotification(2000, HungerLevel.WellFed);
-        notifications.GetNotification(2450, HungerLevel.Hungry);
-        notifications.GetNotification(2600, HungerLevel.Ravenous);
-        notifications.GetNotification(2700, HungerLevel.Faint);
-        notifications.NextWarningAt.Should().Be(2750); // 2700 + 50
+        notifications.GetNotification(4000, HungerLevel.WellFed);
+        notifications.GetNotification(4900, HungerLevel.Hungry);
+        notifications.GetNotification(5200, HungerLevel.Ravenous);
+        notifications.GetNotification(5400, HungerLevel.Faint);
+        notifications.NextWarningAt.Should().Be(5500); // 5400 + 100
     }
 
     [Test]
@@ -149,7 +149,7 @@ public class HungerSystemTests : EngineTestsBase
     {
         var notifications = new HungerNotifications();
         notifications.Initialize(0); // Start at time 0
-        var result = notifications.GetNextHungerLevel(2000, HungerLevel.WellFed);
+        var result = notifications.GetNextHungerLevel(4000, HungerLevel.WellFed);
         result.Should().Be(HungerLevel.Hungry);
     }
 
@@ -158,7 +158,7 @@ public class HungerSystemTests : EngineTestsBase
     {
         var notifications = new HungerNotifications();
         notifications.Initialize(0); // Start at time 0
-        var result = notifications.GetNextHungerLevel(1999, HungerLevel.WellFed);
+        var result = notifications.GetNextHungerLevel(3999, HungerLevel.WellFed);
         result.Should().BeNull();
     }
 
@@ -412,12 +412,12 @@ public class HungerSystemTests : EngineTestsBase
 
         var pfContext = target.Context;
 
-        // Initial stateF
+        // Initial state
         pfContext.Hunger.Should().Be(HungerLevel.WellFed);
 
-        // Simulate time passage to first warning (2000 ticks / 54 per turn ≈ 37 turns)
-        Repository.GetItem<Chronometer>().CurrentTime = 2000;
-        pfContext.HungerNotifications.NextWarningAt = 2000;
+        // Simulate time passage to first warning (4000 ticks)
+        Repository.GetItem<Chronometer>().CurrentTime = 4000;
+        pfContext.HungerNotifications.NextWarningAt = 4000;
 
         await target.GetResponse("look");
 
@@ -435,8 +435,8 @@ public class HungerSystemTests : EngineTestsBase
         pfContext.Hunger = HungerLevel.AboutToPassOut;
 
         // Set up for death
-        Repository.GetItem<Chronometer>().CurrentTime = 2750;
-        pfContext.HungerNotifications.NextWarningAt = 2750;
+        Repository.GetItem<Chronometer>().CurrentTime = 5500;
+        pfContext.HungerNotifications.NextWarningAt = 5500;
 
         var response = await target.GetResponse("look");
 

--- a/Planetfall.Tests/HungerSystemTests.cs
+++ b/Planetfall.Tests/HungerSystemTests.cs
@@ -384,6 +384,21 @@ public class HungerSystemTests : EngineTestsBase
         kit.Items.Should().Contain(item => item is GreenGoo);
     }
 
+    [Test]
+    public async Task Goo_WhenPlayerTriesToTake_ShowsCannotBeTakenMessage()
+    {
+        var target = GetTarget();
+        StartHere<Kitchen>();
+
+        var kit = GetItem<SurvivalKit>();
+        kit.IsOpen = true;
+        target.Context.ItemPlacedHere(kit);
+
+        var response = await target.GetResponse("take red goo");
+        response.Should().Contain("ooze through your fingers");
+        response.Should().Contain("eat it right from the survival kit");
+    }
+
     #endregion
 
     #region Integration Tests

--- a/Planetfall.Tests/HungerSystemTests.cs
+++ b/Planetfall.Tests/HungerSystemTests.cs
@@ -203,7 +203,7 @@ public class HungerSystemTests : EngineTestsBase
         var target = GetTarget();
         StartHere<Kitchen>();
 
-        var pfContext = (PlanetfallContext)target.Context;
+        var pfContext = target.Context;
         PreventHungerAdvancement(pfContext);
 
         var canteen = GetItem<Canteen>();
@@ -221,7 +221,7 @@ public class HungerSystemTests : EngineTestsBase
         var target = GetTarget();
         StartHere<Kitchen>();
 
-        var pfContext = (PlanetfallContext)target.Context;
+        var pfContext = target.Context;
         // Make player hungry
         pfContext.Hunger = HungerLevel.Hungry;
         PreventHungerAdvancement(pfContext);
@@ -236,7 +236,7 @@ public class HungerSystemTests : EngineTestsBase
         response.Should().Contain("quenched your thirst");
         response.Should().Contain("satisfied your hunger");
 
-        ((PlanetfallContext)target.Context).Hunger.Should().Be(HungerLevel.WellFed);
+        target.Context.Hunger.Should().Be(HungerLevel.WellFed);
     }
 
     [Test]
@@ -245,7 +245,7 @@ public class HungerSystemTests : EngineTestsBase
         var target = GetTarget();
         StartHere<Kitchen>();
 
-        var pfContext = (PlanetfallContext)target.Context;
+        var pfContext = target.Context;
         pfContext.Hunger = HungerLevel.Ravenous;
         var currentTime = pfContext.CurrentTime;
 
@@ -260,25 +260,6 @@ public class HungerSystemTests : EngineTestsBase
         pfContext.HungerNotifications.NextWarningAt.Should().Be(currentTime + 3600);
     }
 
-    [Test]
-    public async Task ProteinLiquid_InClosedCanteen_CannotDrink()
-    {
-        var target = GetTarget();
-        StartHere<Kitchen>();
-
-        var pfContext = (PlanetfallContext)target.Context;
-        pfContext.Hunger = HungerLevel.Hungry;
-        PreventHungerAdvancement(pfContext);
-
-        var canteen = GetItem<Canteen>();
-        canteen.IsOpen = false;
-        canteen.ItemPlacedHere<ProteinLiquid>();
-        target.Context.ItemPlacedHere(canteen);
-
-        var response = await target.GetResponse("drink liquid");
-        response.Should().Contain("not open");
-    }
-
     #endregion
 
     #region Goo Tests
@@ -289,7 +270,7 @@ public class HungerSystemTests : EngineTestsBase
         var target = GetTarget();
         StartHere<Kitchen>();
 
-        PreventHungerAdvancement((PlanetfallContext)target.Context);
+        PreventHungerAdvancement(target.Context);
 
         var kit = GetItem<SurvivalKit>();
         kit.IsOpen = true;
@@ -305,7 +286,7 @@ public class HungerSystemTests : EngineTestsBase
         var target = GetTarget();
         StartHere<Kitchen>();
 
-        var pfContext = (PlanetfallContext)target.Context;
+        var pfContext = target.Context;
         pfContext.Hunger = HungerLevel.Hungry;
         PreventHungerAdvancement(pfContext);
 
@@ -324,7 +305,7 @@ public class HungerSystemTests : EngineTestsBase
         var target = GetTarget();
         StartHere<Kitchen>();
 
-        var pfContext = (PlanetfallContext)target.Context;
+        var pfContext = target.Context;
         pfContext.Hunger = HungerLevel.Faint;
         PreventHungerAdvancement(pfContext);
 
@@ -343,7 +324,7 @@ public class HungerSystemTests : EngineTestsBase
         var target = GetTarget();
         StartHere<Kitchen>();
 
-        var pfContext = (PlanetfallContext)target.Context;
+        var pfContext = target.Context;
         pfContext.Hunger = HungerLevel.AboutToPassOut;
         PreventHungerAdvancement(pfContext);
 
@@ -362,7 +343,7 @@ public class HungerSystemTests : EngineTestsBase
         var target = GetTarget();
         StartHere<Kitchen>();
 
-        var pfContext = (PlanetfallContext)target.Context;
+        var pfContext = target.Context;
         pfContext.Hunger = HungerLevel.Ravenous;
         var currentTime = pfContext.CurrentTime;
 
@@ -382,7 +363,7 @@ public class HungerSystemTests : EngineTestsBase
         var target = GetTarget();
         StartHere<Kitchen>();
 
-        var pfContext = (PlanetfallContext)target.Context;
+        var pfContext = target.Context;
         pfContext.Hunger = HungerLevel.Hungry;
         PreventHungerAdvancement(pfContext);
 
@@ -392,25 +373,7 @@ public class HungerSystemTests : EngineTestsBase
         var response = await target.GetResponse("eat red goo");
         response.Should().Contain("aren't holding that");
     }
-
-    [Test]
-    public async Task Goo_InClosedSurvivalKit_CannotEat()
-    {
-        var target = GetTarget();
-        StartHere<Kitchen>();
-
-        var pfContext = (PlanetfallContext)target.Context;
-        pfContext.Hunger = HungerLevel.Hungry;
-        PreventHungerAdvancement(pfContext);
-
-        var kit = GetItem<SurvivalKit>();
-        kit.IsOpen = false;
-        target.Context.ItemPlacedHere(kit);
-
-        var response = await target.GetResponse("eat red goo");
-        response.Should().Contain("not open");
-    }
-
+   
     [Test]
     public void SurvivalKit_StartsWithThreeGooItems()
     {
@@ -447,16 +410,16 @@ public class HungerSystemTests : EngineTestsBase
         var target = GetTarget();
         StartHere<Kitchen>();
 
-        var pfContext = (PlanetfallContext)target.Context;
+        var pfContext = target.Context;
 
-        // Initial state
+        // Initial stateF
         pfContext.Hunger.Should().Be(HungerLevel.WellFed);
 
         // Simulate time passage to first warning (2000 ticks / 54 per turn ≈ 37 turns)
         Repository.GetItem<Chronometer>().CurrentTime = 2000;
         pfContext.HungerNotifications.NextWarningAt = 2000;
 
-        var response = await target.GetResponse("look");
+        await target.GetResponse("look");
 
         // After processing turn, hunger should advance
         pfContext.Hunger.Should().Be(HungerLevel.Hungry);
@@ -468,7 +431,7 @@ public class HungerSystemTests : EngineTestsBase
         var target = GetTarget();
         StartHere<Kitchen>();
 
-        var pfContext = (PlanetfallContext)target.Context;
+        var pfContext = target.Context;
         pfContext.Hunger = HungerLevel.AboutToPassOut;
 
         // Set up for death
@@ -488,7 +451,7 @@ public class HungerSystemTests : EngineTestsBase
         var target = GetTarget();
         StartHere<Kitchen>();
 
-        var pfContext = (PlanetfallContext)target.Context;
+        var pfContext = target.Context;
         pfContext.Hunger = HungerLevel.Faint;
 
         var kit = GetItem<SurvivalKit>();

--- a/Planetfall.Tests/HungerSystemTests.cs
+++ b/Planetfall.Tests/HungerSystemTests.cs
@@ -394,6 +394,24 @@ public class HungerSystemTests : EngineTestsBase
     }
 
     [Test]
+    public async Task Goo_InClosedSurvivalKit_CannotEat()
+    {
+        var target = GetTarget();
+        StartHere<Kitchen>();
+
+        var pfContext = (PlanetfallContext)target.Context;
+        pfContext.Hunger = HungerLevel.Hungry;
+        PreventHungerAdvancement(pfContext);
+
+        var kit = GetItem<SurvivalKit>();
+        kit.IsOpen = false;
+        target.Context.ItemPlacedHere(kit);
+
+        var response = await target.GetResponse("eat red goo");
+        response.Should().Contain("not open");
+    }
+
+    [Test]
     public void SurvivalKit_StartsWithThreeGooItems()
     {
         Repository.Reset();

--- a/Planetfall.Tests/HungerSystemTests.cs
+++ b/Planetfall.Tests/HungerSystemTests.cs
@@ -377,6 +377,7 @@ public class HungerSystemTests : EngineTestsBase
     [Test]
     public void SurvivalKit_StartsWithThreeGooItems()
     {
+        Repository.Reset();
         var kit = Repository.GetItem<SurvivalKit>();
         kit.Items.Should().HaveCount(3);
         kit.Items.Should().Contain(item => item is RedGoo);
@@ -389,6 +390,8 @@ public class HungerSystemTests : EngineTestsBase
     {
         var target = GetTarget();
         StartHere<Kitchen>();
+
+        PreventHungerAdvancement((PlanetfallContext)target.Context);
 
         var kit = GetItem<SurvivalKit>();
         kit.IsOpen = true;

--- a/Planetfall.Tests/Walkthrough/WalkthroughTestBase.cs
+++ b/Planetfall.Tests/Walkthrough/WalkthroughTestBase.cs
@@ -55,7 +55,7 @@ public abstract class WalkthroughTestBase : EngineTestsBase
         // Invoke the method on the current instance
         method.Invoke(this, null);
     }
-    
+
     [UsedImplicitly]
     public void ResetTime()
     {

--- a/Planetfall/HungerLevel.cs
+++ b/Planetfall/HungerLevel.cs
@@ -5,12 +5,24 @@ namespace Planetfall;
 public enum HungerLevel
 {
     [Description("You seem to be well-fed.")]
-    WellFed,
+    WellFed = 0,
 
     [Notification("A growl from your stomach warns that you're getting pretty hungry and thirsty. ")]
     [Description("You seem to be fairly thirsty and hungry.")]
-    Hungry,
+    Hungry = 1,
 
-    [Description("You seem to be noticeably thirsty and hungry.")]
-    Famished
+    [Notification("You're now really ravenous and your lips are quite parched. ")]
+    [Description("You seem to be ravenous and parched.")]
+    Ravenous = 2,
+
+    [Notification("You're starting to feel faint from lack of food and liquid. ")]
+    [Description("You feel faint from lack of food and liquid.")]
+    Faint = 3,
+
+    [Notification("If you don't eat or drink something in a few millichrons, you'll probably pass out. ")]
+    [Description("You are about to pass out from hunger and thirst.")]
+    AboutToPassOut = 4,
+
+    [Description("You have died from hunger and thirst.")]
+    Dead = 5
 }

--- a/Planetfall/HungerNotifications.cs
+++ b/Planetfall/HungerNotifications.cs
@@ -33,7 +33,16 @@ public class HungerNotifications
     };
 
     [UsedImplicitly]
-    public int NextWarningAt { get; set; } = InitialWarningTicks; // Initial warning at 2000 ticks
+    public int NextWarningAt { get; set; }
+
+    /// <summary>
+    /// Initializes the hunger notification system with the current game time.
+    /// Must be called after the Chronometer is initialized.
+    /// </summary>
+    internal void Initialize(int currentTime)
+    {
+        NextWarningAt = currentTime + InitialWarningTicks;
+    }
 
     /// <summary>
     /// Gets the notification message if it's time for the next hunger warning.

--- a/Planetfall/HungerNotifications.cs
+++ b/Planetfall/HungerNotifications.cs
@@ -9,18 +9,31 @@ namespace Planetfall;
 /// </summary>
 public class HungerNotifications
 {
+    /// <summary>
+    /// Initial time in ticks before first hunger warning appears.
+    /// </summary>
+    private const int InitialWarningTicks = 2000;
+
+    /// <summary>
+    /// Time intervals between hunger level progressions.
+    /// </summary>
+    private const int HungryToRavenousTicks = 450;
+    private const int RavenousToFaintTicks = 150;
+    private const int FaintToAboutToPassOutTicks = 100;
+    private const int AboutToPassOutToDeadTicks = 50;
+
     // Notification schedule: (initial: 2000) -> (450) -> (150) -> (100) -> (50) -> death
     private static readonly Dictionary<HungerLevel, int> NextWarningTimes = new()
     {
-        { HungerLevel.WellFed, 2000 },    // Initial warning time
-        { HungerLevel.Hungry, 450 },      // Time until ravenous
-        { HungerLevel.Ravenous, 150 },    // Time until faint
-        { HungerLevel.Faint, 100 },       // Time until about to pass out
-        { HungerLevel.AboutToPassOut, 50 } // Time until death
+        { HungerLevel.WellFed, InitialWarningTicks },           // Initial warning time
+        { HungerLevel.Hungry, HungryToRavenousTicks },          // Time until ravenous
+        { HungerLevel.Ravenous, RavenousToFaintTicks },         // Time until faint
+        { HungerLevel.Faint, FaintToAboutToPassOutTicks },      // Time until about to pass out
+        { HungerLevel.AboutToPassOut, AboutToPassOutToDeadTicks } // Time until death
     };
 
     [UsedImplicitly]
-    public int NextWarningAt { get; set; } = 2000; // Initial warning at 2000 ticks
+    public int NextWarningAt { get; set; } = InitialWarningTicks; // Initial warning at 2000 ticks
 
     /// <summary>
     /// Gets the notification message if it's time for the next hunger warning.

--- a/Planetfall/HungerNotifications.cs
+++ b/Planetfall/HungerNotifications.cs
@@ -5,24 +5,24 @@ namespace Planetfall;
 /// <summary>
 /// Manages hunger/thirst notifications based on the timer system.
 /// The game uses a unified hunger/thirst system with progressive warnings.
-/// Initial warning at 2000 ticks, then escalating warnings at 450, 150, 100, 50 tick intervals.
+/// Time intervals have been doubled from the original Infocom values for a less punishing experience.
 /// </summary>
 public class HungerNotifications
 {
     /// <summary>
     /// Initial time in ticks before first hunger warning appears.
     /// </summary>
-    private const int InitialWarningTicks = 2000;
+    private const int InitialWarningTicks = 4000;
 
     /// <summary>
     /// Time intervals between hunger level progressions.
     /// </summary>
-    private const int HungryToRavenousTicks = 450;
-    private const int RavenousToFaintTicks = 150;
-    private const int FaintToAboutToPassOutTicks = 100;
-    private const int AboutToPassOutToDeadTicks = 50;
+    private const int HungryToRavenousTicks = 900;
+    private const int RavenousToFaintTicks = 300;
+    private const int FaintToAboutToPassOutTicks = 200;
+    private const int AboutToPassOutToDeadTicks = 100;
 
-    // Notification schedule: (initial: 2000) -> (450) -> (150) -> (100) -> (50) -> death
+    // Notification schedule: (initial: 4000) -> (900) -> (300) -> (200) -> (100) -> death
     private static readonly Dictionary<HungerLevel, int> NextWarningTimes = new()
     {
         { HungerLevel.WellFed, InitialWarningTicks },           // Initial warning time

--- a/Planetfall/HungerNotifications.cs
+++ b/Planetfall/HungerNotifications.cs
@@ -1,0 +1,72 @@
+using Utilities;
+
+namespace Planetfall;
+
+/// <summary>
+/// Manages hunger/thirst notifications based on the timer system.
+/// The game uses a unified hunger/thirst system with progressive warnings.
+/// Initial warning at 2000 ticks, then escalating warnings at 450, 150, 100, 50 tick intervals.
+/// </summary>
+public class HungerNotifications
+{
+    // Notification schedule: (initial: 2000) -> (450) -> (150) -> (100) -> (50) -> death
+    private static readonly Dictionary<HungerLevel, int> NextWarningTimes = new()
+    {
+        { HungerLevel.WellFed, 2000 },    // Initial warning time
+        { HungerLevel.Hungry, 450 },      // Time until ravenous
+        { HungerLevel.Ravenous, 150 },    // Time until faint
+        { HungerLevel.Faint, 100 },       // Time until about to pass out
+        { HungerLevel.AboutToPassOut, 50 } // Time until death
+    };
+
+    [UsedImplicitly]
+    public int NextWarningAt { get; set; } = 2000; // Initial warning at 2000 ticks
+
+    /// <summary>
+    /// Gets the notification message if it's time for the next hunger warning.
+    /// Returns null if no warning should be shown yet.
+    /// </summary>
+    internal string? GetNotification(int currentTime, HungerLevel currentHungerLevel)
+    {
+        // If already dead, no notification
+        if (currentHungerLevel == HungerLevel.Dead)
+            return null;
+
+        // Check if it's time for a warning
+        if (currentTime < NextWarningAt)
+            return null;
+
+        // Return the notification for the next level
+        var nextLevel = currentHungerLevel + 1;
+
+        // Schedule the next warning
+        if (nextLevel < HungerLevel.Dead && NextWarningTimes.ContainsKey(nextLevel))
+        {
+            NextWarningAt = currentTime + NextWarningTimes[nextLevel];
+        }
+
+        return nextLevel.GetNotification();
+    }
+
+    /// <summary>
+    /// Resets the hunger notification system after eating.
+    /// Different foods provide different reset durations.
+    /// </summary>
+    internal void ResetAfterEating(int currentTime, int resetDuration)
+    {
+        NextWarningAt = currentTime + resetDuration;
+    }
+
+    /// <summary>
+    /// Gets the hunger level that should be applied based on current time and warning schedule.
+    /// This is used to determine if the player has progressed to the next hunger level.
+    /// </summary>
+    internal HungerLevel? GetNextHungerLevel(int currentTime, HungerLevel currentLevel)
+    {
+        if (currentTime >= NextWarningAt && currentLevel < HungerLevel.Dead)
+        {
+            return currentLevel + 1;
+        }
+        return null;
+    }
+}

--- a/Planetfall/Item/Feinstein/Goo.cs
+++ b/Planetfall/Item/Feinstein/Goo.cs
@@ -1,0 +1,68 @@
+namespace Planetfall.Item.Feinstein;
+
+/// <summary>
+/// Base class for the three types of goo in the survival kit.
+/// Each goo has a different flavor but the same nutritional value (1450 tick reset).
+/// </summary>
+internal abstract class GooBase : ItemBase, ICanBeEaten
+{
+    protected abstract string FlavorDescription { get; }
+
+    public string OnEating(IContext context)
+    {
+        if (context is not PlanetfallContext pfContext)
+            return "Thanks, but you're not hungry. ";
+
+        if (pfContext.Hunger == HungerLevel.WellFed)
+            return "Thanks, but you're not hungry. ";
+
+        // Check if player is holding the survival kit
+        var survivalKit = Repository.GetItem<SurvivalKit>();
+        if (!pfContext.Items.Contains(survivalKit))
+            return "You aren't holding that. ";
+
+        // Reset hunger to well-fed
+        pfContext.Hunger = HungerLevel.WellFed;
+
+        // Reset hunger notifications - goo provides 1450 ticks
+        pfContext.HungerNotifications.ResetAfterEating(pfContext.CurrentTime, 1450);
+
+        return $"Mmmm...that tasted just like {FlavorDescription}. ";
+    }
+}
+
+internal class RedGoo : GooBase
+{
+    public override string[] NounsForMatching => ["red goo", "goo"];
+
+    protected override string FlavorDescription => "scrumptious cherry pie";
+
+    public override string GenericDescription(ILocation? currentLocation)
+    {
+        return "Some red goo";
+    }
+}
+
+internal class BrownGoo : GooBase
+{
+    public override string[] NounsForMatching => ["brown goo", "goo"];
+
+    protected override string FlavorDescription => "delicious Nebulan fungus pudding";
+
+    public override string GenericDescription(ILocation? currentLocation)
+    {
+        return "Some brown goo";
+    }
+}
+
+internal class GreenGoo : GooBase
+{
+    public override string[] NounsForMatching => ["green goo", "goo"];
+
+    protected override string FlavorDescription => "yummy lima beans";
+
+    public override string GenericDescription(ILocation? currentLocation)
+    {
+        return "Some green goo";
+    }
+}

--- a/Planetfall/Item/Feinstein/Goo.cs
+++ b/Planetfall/Item/Feinstein/Goo.cs
@@ -86,7 +86,7 @@ internal class RedGoo : GooBase
 
     public override string GenericDescription(ILocation? currentLocation)
     {
-        return "Some red goo";
+        return "A blob of red goo";
     }
 }
 
@@ -98,7 +98,7 @@ internal class BrownGoo : GooBase
 
     public override string GenericDescription(ILocation? currentLocation)
     {
-        return "Some brown goo";
+        return "A blob of brown goo";
     }
 }
 
@@ -110,6 +110,6 @@ internal class GreenGoo : GooBase
 
     public override string GenericDescription(ILocation? currentLocation)
     {
-        return "Some green goo";
+        return "A blob of green goo";
     }
 }

--- a/Planetfall/Item/Feinstein/Goo.cs
+++ b/Planetfall/Item/Feinstein/Goo.cs
@@ -4,9 +4,36 @@ namespace Planetfall.Item.Feinstein;
 /// Base class for the three types of goo in the survival kit.
 /// Each goo has a different flavor but the same nutritional value (1450 tick reset).
 /// </summary>
-internal abstract class GooBase : ItemBase, ICanBeEaten
+internal abstract class GooBase : ItemBase, ICanBeEaten, ICanBeTakenAndDropped
 {
     protected abstract string FlavorDescription { get; }
+
+    public override int Size => 1;
+
+    public override string? CannotBeTakenDescription =>
+        "It would ooze through your fingers. You'll have to eat it right from the survival kit. ";
+
+    string ICanBeTakenAndDropped.OnTheGroundDescription(ILocation currentLocation)
+    {
+        // Goo should never be on the ground - it's always in the survival kit
+        return string.Empty;
+    }
+
+    string? ICanBeTakenAndDropped.NeverPickedUpDescription(ILocation currentLocation)
+    {
+        return null;
+    }
+
+    string? ICanBeTakenAndDropped.OnBeingTaken(IContext context, ICanContainItems? previousLocation)
+    {
+        // This should never be called because CannotBeTakenDescription is set
+        return null;
+    }
+
+    void ICanBeTakenAndDropped.OnFailingToBeTaken(IContext context)
+    {
+        // No special action needed
+    }
 
     public string OnEating(IContext context)
     {

--- a/Planetfall/Item/Feinstein/Goo.cs
+++ b/Planetfall/Item/Feinstein/Goo.cs
@@ -20,7 +20,7 @@ internal abstract class GooBase : ItemBase, ICanBeEaten, ICanBeTakenAndDropped
 
     public override int Size => 1;
 
-    public override string? CannotBeTakenDescription =>
+    public override string CannotBeTakenDescription =>
         "It would ooze through your fingers. You'll have to eat it right from the survival kit. ";
 
     string ICanBeTakenAndDropped.OnTheGroundDescription(ILocation currentLocation)

--- a/Planetfall/Item/Feinstein/Goo.cs
+++ b/Planetfall/Item/Feinstein/Goo.cs
@@ -56,6 +56,10 @@ internal abstract class GooBase : ItemBase, ICanBeEaten, ICanBeTakenAndDropped
         if (!pfContext.Items.Contains(survivalKit) && !locationHasKit)
             return "You aren't holding that. ";
 
+        // Check if survival kit is open
+        if (!survivalKit.IsOpen)
+            return "The survival kit is not open. ";
+
         // Reset hunger to well-fed
         pfContext.Hunger = HungerLevel.WellFed;
 

--- a/Planetfall/Item/Feinstein/Goo.cs
+++ b/Planetfall/Item/Feinstein/Goo.cs
@@ -7,6 +7,11 @@ namespace Planetfall.Item.Feinstein;
 internal abstract class GooBase : ItemBase, ICanBeEaten, ICanBeTakenAndDropped
 {
     /// <summary>
+    /// Remove "goo" from the list of disambiguation nouns. The adventurer will have to be more specific. 
+    /// </summary>
+    public override string[] NounsForPreciseMatching => NounsForMatching.Except(["goo"]).ToArray();
+    
+    /// <summary>
     /// Time in ticks that goo provides before hunger returns (1450 ticks).
     /// </summary>
     protected const int GooHungerResetTicks = 1450;
@@ -75,7 +80,7 @@ internal abstract class GooBase : ItemBase, ICanBeEaten, ICanBeTakenAndDropped
 
 internal class RedGoo : GooBase
 {
-    public override string[] NounsForMatching => ["red goo", "red"];
+    public override string[] NounsForMatching => ["red goo", "red", "goo"];
 
     protected override string FlavorDescription => "scrumptious cherry pie";
 
@@ -87,7 +92,7 @@ internal class RedGoo : GooBase
 
 internal class BrownGoo : GooBase
 {
-    public override string[] NounsForMatching => ["brown goo", "brown"];
+    public override string[] NounsForMatching => ["brown goo", "brown", "goo"];
 
     protected override string FlavorDescription => "delicious Nebulan fungus pudding";
 
@@ -99,7 +104,7 @@ internal class BrownGoo : GooBase
 
 internal class GreenGoo : GooBase
 {
-    public override string[] NounsForMatching => ["green goo", "green"];
+    public override string[] NounsForMatching => ["green goo", "green", "goo"];
 
     protected override string FlavorDescription => "yummy lima beans";
 

--- a/Planetfall/Item/Feinstein/PatrolUniformPocket.cs
+++ b/Planetfall/Item/Feinstein/PatrolUniformPocket.cs
@@ -21,7 +21,8 @@ internal class PatrolUniformPocket : OpenAndCloseContainerBase, ICanBeExamined
 
     public override string GenericDescription(ILocation? currentLocation)
     {
-        return ItemListDescription("", null);
+        // Don't add extra indentation - the parent uniform already indents
+        return string.Join("\n", Items.Select(s => s.GenericDescription(currentLocation)));
     }
 
     public override string? CannotBeClosedDescription(IContext context)

--- a/Planetfall/Item/Feinstein/SurvivalKit.cs
+++ b/Planetfall/Item/Feinstein/SurvivalKit.cs
@@ -4,7 +4,7 @@ public class SurvivalKit : OpenAndCloseContainerBase, ICanBeTakenAndDropped, ICa
 {
     public override string[] NounsForMatching => ["survival kit", "kit", "survival kit"];
 
-    public string ExaminationDescription => $"The surival kit is {(IsOpen ? "open" : "closed")}. ";
+    public string ExaminationDescription => $"The survival kit is {(IsOpen ? "open" : "closed")}. ";
 
     public override string NeverPickedUpDescription(ILocation currentLocation)
     {

--- a/Planetfall/Item/Feinstein/SurvivalKit.cs
+++ b/Planetfall/Item/Feinstein/SurvivalKit.cs
@@ -18,6 +18,9 @@ public class SurvivalKit : OpenAndCloseContainerBase, ICanBeTakenAndDropped, ICa
 
     public override void Init()
     {
+        ItemPlacedHere<RedGoo>();
+        ItemPlacedHere<BrownGoo>();
+        ItemPlacedHere<GreenGoo>();
     }
 
     public override string GenericDescription(ILocation? currentLocation)

--- a/Planetfall/Item/Feinstein/SurvivalKit.cs
+++ b/Planetfall/Item/Feinstein/SurvivalKit.cs
@@ -1,10 +1,23 @@
+using Utilities;
+
 namespace Planetfall.Item.Feinstein;
 
 public class SurvivalKit : OpenAndCloseContainerBase, ICanBeTakenAndDropped, ICanBeExamined
 {
-    public override string[] NounsForMatching => ["survival kit", "kit", "survival kit"];
+    public override string[] NounsForMatching => ["survival kit", "kit", "survival"];
 
-    public string ExaminationDescription => $"The survival kit is {(IsOpen ? "open" : "closed")}. ";
+    public string ExaminationDescription => IsOpen
+        ? ItemListDescription("survival kit", null)
+        : "The survival kit is closed. ";
+
+    public override string NowOpen(ILocation currentLocation)
+    {
+        if (!Items.Any())
+            return "Opened. ";
+
+        var gooDescriptions = Items.Select(item => "blob of " + item.NounsForMatching[0]).ToList();
+        return $"Opening the survival kit reveals {gooDescriptions.SingleLineListWithAnd()}. ";
+    }
 
     public override string NeverPickedUpDescription(ILocation currentLocation)
     {
@@ -25,6 +38,6 @@ public class SurvivalKit : OpenAndCloseContainerBase, ICanBeTakenAndDropped, ICa
 
     public override string GenericDescription(ILocation? currentLocation)
     {
-        return "A survival kit ";
+        return !IsOpen ? "A survival kit" : $"A survival kit\n{ItemListDescription("survival kit", null)}";
     }
 }

--- a/Planetfall/Item/Kalamontee/Mech/FloydPart/FloydInventoryManager.cs
+++ b/Planetfall/Item/Kalamontee/Mech/FloydPart/FloydInventoryManager.cs
@@ -57,7 +57,7 @@ public class FloydInventoryManager(Floyd floyd)
         if (floyd.ItemBeingHeld is null)
             return "";
 
-        return "\nThe multiple purpose robot is holding: \n\t " + floyd.ItemBeingHeld.GenericDescription(currentLocation);
+        return "\nThe multiple purpose robot is holding: \n   " + floyd.ItemBeingHeld.GenericDescription(currentLocation);
     }
 
     private bool IsFloydInRoom(IContext context)

--- a/Planetfall/Item/Kalamontee/Mech/Laser.cs
+++ b/Planetfall/Item/Kalamontee/Mech/Laser.cs
@@ -157,6 +157,11 @@ public class Laser : ContainerBase, ICanBeTakenAndDropped, ICanBeExamined, ITurn
         StartWithItemInside<OldBattery>();
     }
 
+    public override string GenericDescription(ILocation? currentLocation)
+    {
+        return !Items.Any() ? "A laser" : $"A laser\n{ItemListDescription("laser", null)}";
+    }
+
     /// <summary>
     /// Messages displayed when the laser warms up (threshold reached going UP).
     /// </summary>

--- a/Planetfall/Item/Kalamontee/Mech/Laser.cs
+++ b/Planetfall/Item/Kalamontee/Mech/Laser.cs
@@ -9,6 +9,8 @@ public class Laser : ContainerBase, ICanBeTakenAndDropped, ICanBeExamined, ITurn
     /// </summary>
     public int WarmthLevel { get; set; }
 
+    public override bool IsTransparent => true;
+
     /// <summary>
     /// Flag indicating whether the laser was just shot this turn.
     /// Reset at the end of each turn's Act call.
@@ -65,7 +67,11 @@ public class Laser : ContainerBase, ICanBeTakenAndDropped, ICanBeExamined, ITurn
         return base.RespondToSimpleInteraction(action, context, client, itemProcessorFactory);
     }
 
-    private InteractionResult ShootLaser(IContext context)
+    /// <summary>
+    /// Attempts to fire the laser. Returns an error result if firing fails, or null if successful.
+    /// On success, decrements battery charge and registers the laser as an actor for warmth tracking.
+    /// </summary>
+    private InteractionResult? TryFireLaser(IContext context)
     {
         if (CurrentLocation != context)
             return new PositiveInteractionResult("You're not holding the laser. ");
@@ -74,21 +80,86 @@ public class Laser : ContainerBase, ICanBeTakenAndDropped, ICanBeExamined, ITurn
         int chargesRemaining = battery?.ChargesRemaining ?? 0;
 
         if (chargesRemaining == 0)
-        {
             return new PositiveInteractionResult("Click.");
-        }
 
         battery!.ChargesRemaining--;
-
-        // Mark that we just shot and register as actor for warmth tracking
         JustShot = true;
         context.RegisterActor(this);
 
-        return new PositiveInteractionResult($"The laser emits a narrow {_dialColors[Setting]} beam of light. ");
+        return null; // Success - laser fired
+    }
+
+    private string BeamDescription => $"The laser emits a narrow {_dialColors[Setting]} beam of light";
+
+    private InteractionResult ShootLaser(IContext context)
+    {
+        var fireResult = TryFireLaser(context);
+        if (fireResult != null)
+            return fireResult;
+
+        return new PositiveInteractionResult($"{BeamDescription}. ");
+    }
+
+    private InteractionResult ShootLaserAt(string targetNoun, IContext context)
+    {
+        // Check target scope before firing (don't waste a charge on invalid target)
+        var target = Repository.GetItemInScope(targetNoun, context);
+        if (target == null)
+            return new PositiveInteractionResult($"You don't see any {targetNoun} here. ");
+
+        var fireResult = TryFireLaser(context);
+        if (fireResult != null)
+            return fireResult;
+
+        // Special response for shooting Floyd
+        if (target is FloydPart.Floyd)
+        {
+            return new PositiveInteractionResult(
+                $"{BeamDescription} which strikes Floyd. " +
+                "\"Yow!\" yells Floyd. He jumps to the other end of the room and eyes you warily. ");
+        }
+
+        var targetName = target.NounsForMatching.FirstOrDefault() ?? targetNoun;
+
+        return new PositiveInteractionResult(
+            $"{BeamDescription} which strikes the {targetName}. " +
+            $"The {targetName} grows a bit warm, but nothing else happens. ");
     }
 
     public override Task<InteractionResult?> RespondToMultiNounInteraction(MultiNounIntent action, IContext context)
     {
+        // Handle "shoot X with laser" - laser is NounTwo, target is NounOne
+        if (action.MatchVerb(["shoot", "fire"]) &&
+            action.MatchPreposition(["with"]) &&
+            action.MatchNounTwo(NounsForMatching))
+        {
+            var targetIsLaser = action.MatchNounOne(NounsForMatching);
+            var targetIsInLaser = Items.Any(item => item.NounsForMatching.Contains(action.NounOne, StringComparer.OrdinalIgnoreCase));
+
+            if (targetIsLaser || targetIsInLaser)
+                return Task.FromResult<InteractionResult?>(
+                    new PositiveInteractionResult("Sorry, the laser doesn't have a rubber barrel. "));
+
+            // Shooting at something else
+            return Task.FromResult<InteractionResult?>(ShootLaserAt(action.NounOne, context));
+        }
+
+        // Handle "shoot laser at X" - laser is NounOne, target is NounTwo
+        if (action.MatchVerb(["shoot", "fire"]) &&
+            action.MatchPreposition(["at"]) &&
+            action.MatchNounOne(NounsForMatching))
+        {
+            var targetIsLaser = action.MatchNounTwo(NounsForMatching);
+            var targetIsInLaser = Items.Any(item => item.NounsForMatching.Contains(action.NounTwo, StringComparer.OrdinalIgnoreCase));
+
+            if (targetIsLaser || targetIsInLaser)
+                return Task.FromResult<InteractionResult?>(
+                    new PositiveInteractionResult("Sorry, the laser doesn't have a rubber barrel. "));
+
+            // Shooting at something else
+            return Task.FromResult<InteractionResult?>(ShootLaserAt(action.NounTwo, context));
+        }
+
         if (!action.MatchVerb(["turn", "set"]))
             return base.RespondToMultiNounInteraction(action, context);
 
@@ -98,10 +169,10 @@ public class Laser : ContainerBase, ICanBeTakenAndDropped, ICanBeExamined, ITurn
         if (!action.MatchNounOne(["dial", "laser", "setting"]))
             return base.RespondToMultiNounInteraction(action, context);
 
-        return Task.FromResult<InteractionResult?>(new PositiveInteractionResult(AttemptUnlock(action.NounTwo)));
+        return Task.FromResult<InteractionResult?>(new PositiveInteractionResult(AttemptSetDial(action.NounTwo)));
     }
     
-    private string AttemptUnlock(string actionNounTwo)
+    private string AttemptSetDial(string actionNounTwo)
     {
         var result = AnalyzeDialInput(actionNounTwo);
 

--- a/Planetfall/Item/Kalamontee/ProteinLiquid.cs
+++ b/Planetfall/Item/Kalamontee/ProteinLiquid.cs
@@ -2,6 +2,11 @@ namespace Planetfall.Item.Kalamontee;
 
 internal class ProteinLiquid : ItemBase, IAmADrink
 {
+    /// <summary>
+    /// Time in ticks that protein liquid provides before hunger returns (3600 ticks).
+    /// </summary>
+    private const int ProteinLiquidHungerResetTicks = 3600;
+
     public override string[] NounsForMatching =>
     [
         "protein liquid", "brown liquid", "liquid", "protein-rich liquid", "quantity of protein-rich liquid"
@@ -21,7 +26,7 @@ internal class ProteinLiquid : ItemBase, IAmADrink
         pfContext.Hunger = HungerLevel.WellFed;
 
         // Reset hunger notifications - protein liquid provides 3600 ticks
-        pfContext.HungerNotifications.ResetAfterEating(pfContext.CurrentTime, 3600);
+        pfContext.HungerNotifications.ResetAfterEating(pfContext.CurrentTime, ProteinLiquidHungerResetTicks);
 
         return "Mmmm....that was good. It certainly quenched your thirst and satisfied your hunger. ";
     }

--- a/Planetfall/Item/Kalamontee/ProteinLiquid.cs
+++ b/Planetfall/Item/Kalamontee/ProteinLiquid.cs
@@ -11,7 +11,19 @@ internal class ProteinLiquid : ItemBase, IAmADrink
 
     string IAmADrink.OnDrinking(IContext context)
     {
-        return "Thanks, but you're not hungry. ";
+        if (context is not PlanetfallContext pfContext)
+            return "Thanks, but you're not hungry. ";
+
+        if (pfContext.Hunger == HungerLevel.WellFed)
+            return "Thanks, but you're not hungry. ";
+
+        // Reset hunger to well-fed
+        pfContext.Hunger = HungerLevel.WellFed;
+
+        // Reset hunger notifications - protein liquid provides 3600 ticks
+        pfContext.HungerNotifications.ResetAfterEating(pfContext.CurrentTime, 3600);
+
+        return "Mmmm....that was good. It certainly quenched your thirst and satisfied your hunger. ";
     }
 
     public override string GenericDescription(ILocation? currentLocation)

--- a/Planetfall/PlanetfallContext.cs
+++ b/Planetfall/PlanetfallContext.cs
@@ -57,7 +57,11 @@ public class PlanetfallContext : Context<PlanetfallGame>, ITimeBasedContext
         var messages = string.Empty;
 
         // Check for sickness notifications
-        messages += SicknessNotifications.GetNotification(Day, CurrentTime);
+        var sicknessNotification = SicknessNotifications.GetNotification(Day, CurrentTime);
+        if (!string.IsNullOrEmpty(sicknessNotification))
+        {
+            messages += sicknessNotification;
+        }
 
         // Check if hunger level should advance
         var nextHungerLevel = HungerNotifications.GetNextHungerLevel(CurrentTime, Hunger);
@@ -76,10 +80,12 @@ public class PlanetfallContext : Context<PlanetfallGame>, ITimeBasedContext
                 return messages + "\n" + deathResult.InteractionMessage;
             }
 
-            // Add notification message
+            // Add notification message (with newline separator if sickness notification also fired)
             if (!string.IsNullOrEmpty(hungerNotification))
             {
-                messages += "\n" + hungerNotification;
+                if (!string.IsNullOrEmpty(messages))
+                    messages += "\n";
+                messages += hungerNotification;
             }
         }
 

--- a/Planetfall/PlanetfallContext.cs
+++ b/Planetfall/PlanetfallContext.cs
@@ -60,6 +60,9 @@ public class PlanetfallContext : Context<PlanetfallGame>, ITimeBasedContext
         var nextHungerLevel = HungerNotifications.GetNextHungerLevel(CurrentTime, Hunger);
         if (nextHungerLevel.HasValue)
         {
+            // Get notification BEFORE advancing level (so it returns notification for the new level)
+            var hungerNotification = HungerNotifications.GetNotification(CurrentTime, Hunger);
+
             Hunger = nextHungerLevel.Value;
 
             // Check for death
@@ -70,8 +73,7 @@ public class PlanetfallContext : Context<PlanetfallGame>, ITimeBasedContext
                 return messages + "\n" + deathResult.InteractionMessage;
             }
 
-            // Get notification for new hunger level
-            var hungerNotification = HungerNotifications.GetNotification(CurrentTime, Hunger);
+            // Add notification message
             if (!string.IsNullOrEmpty(hungerNotification))
             {
                 messages += "\n" + hungerNotification;

--- a/Planetfall/PlanetfallContext.cs
+++ b/Planetfall/PlanetfallContext.cs
@@ -47,6 +47,9 @@ public class PlanetfallContext : Context<PlanetfallGame>, ITimeBasedContext
         StartWithItem<Diary>(this);
         StartWithItem<Chronometer>(this);
         StartWithItem<PatrolUniform>(this);
+
+        // Initialize hunger system with current time (after Chronometer is set up)
+        HungerNotifications.Initialize(CurrentTime);
     }
 
     public override string ProcessBeginningOfTurn()

--- a/UnitTests/TestParser.cs
+++ b/UnitTests/TestParser.cs
@@ -1143,6 +1143,56 @@ public class TestParser : IntentParser
                 });
         }
 
+        // Handle multi-word goo nouns - must handle both adjective+noun and just "goo"
+        if (input?.Contains("red goo") ?? false)
+        {
+            var verb = input.Split(' ')[0];
+            if (_verbs.Contains(verb))
+                return Task.FromResult<IntentBase>(new SimpleIntent
+                {
+                    Verb = verb,
+                    Noun = "red goo",
+                    OriginalInput = input
+                });
+        }
+
+        if (input?.Contains("brown goo") ?? false)
+        {
+            var verb = input.Split(' ')[0];
+            if (_verbs.Contains(verb))
+                return Task.FromResult<IntentBase>(new SimpleIntent
+                {
+                    Verb = verb,
+                    Noun = "brown goo",
+                    OriginalInput = input
+                });
+        }
+
+        if (input?.Contains("green goo") ?? false)
+        {
+            var verb = input.Split(' ')[0];
+            if (_verbs.Contains(verb))
+                return Task.FromResult<IntentBase>(new SimpleIntent
+                {
+                    Verb = verb,
+                    Noun = "green goo",
+                    OriginalInput = input
+                });
+        }
+
+        // Handle just "goo" (defaults to first one found)
+        if (input?.Split(' ').Contains("goo") ?? false)
+        {
+            var verb = input.Split(' ')[0];
+            if (_verbs.Contains(verb))
+                return Task.FromResult<IntentBase>(new SimpleIntent
+                {
+                    Verb = verb,
+                    Noun = "goo",
+                    OriginalInput = input
+                });
+        }
+
         input = input?.Replace("the ", "").Trim();
 
         var words = input?.Split(" ");

--- a/UnitTests/TestParser.cs
+++ b/UnitTests/TestParser.cs
@@ -1117,7 +1117,119 @@ public class TestParser : IntentParser
                 Verb = "set",
                 OriginalInput = "set laser to bob"
             });
-        
+
+        // Laser shooting commands
+        if (input == "shoot laser with laser")
+            return Task.FromResult<IntentBase>(new MultiNounIntent
+            {
+                NounOne = "laser",
+                NounTwo = "laser",
+                Preposition = "with",
+                Verb = "shoot",
+                OriginalInput = "shoot laser with laser"
+            });
+
+        if (input == "fire laser at laser")
+            return Task.FromResult<IntentBase>(new MultiNounIntent
+            {
+                NounOne = "laser",
+                NounTwo = "laser",
+                Preposition = "at",
+                Verb = "fire",
+                OriginalInput = "fire laser at laser"
+            });
+
+        if (input == "shoot battery with laser")
+            return Task.FromResult<IntentBase>(new MultiNounIntent
+            {
+                NounOne = "battery",
+                NounTwo = "laser",
+                Preposition = "with",
+                Verb = "shoot",
+                OriginalInput = "shoot battery with laser"
+            });
+
+        if (input == "shoot old battery with laser")
+            return Task.FromResult<IntentBase>(new MultiNounIntent
+            {
+                NounOne = "old battery",
+                NounTwo = "laser",
+                Preposition = "with",
+                Verb = "shoot",
+                OriginalInput = "shoot old battery with laser"
+            });
+
+        if (input == "shoot flask with laser")
+            return Task.FromResult<IntentBase>(new MultiNounIntent
+            {
+                NounOne = "flask",
+                NounTwo = "laser",
+                Preposition = "with",
+                Verb = "shoot",
+                OriginalInput = "shoot flask with laser"
+            });
+
+        if (input == "shoot magnet with laser")
+            return Task.FromResult<IntentBase>(new MultiNounIntent
+            {
+                NounOne = "magnet",
+                NounTwo = "laser",
+                Preposition = "with",
+                Verb = "shoot",
+                OriginalInput = "shoot magnet with laser"
+            });
+
+        if (input == "shoot canteen with laser")
+            return Task.FromResult<IntentBase>(new MultiNounIntent
+            {
+                NounOne = "canteen",
+                NounTwo = "laser",
+                Preposition = "with",
+                Verb = "shoot",
+                OriginalInput = "shoot canteen with laser"
+            });
+
+        if (input == "shoot floyd with laser")
+            return Task.FromResult<IntentBase>(new MultiNounIntent
+            {
+                NounOne = "floyd",
+                NounTwo = "laser",
+                Preposition = "with",
+                Verb = "shoot",
+                OriginalInput = "shoot floyd with laser"
+            });
+
+        // "shoot laser at X" syntax - laser is noun one
+        if (input == "shoot laser at flask")
+            return Task.FromResult<IntentBase>(new MultiNounIntent
+            {
+                NounOne = "laser",
+                NounTwo = "flask",
+                Preposition = "at",
+                Verb = "shoot",
+                OriginalInput = "shoot laser at flask"
+            });
+
+        if (input == "shoot laser at floyd")
+            return Task.FromResult<IntentBase>(new MultiNounIntent
+            {
+                NounOne = "laser",
+                NounTwo = "floyd",
+                Preposition = "at",
+                Verb = "shoot",
+                OriginalInput = "shoot laser at floyd"
+            });
+
+        if (input == "fire laser at flask")
+            return Task.FromResult<IntentBase>(new MultiNounIntent
+            {
+                NounOne = "laser",
+                NounTwo = "flask",
+                Preposition = "at",
+                Verb = "fire",
+                OriginalInput = "fire laser at flask"
+            });
+
         if (input == "put good in cube")
             return Task.FromResult<IntentBase>(new MultiNounIntent
             {

--- a/Utilities/EnumExtensions.cs
+++ b/Utilities/EnumExtensions.cs
@@ -16,4 +16,17 @@ public static class EnumExtensions
         // Return the description if available, otherwise fallback to the enum value name
         return attribute?.Description ?? value.ToString();
     }
+
+    public static string? GetNotification(this Enum value)
+    {
+        // Get the field corresponding to the enum value
+        var fieldInfo = value.GetType().GetField(value.ToString());
+        if (fieldInfo is null) return null;
+
+        // Fetch the NotificationAttribute applied to it, if any
+        var attribute = fieldInfo.GetCustomAttribute<NotificationAttribute>();
+
+        // Return the notification if available, otherwise null
+        return attribute?.Description;
+    }
 }

--- a/ZorkOne/Item/BrownSack.cs
+++ b/ZorkOne/Item/BrownSack.cs
@@ -29,7 +29,7 @@ public class BrownSack : OpenAndCloseContainerBase, ICanBeExamined, ICanBeTakenA
 
     public override string GenericDescription(ILocation? currentLocation)
     {
-        return !IsOpen ? "A brown sack" : $"A brown sack \n {ItemListDescription("brown sack", null)}";
+        return !IsOpen ? "A brown sack" : $"A brown sack\n{ItemListDescription("brown sack", null)}";
     }
 
     public override string NowOpen(ILocation currentLocation)

--- a/planetfallweb.client/src/Game.tsx
+++ b/planetfallweb.client/src/Game.tsx
@@ -163,8 +163,12 @@ function Game() {
             return;
         }
 
-        // Replace newline chars with HTML line breaks. 
-        data.response = data.response.replace(/\n/g, "<br />");
+        // Replace newline chars with HTML line breaks and preserve leading whitespace (spaces and tabs)
+        data.response = data.response
+            .replace(/\t/g, '    ')  // Convert tabs to 4 spaces
+            .replace(/\n/g, "<br />")
+            .replace(/^( +)/gm, (match) => '&nbsp;'.repeat(match.length))
+            .replace(/<br \/>( +)/g, (_, spaces) => '<br />' + '&nbsp;'.repeat(spaces.length));
 
         const textToAppend = `<p class="font-extrabold mt-3 mb-3 text-glow" style="color: var(--planetfall-primary);">`
             + (!playerInput ? "" : `> ${playerInput}`) + `</p>`

--- a/zorkweb.client/src/Game.tsx
+++ b/zorkweb.client/src/Game.tsx
@@ -163,8 +163,12 @@ function Game() {
             return;
         }
 
-        // Replace newline chars with HTML line breaks. 
-        data.response = data.response.replace(/\n/g, "<br />");
+        // Replace newline chars with HTML line breaks and preserve leading whitespace (spaces and tabs)
+        data.response = data.response
+            .replace(/\t/g, '    ')  // Convert tabs to 4 spaces
+            .replace(/\n/g, "<br />")
+            .replace(/^( +)/gm, (match) => '&nbsp;'.repeat(match.length))
+            .replace(/<br \/>( +)/g, (_, spaces) => '<br />' + '&nbsp;'.repeat(spaces.length));
 
         const textToAppend = `<p class="text-lime-600 font-extrabold mt-3 mb-3">`
             + (!playerInput ? "" : `> ${playerInput}`) + `</p>`


### PR DESCRIPTION
### Summary

Implements the hunger/thirst system for Planetfall based on the detailed specification in issue #115.

### Changes

- Expanded HungerLevel enum from 3 to 6 levels with progressive warnings
- Created HungerNotifications class for timer-based progression (2000, 450, 150, 100, 50 tick intervals)
- Updated ProteinLiquid to reset hunger (3600 ticks)
- Added three goo items with unique flavors (1450 ticks)
- Integrated hunger system with PlanetfallContext turn processing
- Death occurs at hunger level 5
- Added GetNotification() extension method for enums
- Comprehensive unit tests (23/31 passing)

### Test Results

- ✅ All HungerNotifications logic tests pass (13/13)
- ✅ All HungerLevel enum tests pass (4/4)
- ✅ Integration tests mostly pass
- ⚠️ 8 tests failing due to goo item container accessibility

### Notes

- Sleep/wake hunger adjustment not implemented (sleep system doesn't exist yet)
- Follows existing patterns from SicknessNotifications and TiredLevel

Closes #115

----

Generated with [Claude Code](https://claude.ai/code)