### PR TITLE
Fix Blather conversation routing

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -5,7 +5,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 # ZorkAI - Text Adventure Game Engine with AI Integration
 
 ## Project Overview
-This is a sophisticated C# .NET 8.0 recreation of classic Infocom-style text adventure games (like Zork) with modern AI integration. The engine can run multiple games including Zork I and Planetfall.
+This is a sophisticated C# .NET 10.0 recreation of classic Infocom-style text adventure games (like Zork) with modern AI integration. The engine can run multiple games including Zork I and Planetfall.
 
 ## Essential Development Commands
 
@@ -15,7 +15,7 @@ This is a sophisticated C# .NET 8.0 recreation of classic Infocom-style text adv
 - **Run tests for specific project**: `dotnet test UnitTests` or `dotnet test ZorkOne.Tests`
 - **Run specific test class**: `dotnet test --filter "TestClass=ContextTests"`
 - **Run specific test**: `dotnet test --filter "BlatherTests.ThePlayer_TriesToBlather_BlatherIsAlive"`
-- **Check .NET version**: `dotnet --version` (requires .NET 8.0+)
+- **Check .NET version**: `dotnet --version` (requires .NET 10.0+)
 
 ### Test Projects Structure
 - **UnitTests**: Core engine tests (667+ comprehensive tests)
@@ -168,6 +168,21 @@ This project exemplifies **thoughtful AI integration** - using AI to enhance rat
 The codebase demonstrates production-level C# development with proper dependency injection, logging, monitoring, and testing practices while maintaining the essential character of classic text adventures.
 
 ## AWS Lambda Integration & Deployment
+
+### AWS Account & Credentials (IMPORTANT)
+All ZorkAI AWS infrastructure lives in a **dedicated AWS account (`576431164672`, "Delve")** in region `us-east-1`. This includes:
+- `ZorkStack-AspNetCoreFunction-*` (Zork One Lambda)
+- `PlanetfallStack-AspNetCoreFunction-*` (Planetfall Lambda)
+- `Floyd-LangGraphFunction-...-MySimpleLambda-*` (the Floyd/companion LangGraph lambda invoked by `ChatLambda/`)
+- `planetfall-hints-*`, `ZorkReleaseNotes`
+
+**The machine's default `~/.aws` credentials point at a DIFFERENT account and do not contain these resources.** The Lambda invocation code (`ChatLambda/ChatWithCompanion.cs`, `ChatLambda/ParseConversation.cs`) calls Floyd by its bare function name, which resolves to whatever account the active credentials belong to. Running under the wrong (default) account therefore fails with:
+`Function not found: arn:aws:lambda:us-east-1:<wrong-account>:function:Floyd-...`
+This is an account/credentials problem, **not** a wrong function name — the hardcoded Floyd function name is correct.
+
+Note: the **deployed** lambdas run *inside* the Delve account, so production is unaffected — the bare function name resolves to the correct (in-account) Floyd. The mismatch only bites when running locally (e.g. the `[Explicit]` integration tests in `IntegrationTests/ChatWithFloydTests.cs`), where the SDK falls back to the machine's default credential chain.
+
+A named `delve` AWS profile is configured in `~/.aws/credentials` / `~/.aws/config` (alongside, and without disturbing, `[default]`). The `IntegrationTests` project selects it automatically via `IntegrationTests/AwsProfileSetup.cs` (an assembly-wide NUnit `[SetUpFixture]` that sets `AWS_PROFILE=delve`), so the AWS-touching tests just run — in Rider or `dotnet test` — with no extra configuration. Verify the account with `aws sts get-caller-identity --profile delve` (expect `576431164672`).
 
 ### Lambda Project Structure (`Lambda/src/Lambda/`)
 - **ZorkOneController.cs**: RESTful API endpoints for game interaction

--- a/GameEngine/ConversationHandler.cs
+++ b/GameEngine/ConversationHandler.cs
@@ -119,17 +119,71 @@ public class ConversationHandler(
         var parseResult = await parseConversation.ParseAsync(input);
         logger?.LogDebug($"[CONVERSATION DEBUG] ParseConversation result - isConversational: {parseResult.isConversational}, response: '{parseResult.response}'");
 
-        // If not conversational, continue with normal processing
-        if (!parseResult.isConversational)
+        string textForCharacter;
+        if (parseResult.isConversational)
+        {
+            // The rewriter recognized a command/speech directed at the character; use its
+            // second-person rewrite (e.g. "floyd, go north" -> "go north").
+            textForCharacter = parseResult.response;
+        }
+        else if (TryStripDirectAddress(input, targetCharacter, out var remainder))
+        {
+            // The player explicitly addressed the character by name (e.g. "blather, ...").
+            // That is an unambiguous signal of conversation even when the rewriter doesn't
+            // recognize a command, so route what they said (minus the leading name) to the
+            // character rather than dropping it back into normal command parsing.
+            logger?.LogDebug($"[CONVERSATION DEBUG] Direct address detected; using remainder: '{remainder}'");
+            textForCharacter = remainder;
+        }
+        else
         {
             logger?.LogDebug("[CONVERSATION DEBUG] Not conversational, continuing with normal processing");
             return null;
         }
 
-        // Send the rewritten message to the character
-        logger?.LogDebug($"[CONVERSATION DEBUG] Sending rewritten message '{parseResult.response}' to character");
-        var result = await targetCharacter.OnBeingTalkedTo(parseResult.response, context, generationClient);
+        logger?.LogDebug($"[CONVERSATION DEBUG] Sending message '{textForCharacter}' to character");
+        var result = await targetCharacter.OnBeingTalkedTo(textForCharacter, context, generationClient);
         logger?.LogDebug($"[CONVERSATION DEBUG] Character response: '{result}'");
         return result;
+    }
+
+    /// <summary>
+    /// Detects the vocative "Name, ..." direct-address pattern (e.g. "blather, you clean the
+    /// floor") and returns the text that follows the name. This is a strong, deterministic
+    /// signal that the player is speaking to the character, independent of the AI rewriter,
+    /// which only reliably recognizes imperative commands.
+    /// </summary>
+    private static bool TryStripDirectAddress(string input, ICanBeTalkedTo targetCharacter, out string remainder)
+    {
+        remainder = input;
+
+        if (targetCharacter is not IItem item)
+            return false;
+
+        var trimmed = input.TrimStart();
+
+        // Prefer the longest matching noun so "ensign blather" wins over "blather".
+        foreach (var noun in item.NounsForMatching.OrderByDescending(n => n.Length))
+        {
+            if (!trimmed.StartsWith(noun, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            var rest = trimmed[noun.Length..];
+
+            // Require the name to be followed by a comma (or to be the whole input) so we
+            // only catch genuine direct address and never hijack a real command.
+            if (!rest.StartsWith(',') && rest.Trim().Length != 0)
+                continue;
+
+            remainder = rest.TrimStart(',', ' ', '.', '!', '?').Trim();
+
+            // "blather" / "blather," on its own: pass the whole utterance through.
+            if (string.IsNullOrWhiteSpace(remainder))
+                remainder = input.Trim();
+
+            return true;
+        }
+
+        return false;
     }
 }

--- a/IntegrationTests/BlatherConversationRoutingTests.cs
+++ b/IntegrationTests/BlatherConversationRoutingTests.cs
@@ -1,0 +1,59 @@
+using ChatLambda;
+using GameEngine;
+using Model.AIGeneration;
+using Model.Interface;
+using Moq;
+using Planetfall;
+using Planetfall.Item.Feinstein;
+using Planetfall.Location.Feinstein;
+
+namespace IntegrationTests;
+
+/// <summary>
+/// Reproduces the production bug where talking to Ensign Blather does not work.
+///
+/// All talkable characters are gated through <see cref="IParseConversation.ParseAsync"/>
+/// (the Floyd lambda's "RewriteSecondPerson" assistant). For input like
+/// "blather, you clean the floor" that classifier returns "no" (it only recognizes
+/// imperative commands), so <see cref="ConversationHandler.CheckForConversation"/> drops
+/// the input and it never reaches Blather. We force that exact condition with a mocked
+/// classifier and assert the player's directly-addressed input still reaches Blather.
+/// </summary>
+[TestFixture]
+[Explicit]
+public class BlatherConversationRoutingTests
+{
+    [Test]
+    public async Task TalkingToBlatherByName_WhenClassifierDoesNotRecognizeACommand_StillReachesBlather()
+    {
+        Repository.Reset();
+
+        var context = new PlanetfallContext();
+        var lobby = Repository.GetLocation<ReactorLobby>();
+        context.CurrentLocation = lobby;
+
+        var blather = Repository.GetItem<Blather>();
+        lobby.ItemPlacedHere(blather);
+
+        // Reproduce production: RewriteSecondPerson returns "no" for "blather, you clean the
+        // floor" => the handler currently considers it "not conversational".
+        var parseConversation = new Mock<IParseConversation>();
+        parseConversation
+            .Setup(x => x.ParseAsync(It.IsAny<string>()))
+            .ReturnsAsync((false, ""));
+
+        var generationClient = new Mock<IGenerationClient>();
+        generationClient.SetupGet(x => x.IsDisabled).Returns(false);
+
+        var handler = new ConversationHandler(null, parseConversation.Object, generationClient.Object);
+
+        var result = await handler.CheckForConversation("blather, you clean the floor", context);
+
+        // Before the fix: null (the input is dropped and never reaches Blather).
+        // After the fix: Blather responds in character via the ChatWithBlather lambda.
+        result.Should().NotBeNull(
+            "input that directly addresses Blather by name must reach him even when the " +
+            "second-person rewriter doesn't recognize a command");
+        result.Should().Contain("Blather");
+    }
+}

--- a/IntegrationTests/ChatWithBlatherTests.cs
+++ b/IntegrationTests/ChatWithBlatherTests.cs
@@ -1,0 +1,84 @@
+using ChatLambda;
+
+namespace IntegrationTests;
+
+[TestFixture]
+[Explicit]
+[Parallelizable(ParallelScope.Children)]
+public class ChatWithBlatherTests
+{
+    private static IEnumerable<string> TestPhrases()
+    {
+        yield return "blather, I've finished scrubbing the floor, sir";
+        yield return "blather, why do you hate me so much?";
+        yield return "blather, can I please have a promotion?";
+        yield return "blather, bkjff3f3f";
+        yield return "blather, the ship is going to explode!";
+        yield return "blather, you have a speck of dust on your uniform";
+        yield return "blather, where are all the other officers?";
+        yield return "blather, I'm sorry sir, it won't happen again";
+    }
+
+    [Test]
+    [TestCaseSource(nameof(TestPhrases))]
+    public async Task ChatWithBlather(string phrase)
+    {
+        var target = new ChatWithBlather(null);
+        var result = await target.AskBlatherAsync(phrase);
+
+        Console.WriteLine($"Phrase: \"{phrase}\"");
+        Console.WriteLine($"Response: {result.Message}");
+
+        if (result.Metadata != null)
+        {
+            Console.WriteLine($"Assistant Type: {result.Metadata.AssistantType}");
+            if (result.Metadata.Parameters != null)
+            {
+                foreach (var param in result.Metadata.Parameters)
+                {
+                    Console.WriteLine($"  {param.Key}: {param.Value}");
+                }
+            }
+        }
+
+        Console.WriteLine(new string('-', 50));
+    }
+
+    [Test]
+    public async Task BlatherGivesDemerits()
+    {
+        var target = new ChatWithBlather(null);
+        var result = await target.AskBlatherAsync("blather, I refuse to do any more push-ups");
+        Console.WriteLine(result.Message);
+        if (result.Metadata != null)
+        {
+            Console.WriteLine($"Assistant Type: {result.Metadata.AssistantType}");
+            if (result.Metadata.Parameters != null)
+            {
+                foreach (var param in result.Metadata.Parameters)
+                {
+                    Console.WriteLine($"  {param.Key}: {param.Value}");
+                }
+            }
+        }
+    }
+
+    [Test]
+    public async Task BlatherInspectsTheFloor()
+    {
+        var target = new ChatWithBlather(null);
+        var result = await target.AskBlatherAsync("blather, come inspect the floor I just polished");
+        Console.WriteLine(result.Message);
+        if (result.Metadata != null)
+        {
+            Console.WriteLine($"Assistant Type: {result.Metadata.AssistantType}");
+            if (result.Metadata.Parameters != null)
+            {
+                foreach (var param in result.Metadata.Parameters)
+                {
+                    Console.WriteLine($"  {param.Key}: {param.Value}");
+                }
+            }
+        }
+    }
+}

--- a/IntegrationTests/IntegrationTestSetup.cs
+++ b/IntegrationTests/IntegrationTestSetup.cs
@@ -1,0 +1,26 @@
+using NUnit.Framework;
+
+// No namespace == applies to the entire IntegrationTests assembly, once, before any test.
+// Centralizes the local secrets these [Explicit] integration tests need, so individual
+// fixtures don't each have to (and currently don't reliably) locate them:
+//   - AWS_PROFILE=delve  -> all ZorkAI infra (Floyd lambda, ZorkStack, DynamoDb) lives in
+//     the "delve" account; without this the SDK falls back to the wrong default account.
+//   - ~/Dropbox/env      -> OPEN_AI_KEY and other API keys, loaded into the environment.
+[SetUpFixture]
+public class IntegrationTestSetup
+{
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        Environment.SetEnvironmentVariable("AWS_PROFILE", "delve");
+
+        var envFile = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+            "Dropbox", "env");
+
+        if (File.Exists(envFile))
+            Env.Load(envFile);
+        else
+            TestContext.Progress.WriteLine($"Warning: secrets file not found at {envFile}");
+    }
+}


### PR DESCRIPTION
## Problem

Talking to Ensign Blather in Planetfall doesn't work. Input like `blather, you clean the floor` never reaches Blather — the player gets a generic AI-narrator response instead of Blather replying in character.

## Root cause

Every `ICanBeTalkedTo` character is gated through `ParseConversation.ParseAsync` → the Floyd lambda's **`RewriteSecondPerson`** assistant. That classifier only reliably recognizes **imperative commands** addressed to a companion (it's tuned for Floyd, e.g. `floyd, go north` → `go north`). For non-imperative input it returns `"no"`:

| Input | `RewriteSecondPerson` | Routed to character? |
|---|---|---|
| `floyd, go north` | `Go north.` | ✅ |
| `tell blather to clean the floor` | `Clean the floor.` | ✅ |
| `blather, you clean the floor` | `no` | ❌ dropped |

When it returns `"no"`, `ConversationHandler` returned `null`, the command fell through to normal parsing, and `OnBeingTalkedTo` (the `ChatWithBlather` lambda) was never called.

## Fix

`ConversationHandler.ProcessConversation` now also recognizes the vocative **`Name, ...`** direct-address pattern. When the player addresses a talkable character by name, the text after the name is routed to `OnBeingTalkedTo` even if the rewriter didn't recognize a command.

- The existing rewrite path is unchanged (`floyd, go north` → `go north`).
- The new path is conservative — it requires a comma after the name (or the bare name), so it can't hijack real commands like `examine blather`.
- As a bonus, this also fixes declarative/gibberish input addressed to Floyd, which had the same drop-through.

## Tests (IntegrationTests, `[Explicit]`)

- **`BlatherConversationRoutingTests`** — reproduces the bug (red before the fix: `CheckForConversation` returns null) and verifies directly-addressed input reaches Blather after the fix.
- **`ChatWithBlatherTests`** — exercises the `ChatWithBlather` lambda directly, mirroring `ChatWithFloydTests`.
- **`IntegrationTestSetup`** — assembly-wide `[SetUpFixture]` that selects the AWS profile and loads local API keys, so the AWS-touching integration tests run with no per-run configuration.

Full non-explicit suites pass: 2180 Planetfall + 813 unit tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)