### PR TITLE
Fix ClickableText dropping first character of a word at start of text node

### DIFF
--- a/shared-web-types/src/components/ClickableText.tsx
+++ b/shared-web-types/src/components/ClickableText.tsx
@@ -118,7 +118,12 @@ const ClickableText = forwardRef<HTMLDivElement & ClickableTextHandle, Clickable
                 ) {
                 clonedRange.setStart(node, clonedRange.startOffset - 1);
             }
-            clonedRange.setStart(node, clonedRange.startOffset + 1);
+            // Only step past the leading space when the loop actually stopped ON one.
+            // If it stopped because we hit the start of the text node (offset 0), the
+            // first character IS part of the word and stepping forward would drop it.
+            if (clonedRange.toString().indexOf(" ") === 0) {
+                clonedRange.setStart(node, clonedRange.startOffset + 1);
+            }
 
             // Find ending point
             // Keep extending until we find a space or reach the end of the text

--- a/zorkweb.client/src/__tests__/ClickableText.test.tsx
+++ b/zorkweb.client/src/__tests__/ClickableText.test.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { ClickableText } from '@zork-ai/shared-types';
+
+// Helper: place a collapsed caret at `offset` inside the first text node of the
+// rendered clickable div, then click it (handleClick reads window.getSelection()).
+function clickAtOffset(container: HTMLElement, offset: number) {
+    const div = container.querySelector('.clickable') as HTMLElement;
+    const textNode = div.firstChild as Node;
+
+    const range = document.createRange();
+    range.setStart(textNode, offset);
+    range.setEnd(textNode, offset);
+
+    const selection = window.getSelection()!;
+    selection.removeAllRanges();
+    selection.addRange(range);
+
+    fireEvent.click(div);
+    return div;
+}
+
+describe('ClickableText word selection', () => {
+    it('returns the whole first word when it starts the text node (no leading space)', () => {
+        const onWordClick = jest.fn();
+        const { container } = render(
+            <ClickableText exits={[]} onWordClick={onWordClick}>
+                {'north of house'}
+            </ClickableText>
+        );
+
+        // Caret inside "north" (offset 2 = between 'o' and 'r').
+        clickAtOffset(container, 2);
+
+        expect(onWordClick).toHaveBeenCalledWith('north');
+    });
+
+    it('returns the whole word for a word in the middle of the text node', () => {
+        const onWordClick = jest.fn();
+        const { container } = render(
+            <ClickableText exits={[]} onWordClick={onWordClick}>
+                {'north of house'}
+            </ClickableText>
+        );
+
+        // Caret inside "house" (text "north of house"; 'house' starts at index 9).
+        clickAtOffset(container, 11);
+
+        expect(onWordClick).toHaveBeenCalledWith('house');
+    });
+});


### PR DESCRIPTION
## The bug

`ClickableText.handleClick` (in `shared-web-types`) figures out which word was clicked by walking the selection range's start offset backward until it finds a leading space or reaches the start of the text node, then stepping the start forward by one to skip that space.

The forward step was **unconditional**. When the clicked word starts the text node (offset 0, no preceding space), the loop stops at offset 0 — but the code still stepped forward to offset 1, dropping the word's first character. Clicking **north** in `"north of house"` returned **orth**.

`shared-web-types/src/components/ClickableText.tsx:114`

## The fix

Only step the start forward when the loop actually stopped *on* a space:

```ts
if (clonedRange.toString().indexOf(" ") === 0) {
    clonedRange.setStart(node, clonedRange.startOffset + 1);
}
```

Behavior is unchanged for words in the middle of a text node (the loop still stops on the preceding space and skips it).

## Proof (red → green)

Added `zorkweb.client/src/__tests__/ClickableText.test.tsx` with two cases driving a real jsdom selection:
- **first word of the text node** — failed before the fix (`Expected "north", Received "orth"`), passes after.
- **middle word** — passes before and after (guards against regressing the working path).

## Test runs (no regressions)
- `zorkweb.client`: 92 passed (90 baseline + 2 new)
- `planetfallweb.client`: 84 passed (also consumes the shared component)

🤖 Generated with [Claude Code](https://claude.com/claude-code)