### PR TITLE
Fix: off lamp in a container wrongly counts as a light source

### DIFF
--- a/GameEngine/Context.cs
+++ b/GameEngine/Context.cs
@@ -151,7 +151,10 @@ public abstract class Context<T> : IContext where T : IInfocomGame, new()
                 .Any(container =>
                     container is IOpenAndClose { IsOpen: true } or ContainerBase { IsTransparent: true } &&
                     container.Items.Any(s =>
-                        s is IAmALightSource or IAmALightSourceThatTurnsOnAndOff { IsOn: true }));
+                        // A toggleable lamp only lights the room when it's on; constant sources always do.
+                        // (IAmALightSourceThatTurnsOnAndOff derives from IAmALightSource, so exclude an off one.)
+                        s is IAmALightSourceThatTurnsOnAndOff { IsOn: true } ||
+                        s is IAmALightSource and not IAmALightSourceThatTurnsOnAndOff));
 
             return constantLightSources ||
                    lightSourcesThatAreInMyPossession ||

--- a/UnitTests/HasLightSourceContainerTests.cs
+++ b/UnitTests/HasLightSourceContainerTests.cs
@@ -1,0 +1,71 @@
+using GameEngine;
+using Model.Interface;
+using ZorkOne.Item;
+using ZorkOne.Location;
+
+namespace UnitTests;
+
+/// <summary>
+///     Tests for <see cref="Context{T}.HasLightSource" /> covering light sources that live
+///     inside a container in the room (the "shaft basket" puzzle scenario).
+/// </summary>
+public class HasLightSourceContainerTests : EngineTestsBase
+{
+    [Test]
+    public void OffLampInTransparentContainerInRoom_IsNotALightSource()
+    {
+        var engine = GetTarget();
+
+        // Dark room as the current location.
+        var cellar = Repository.GetLocation<Cellar>();
+        engine.Context.CurrentLocation = cellar;
+
+        // A transparent container in the room.
+        var basket = Repository.GetItem<Basket>();
+        cellar.ItemPlacedHere(basket);
+
+        // A toggleable lamp inside the container, turned OFF.
+        var lantern = Repository.GetItem<Lantern>();
+        lantern.IsOn = false;
+        basket.ItemPlacedHere(lantern);
+
+        // An OFF lamp provides no light, even inside an open/transparent container.
+        engine.Context.HasLightSource.Should().BeFalse();
+    }
+
+    [Test]
+    public void OnLampInTransparentContainerInRoom_IsALightSource()
+    {
+        var engine = GetTarget();
+
+        var cellar = Repository.GetLocation<Cellar>();
+        engine.Context.CurrentLocation = cellar;
+
+        var basket = Repository.GetItem<Basket>();
+        cellar.ItemPlacedHere(basket);
+
+        var lantern = Repository.GetItem<Lantern>();
+        lantern.IsOn = true;
+        basket.ItemPlacedHere(lantern);
+
+        engine.Context.HasLightSource.Should().BeTrue();
+    }
+
+    [Test]
+    public void ConstantLightSourceInTransparentContainerInRoom_IsALightSource()
+    {
+        var engine = GetTarget();
+
+        var cellar = Repository.GetLocation<Cellar>();
+        engine.Context.CurrentLocation = cellar;
+
+        var basket = Repository.GetItem<Basket>();
+        cellar.ItemPlacedHere(basket);
+
+        // The torch is a constant light source (ICannotBeTurnedOff) - the actual shaft puzzle item.
+        var torch = Repository.GetItem<Torch>();
+        basket.ItemPlacedHere(torch);
+
+        engine.Context.HasLightSource.Should().BeTrue();
+    }
+}


### PR DESCRIPTION
## Bug

`GameEngine/Context.cs:154` — in `HasLightSource`, the "light source inside a container in the room" branch matched:

```csharp
s is IAmALightSource or IAmALightSourceThatTurnsOnAndOff { IsOn: true }
```

Because `IAmALightSourceThatTurnsOnAndOff : IAmALightSource` (see `Model/Item/IAmALightSourceThatTurnsOnAndOff.cs`), the first pattern `s is IAmALightSource` **also** matches a toggleable lamp that is turned **OFF**. So a switched-off lamp sitting in an open (or transparent) container in a dark room wrongly counted as an active light source.

The direct-in-room branch (`Context.cs:144`) correctly requires `IAmALightSourceThatTurnsOnAndOff { IsOn: true }`; the container branch did not.

## Fix

One-line change: a toggleable source only counts when `IsOn`; constant (non-toggleable) sources still always count.

```csharp
s is IAmALightSourceThatTurnsOnAndOff { IsOn: true } ||
s is IAmALightSource and not IAmALightSourceThatTurnsOnAndOff
```

This preserves the Zork I "shaft basket" puzzle (the constant `Torch` placed in the transparent `Basket` still provides light).

## Proof (red → green)

New test `UnitTests/HasLightSourceContainerTests.cs`:
- `OffLampInTransparentContainerInRoom_IsNotALightSource` — **FAILED before** (`Expected ... to be False, but found True`), **passes after**.
- `OnLampInTransparentContainerInRoom_IsALightSource` — on lamp still counts.
- `ConstantLightSourceInTransparentContainerInRoom_IsALightSource` — constant `Torch` still counts (shaft puzzle).

## Regression (each suite run separately)

- `UnitTests`: 816 passed, 1 skipped, 0 failed
- `ZorkOne.Tests`: 1161 passed, 0 failed (with only this change applied)
- `Planetfall.Tests`: 2180 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)