### PR TITLE
Block multi-noun interactions on items inside a closed container

### DIFF
--- a/GameEngine/Item/OpenAndCloseContainerBase.cs
+++ b/GameEngine/Item/OpenAndCloseContainerBase.cs
@@ -62,6 +62,16 @@ public abstract class OpenAndCloseContainerBase : ContainerBase, IOpenAndClose
         return await ApplyProcessors(action, context, null, client, itemProcessorFactory);
     }
 
+    public override async Task<InteractionResult?> RespondToMultiNounInteraction(MultiNounIntent action,
+        IContext context)
+    {
+        // A closed, non-transparent container hides its contents from multi-noun interactions, just like simple ones.
+        if (!IsOpen && !IsTransparent)
+            return new NoNounMatchInteractionResult();
+
+        return await base.RespondToMultiNounInteraction(action, context);
+    }
+
     public override (bool HasItem, IItem? TheItem) HasMatchingNoun(string? noun, bool lookInsideContainers = true)
     {
         // If open or transparent, search inside

--- a/UnitTests/ClosedContainerMultiNounTests.cs
+++ b/UnitTests/ClosedContainerMultiNounTests.cs
@@ -1,0 +1,91 @@
+using GameEngine;
+using GameEngine.Item;
+using Model.AIGeneration;
+using Model.Intent;
+using Model.Interaction;
+using Model.Interface;
+using Model.Item;
+
+namespace UnitTests;
+
+/// <summary>
+/// Verifies that a closed (and non-transparent) openable container does not leak its
+/// contents to multi-noun interactions. A closed container already blocks simple
+/// interactions and noun matching against its contents; multi-noun interactions must
+/// behave the same way.
+/// </summary>
+public class ClosedContainerMultiNounTests : EngineTestsBase
+{
+    /// <summary>An item inside the container that always reacts to a multi-noun interaction.</summary>
+    private class WidgetInsideContainer : ItemBase
+    {
+        public override string[] NounsForMatching => ["widget"];
+
+        public override Task<InteractionResult?> RespondToMultiNounInteraction(MultiNounIntent action, IContext context)
+        {
+            return Task.FromResult<InteractionResult?>(
+                new PositiveInteractionResult("You poke the widget. "));
+        }
+    }
+
+    /// <summary>A minimal openable, non-transparent container holding the widget.</summary>
+    private class TestBox : OpenAndCloseContainerBase
+    {
+        public override string[] NounsForMatching => ["box"];
+
+        public override void Init()
+        {
+        }
+    }
+
+    [Test]
+    public async Task ClosedContainer_DoesNotRespondToMultiNounInteractionOnItemInside()
+    {
+        Repository.Reset();
+        var context = GetTarget().Context;
+
+        var box = new TestBox();
+        var widget = new WidgetInsideContainer();
+        box.ItemPlacedHere(widget);
+        box.IsOpen = false;
+
+        var intent = new MultiNounIntent
+        {
+            Verb = "poke",
+            NounOne = "widget",
+            NounTwo = "stick",
+            Preposition = "with",
+            OriginalInput = "poke widget with stick"
+        };
+
+        var result = await box.RespondToMultiNounInteraction(intent, context);
+
+        // The box is closed and not transparent, so the widget inside is inaccessible.
+        result?.InteractionHappened.Should().NotBe(true);
+    }
+
+    [Test]
+    public async Task OpenContainer_StillRespondsToMultiNounInteractionOnItemInside()
+    {
+        Repository.Reset();
+        var context = GetTarget().Context;
+
+        var box = new TestBox();
+        var widget = new WidgetInsideContainer();
+        box.ItemPlacedHere(widget);
+        box.IsOpen = true;
+
+        var intent = new MultiNounIntent
+        {
+            Verb = "poke",
+            NounOne = "widget",
+            NounTwo = "stick",
+            Preposition = "with",
+            OriginalInput = "poke widget with stick"
+        };
+
+        var result = await box.RespondToMultiNounInteraction(intent, context);
+
+        result?.InteractionHappened.Should().BeTrue();
+    }
+}


### PR DESCRIPTION
## Bug

`GameEngine/Item/OpenAndCloseContainerBase.cs` — a closed, non-transparent openable container leaked its contents to multi-noun interactions.

`OpenAndCloseContainerBase` gates inner-item access behind `IsOpen || IsTransparent` in both `RespondToSimpleInteraction` (line 42) and `HasMatchingNoun` (line 68). But it did **not** override `RespondToMultiNounInteraction`, so it inherited `ContainerBase.RespondToMultiNounInteraction` (`ContainerBase.cs:197-209`), which iterates `Items` **unconditionally** — regardless of open/closed/transparent state.

### Reachable scenario
`MultiNounEngine.Process` (`MultiNounEngine.cs:45-51`) calls `RespondToMultiNounInteraction` on every item on the ground. A closed `Egg` (which starts closed in the bird's nest, holding a `Canary`) would let the canary inside respond to multi-noun commands even though the egg is shut — inconsistent with simple interactions, which are correctly blocked.

## Fix

Override `RespondToMultiNounInteraction` in `OpenAndCloseContainerBase`: when the container is closed and not transparent, return `NoNounMatchInteractionResult` instead of recursing into its contents — mirroring the existing simple-interaction logic. One-line guard plus a comment.

## Proof (red → green)

New test `UnitTests/ClosedContainerMultiNounTests.cs` (minimal test-only `OpenAndCloseContainerBase` + an inner item that responds to multi-noun interactions):
- `ClosedContainer_DoesNotRespondToMultiNounInteractionOnItemInside` — FAILED before the fix (closed container responded), PASSES after.
- `OpenContainer_StillRespondsToMultiNounInteractionOnItemInside` — passes before and after (no regression to open-container behavior).

## Regression suites (run separately)

- `dotnet test UnitTests` — Passed: 816, Skipped: 1
- `dotnet test ZorkOne.Tests` — Passed: 1161
- `dotnet test Planetfall.Tests` — Passed: 2180

🤖 Generated with [Claude Code](https://claude.com/claude-code)