### PR TITLE
Fix #23: accept American 'scepter' spelling for the sceptre

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -7,6 +7,55 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Project Overview
 This is a sophisticated C# .NET 10.0 recreation of classic Infocom-style text adventure games (like Zork) with modern AI integration. The engine can run multiple games including Zork I and Planetfall.
 
+## Original Zork I Source (`zork1/`) — Reference Only
+
+The original Infocom Zork I source (the `historicalsource/zork1` repository, written in ZIL) is
+cloned locally into `zork1/` at the repo root. It is **gitignored** and is **not** part of this
+project — it is a local reference checkout only.
+
+**Permitted use — verification:** Read the ZIL to establish the *intended* original behavior so you
+can confirm a suspected bug or detect where this C# port has **unintentionally diverged** from the
+original game. The ZIL is ground truth for facts like object synonyms/adjectives (`SYNONYM`,
+`ADJECTIVE`), treasure scoring (`VALUE`/`TVALUE`), flags, sizes, room exits, and what an action
+routine is supposed to do. Quote a specific `file:line` from `zork1/` as evidence in commits/PRs
+when a fix restores original behavior (see PR for issue #23).
+
+**Forbidden use — copying/reproducing:** Never copy, paste, transliterate, or mechanically port ZIL
+code, routines, structures, or large/verbatim text passages into this codebase. Do not "reproduce"
+the original implementation. Use it strictly to *understand and confirm* correct behavior, then write
+original C# that fits this engine's existing patterns. When in doubt, treat the ZIL as read-only
+documentation of intended behavior, not as source to be transcribed.
+
+## Bug Fixes Require TDD (Mandatory)
+
+**Every bug fix MUST follow test-driven development. No exceptions.** A "fix" without a test that
+fails before it and passes after it is not done.
+
+The required order is:
+
+1. **Reproduce first.** Understand the bug and identify the exact wrong behavior, the correct
+   behavior, and a concrete reproducing input. For behavioral questions about Zork I, confirm the
+   intended behavior against the original ZIL (see "Original Zork I Source" above).
+2. **Write a failing test (red).** Add a deterministic test next to related tests, matching the
+   surrounding file's style and framework. Run *just that test* and confirm it fails **for the right
+   reason** — read the assertion diff, not merely a non-zero exit. A test that errors on setup has
+   not proven the bug.
+3. **Make the minimal fix (green).** Change only what is needed to correct the behavior, preserving
+   everything that already worked. Add a brief comment explaining the trap so it is not reintroduced.
+4. **Verify, no regressions.** Re-run the new test (green), then run every suite that exercises the
+   changed code (run each project separately — `dotnet test A B` errors with MSB1008).
+
+Rules:
+- The proving test must run in the component's **normal** test command — never `[Explicit]`,
+  integration-only, or cloud/credential-gated.
+- Tests must be **deterministic**: no real randomness, clock, network, filesystem, AWS, or AI. Use
+  real `Repository` objects with `Repository.Reset()` and mock `IRandomChooser` (see "Randomness
+  Pattern"); stub the equivalent seams in the web clients.
+- Put the test in the most appropriate **existing** test class rather than creating a new one when a
+  natural home exists.
+- This applies to *all* bug fixes anywhere in the repo — C# engine/games, the React/TypeScript web
+  clients, and the Lambda APIs — not just the game engine.
+
 ## Essential Development Commands
 
 ### Building and Testing

--- a/ZorkOne.Tests/Things/SceptreTests.cs
+++ b/ZorkOne.Tests/Things/SceptreTests.cs
@@ -100,4 +100,61 @@ public class SceptreTests : EngineTestsBase
         response.Should().Contain("Bye");
         target.Context.DeathCounter.Should().Be(1);
     }
+
+    // Issue #23: the original Zork I source accepts both the British "sceptre" and the
+    // American "scepter" spelling: (SYNONYM SCEPTRE SCEPTER TREASURE). The port had dropped
+    // the American spelling, so "scepter" did not match the item at all.
+    [Test]
+    public void Sceptre_RecognizesBothSpellings()
+    {
+        GetTarget();
+        var sceptre = Repository.GetItem<Sceptre>();
+
+        sceptre.HasMatchingNoun("sceptre").HasItem.Should().BeTrue();
+        sceptre.HasMatchingNoun("scepter").HasItem.Should().BeTrue();
+        sceptre.HasMatchingNoun("ornamental sceptre").HasItem.Should().BeTrue();
+        sceptre.HasMatchingNoun("ornamental scepter").HasItem.Should().BeTrue();
+    }
+
+    [TestCase("sceptre")]
+    [TestCase("scepter")]
+    public async Task PutSceptreInCase_FromInventory_GoesIntoCase(string noun)
+    {
+        var target = GetTarget();
+        target.Context.CurrentLocation = Repository.GetLocation<LivingRoom>();
+        await target.GetResponse("open case");
+
+        var sceptre = Repository.GetItem<Sceptre>();
+        target.Context.Take(sceptre);
+
+        var response = await target.GetResponse($"put {noun} in case");
+
+        response.Should().Contain("Done");
+        sceptre.CurrentLocation.Should().Be(Repository.GetItem<TrophyCase>());
+    }
+
+    [TestCase("sceptre")]
+    [TestCase("scepter")]
+    public async Task PutSceptreInCase_WhenAlreadyInCase_ResolvesToSceptre(string noun)
+    {
+        var target = GetTarget();
+        target.Context.CurrentLocation = Repository.GetLocation<LivingRoom>();
+        await target.GetResponse("open case");
+
+        var sceptre = Repository.GetItem<Sceptre>();
+        var trophyCase = Repository.GetItem<TrophyCase>();
+
+        // Put it in the case first (using the canonical spelling).
+        target.Context.Take(sceptre);
+        await target.GetResponse("put sceptre in case");
+        sceptre.CurrentLocation.Should().Be(trophyCase);
+
+        // Now ask again with the spelling under test. It must resolve to the sceptre
+        // (which is already in the case) rather than silently no-op or mis-resolve to
+        // the case itself.
+        var response = await target.GetResponse($"put {noun} in case");
+
+        response.Should().Contain("sceptre");
+        sceptre.CurrentLocation.Should().Be(trophyCase);
+    }
 }

--- a/ZorkOne/Item/Sceptre.cs
+++ b/ZorkOne/Item/Sceptre.cs
@@ -8,7 +8,10 @@ namespace ZorkOne.Item;
 public class Sceptre : ItemBase, ICanBeTakenAndDropped, IGivePointsWhenPlacedInTrophyCase,
     IGivePointsWhenFirstPickedUp, IAmPointyAndPunctureThings
 {
-    public override string[] NounsForMatching => ["sceptre", "ornamental sceptre"];
+    // The original Zork I source accepts both spellings: (SYNONYM SCEPTRE SCEPTER TREASURE).
+    // Keep the American "scepter" so players can refer to the item either way.
+    public override string[] NounsForMatching =>
+        ["sceptre", "scepter", "ornamental sceptre", "ornamental scepter"];
 
     public string OnTheGroundDescription(ILocation currentLocation)
     {


### PR DESCRIPTION
Closes #23.

## Diagnosis
The reporter referred to the item as **scepter** (American spelling). The C# port only declared:

```csharp
public override string[] NounsForMatching => ["sceptre", "ornamental sceptre"];
```

so `"scepter"` matched **nothing**. Two consequences:
- The parser's recognized-noun list is reflected from every item's `NounsForMatching` (`Repository.GetNouns`), so `"scepter"` wasn't even a known noun.
- Noun resolution (`HasMatchingNoun`) never resolved `"scepter"` to the sceptre, so `put scepter in case` could not act on the item.

## Ground truth — the original Zork I source
The bundled original Infocom source declares both spellings:

```
<OBJECT SCEPTRE
	(SYNONYM SCEPTRE SCEPTER TREASURE)
	...
```

This is an unintentional divergence from the original game: the American synonym was dropped in the port.

## Fix
Restore the American spelling (and the adjective-qualified variant):

```csharp
public override string[] NounsForMatching =>
    ["sceptre", "scepter", "ornamental sceptre", "ornamental scepter"];
```

(`TREASURE` is intentionally not added — it is a generic synonym shared by every treasure and would create disambiguation noise; this change is scoped to the spelling bug in #23.)

## Proof (red → green)
Added to `ZorkOne.Tests/Things/SceptreTests.cs`:
- `Sceptre_RecognizesBothSpellings` — direct `HasMatchingNoun` check for both spellings.
- `PutSceptreInCase_FromInventory_GoesIntoCase` `[TestCase("sceptre")]` / `[TestCase("scepter")]` — end-to-end `put … in case` puts the item in the case.
- `PutSceptreInCase_WhenAlreadyInCase_ResolvesToSceptre` `[TestCase("sceptre")]` / `[TestCase("scepter")]` — the exact scenario from the issue: with the sceptre already in the case, both spellings resolve to the sceptre instead of no-op'ing.

Before the fix, every `"scepter"` case failed (e.g. `HasMatchingNoun("scepter")` was `False`); the `"sceptre"` cases passed. After the fix, all pass.

## Test runs (no regressions)
- `ZorkOne.Tests`: 1166 passed
- `UnitTests`: 820 passed (1 pre-existing skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)