### PR TITLE
Fix SentenceSplitter merging "no" answer with following command

### DIFF
--- a/GameEngine/SentenceSplitter.cs
+++ b/GameEngine/SentenceSplitter.cs
@@ -10,7 +10,8 @@ public static class SentenceSplitter
 {
     private static readonly HashSet<string> CommonAbbreviations = new()
     {
-        "mr", "mrs", "ms", "dr", "prof", "sr", "jr", "st", "vs", "etc", "no", "corp", "inc"
+        // "no" omitted: it is a common standalone yes/no answer, not an abbreviation in game input.
+        "mr", "mrs", "ms", "dr", "prof", "sr", "jr", "st", "vs", "etc", "corp", "inc"
     };
 
     /// <summary>

--- a/UnitTests/SentenceSplitterTests.cs
+++ b/UnitTests/SentenceSplitterTests.cs
@@ -274,4 +274,16 @@ public class SentenceSplitterTests
         result[1].Should().Be("turn it on");
         result[2].Should().Be("go north");
     }
+
+    [Test]
+    public void Split_NoAnswerFollowedByCommand_SplitsCorrectly()
+    {
+        // "no" is a standalone answer (e.g. to a yes/no prompt), not an abbreviation,
+        // so it must split rather than merge with the following command.
+        var result = SentenceSplitter.Split("no. take lamp");
+
+        result.Should().HaveCount(2);
+        result[0].Should().Be("no");
+        result[1].Should().Be("take lamp");
+    }
 }


### PR DESCRIPTION
## Bug

`GameEngine/SentenceSplitter.cs:13` — `"no"` was included in `CommonAbbreviations`.

The abbreviation-merge loop treats the last word of a part as an abbreviation and merges it with the next part. Because `"no"` was in the set, input like `"no. take lamp"` was merged into the single command `"no. take lamp"` instead of splitting into `["no", "take lamp"]`.

In this adventure-game context, `"no"` is a common standalone yes/no answer (e.g. responding to the quit confirmation prompt in `QuitProcessor.cs`), never an abbreviation. Real abbreviations like `Mr.`, `Dr.`, `etc.` legitimately appear mid-sentence; `"no"` does not.

## Trace (input `"no. take lamp"`)

- `parts = ["no", " take lamp"]`
- i=0: `lastWord = "no"` → in `CommonAbbreviations` → merges: `parts[1] = "no. take lamp"`
- Result before fix: `["no. take lamp"]` (wrong) — after fix: `["no", "take lamp"]` (correct)

## Fix

Remove `"no"` from `CommonAbbreviations` (one-line change + explanatory comment). All existing documented XML-doc examples and existing tests are unaffected.

## Red → Green proof

New deterministic test `Split_NoAnswerFollowedByCommand_SplitsCorrectly` in `UnitTests/SentenceSplitterTests.cs`:
- Before fix: FAILED — expected count 2, found 1 (the merged command).
- After fix: PASSED.

## Regression

- `UnitTests`: 814 passed, 1 skipped (pre-existing skip).
- `Planetfall.Tests`: 2180 passed.
- `ZorkOne.Tests`: 1 pre-existing failure (`InventoryCapacityTests`) unrelated to this change — confirmed it fails identically with this fix stashed out; it lives in a separate untracked file owned by another change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)