### PR TITLE
Fix #35: vampire bat carries player off to random BAT-DROPS room

### DIFF
--- a/ZorkOne.Tests/Places/BatRoomTests.cs
+++ b/ZorkOne.Tests/Places/BatRoomTests.cs
@@ -1,0 +1,143 @@
+using FluentAssertions;
+using GameEngine;
+using Model.Interface;
+using Model.Location;
+using Moq;
+using ZorkOne.Item;
+using ZorkOne.Location;
+using ZorkOne.Location.CoalMineLocation;
+
+namespace ZorkOne.Tests.Places;
+
+[TestFixture]
+public class BatRoomTests : EngineTestsBase
+{
+    private static IEnumerable<TestCaseData> AllBatDropRooms()
+    {
+        yield return new TestCaseData((Func<ILocation>)(() => Repository.GetLocation<CoalMineOne>())).SetName("{m}(CoalMineOne)");
+        yield return new TestCaseData((Func<ILocation>)(() => Repository.GetLocation<CoalMineTwo>())).SetName("{m}(CoalMineTwo)");
+        yield return new TestCaseData((Func<ILocation>)(() => Repository.GetLocation<CoalMineThree>())).SetName("{m}(CoalMineThree)");
+        yield return new TestCaseData((Func<ILocation>)(() => Repository.GetLocation<CoalMineFour>())).SetName("{m}(CoalMineFour)");
+        yield return new TestCaseData((Func<ILocation>)(() => Repository.GetLocation<LadderTop>())).SetName("{m}(LadderTop)");
+        yield return new TestCaseData((Func<ILocation>)(() => Repository.GetLocation<LadderBottom>())).SetName("{m}(LadderBottom)");
+        yield return new TestCaseData((Func<ILocation>)(() => Repository.GetLocation<SqueakyRoom>())).SetName("{m}(SqueakyRoom)");
+        yield return new TestCaseData((Func<ILocation>)(() => Repository.GetLocation<MineEntrance>())).SetName("{m}(MineEntrance)");
+    }
+
+    [TestCaseSource(nameof(AllBatDropRooms))]
+    public async Task EnterFromTheEastWithoutGarlic_CarriesPlayerOffToTheChosenRoom(Func<ILocation> getExpectedRoom)
+    {
+        var target = GetTarget();
+        target.Context.Take(Repository.GetItem<Lantern>());
+        Repository.GetItem<Lantern>().IsOn = true;
+        target.Context.CurrentLocation = Repository.GetLocation<ShaftRoom>();
+
+        var expectedRoom = getExpectedRoom();
+        var mockChooser = new Mock<IRandomChooser>();
+        mockChooser.Setup(r => r.Choose(It.IsAny<List<ILocation>>())).Returns(expectedRoom);
+        Repository.GetLocation<BatRoom>().Chooser = mockChooser.Object;
+
+        // Act - enter the Bat Room from the east (the Shaft Room)
+        var response = await target.GetResponse("west");
+        Console.WriteLine(response);
+
+        // Assert
+        response.Should().Contain("Fweep!");
+        response.Should().Contain("The bat grabs you by the scruff of your neck and lifts you away....");
+        target.Context.CurrentLocation.Should().Be(expectedRoom);
+    }
+
+    [Test]
+    public async Task EnterFromTheSouthWithoutGarlic_CarriesPlayerOff()
+    {
+        var target = GetTarget();
+        target.Context.Take(Repository.GetItem<Lantern>());
+        Repository.GetItem<Lantern>().IsOn = true;
+        target.Context.CurrentLocation = Repository.GetLocation<SqueakyRoom>();
+
+        var mockChooser = new Mock<IRandomChooser>();
+        mockChooser.Setup(r => r.Choose(It.IsAny<List<ILocation>>()))
+            .Returns(Repository.GetLocation<MineEntrance>());
+        Repository.GetLocation<BatRoom>().Chooser = mockChooser.Object;
+
+        // Act - enter the Bat Room from the south (the Squeaky Room)
+        var response = await target.GetResponse("north");
+        Console.WriteLine(response);
+
+        // Assert
+        response.Should().Contain("Fweep!");
+        target.Context.CurrentLocation.Should().Be(Repository.GetLocation<MineEntrance>());
+    }
+
+    [Test]
+    public async Task EnterWithGarlicInInventory_IsSafe()
+    {
+        var target = GetTarget();
+        target.Context.Take(Repository.GetItem<Lantern>());
+        Repository.GetItem<Lantern>().IsOn = true;
+        target.Context.Take(Repository.GetItem<Garlic>());
+        target.Context.CurrentLocation = Repository.GetLocation<ShaftRoom>();
+
+        var response = await target.GetResponse("west");
+        Console.WriteLine(response);
+
+        response.Should().NotContain("Fweep!");
+        response.Should().Contain("deranged and holding his nose");
+        target.Context.CurrentLocation.Should().Be(Repository.GetLocation<BatRoom>());
+    }
+
+    [Test]
+    public async Task GarlicLooseOnTheBatRoomFloor_IsSafe()
+    {
+        var target = GetTarget();
+        target.Context.Take(Repository.GetItem<Lantern>());
+        Repository.GetItem<Lantern>().IsOn = true;
+        Repository.GetLocation<BatRoom>().ItemPlacedHere(Repository.GetItem<Garlic>());
+        target.Context.CurrentLocation = Repository.GetLocation<ShaftRoom>();
+
+        var response = await target.GetResponse("west");
+        Console.WriteLine(response);
+
+        response.Should().NotContain("Fweep!");
+        response.Should().Contain("deranged and holding his nose");
+        target.Context.CurrentLocation.Should().Be(Repository.GetLocation<BatRoom>());
+    }
+
+    [Test]
+    public async Task TakingTheBatWithoutGarlic_CarriesPlayerOff()
+    {
+        var target = GetTarget();
+        target.Context.Take(Repository.GetItem<Lantern>());
+        Repository.GetItem<Lantern>().IsOn = true;
+        target.Context.CurrentLocation = Repository.GetLocation<BatRoom>();
+
+        var mockChooser = new Mock<IRandomChooser>();
+        mockChooser.Setup(r => r.Choose(It.IsAny<List<ILocation>>()))
+            .Returns(Repository.GetLocation<MineEntrance>());
+        Repository.GetLocation<BatRoom>().Chooser = mockChooser.Object;
+
+        var response = await target.GetResponse("take bat");
+        Console.WriteLine(response);
+
+        response.Should().Contain("Fweep!");
+        response.Should().Contain("The bat grabs you by the scruff of your neck and lifts you away....");
+        target.Context.CurrentLocation.Should().Be(Repository.GetLocation<MineEntrance>());
+    }
+
+    [Test]
+    public async Task TakingTheBatWithGarlic_CannotReachIt()
+    {
+        var target = GetTarget();
+        target.Context.Take(Repository.GetItem<Lantern>());
+        Repository.GetItem<Lantern>().IsOn = true;
+        target.Context.Take(Repository.GetItem<Garlic>());
+        target.Context.CurrentLocation = Repository.GetLocation<BatRoom>();
+
+        var response = await target.GetResponse("take bat");
+        Console.WriteLine(response);
+
+        response.Should().Contain("You can't reach him; he's on the ceiling.");
+        response.Should().NotContain("Fweep!");
+        target.Context.CurrentLocation.Should().Be(Repository.GetLocation<BatRoom>());
+    }
+}

--- a/ZorkOne/Item/Bat.cs
+++ b/ZorkOne/Item/Bat.cs
@@ -1,7 +1,11 @@
+using GameEngine;
 using GameEngine.Item;
+using GameEngine.Location;
+using Model;
 using Model.AIGeneration;
 using Model.Intent;
 using Model.Interface;
+using ZorkOne.Location;
 
 namespace ZorkOne.Item;
 
@@ -11,6 +15,12 @@ public class Bat : ItemBase
 
     public override string CannotBeTakenDescription => "You can't reach him; he's on the ceiling. ";
 
+    /// <summary>
+    /// Provoking the bat (attacking or trying to take it) without garlic carries you off, same as
+    /// just walking into the room without it - see BatRoom.CarryPlayerOff.
+    /// </summary>
+    private static readonly string[] ProvokingVerbs =
+        Verbs.KillVerbs.Concat(["hold", "take", "pick up", "grab", "get", "acquire", "snatch"]).ToArray();
 
     public override string NeverPickedUpDescription(ILocation currentLocation)
     {
@@ -26,7 +36,22 @@ public class Bat : ItemBase
         IGenerationClient client, IItemProcessorFactory itemProcessorFactory)
     {
         if (action.MatchNoun(NounsForMatching))
+        {
+            var batRoom = Repository.GetLocation<BatRoom>();
+
+            if (context.CurrentLocation == batRoom && action.MatchVerb(ProvokingVerbs) &&
+                !batRoom.IsSafeFromBat(context))
+            {
+                var destination = batRoom.CarryPlayerOff(context);
+                var destinationDescription = context.ItIsDarkHere
+                    ? ((DarkLocation)destination).DarkDescription
+                    : destination.GetDescription(context);
+
+                return new PositiveInteractionResult($"{BatRoom.CarryOffText}\n\n{destinationDescription} ");
+            }
+
             return new PositiveInteractionResult(CannotBeTakenDescription);
+        }
 
         return await base.RespondToSimpleInteraction(action, context, client, itemProcessorFactory);
     }

--- a/ZorkOne/Location/BatRoom.cs
+++ b/ZorkOne/Location/BatRoom.cs
@@ -1,14 +1,32 @@
+using GameEngine;
 using GameEngine.Location;
 using Model.AIGeneration;
 using Model.Interface;
 using Model.Movement;
+using Newtonsoft.Json;
 using ZorkOne.Location.CoalMineLocation;
 
 namespace ZorkOne.Location;
 
 internal class BatRoom : DarkLocation
 {
+    [UsedImplicitly] [JsonIgnore]
+    public IRandomChooser Chooser { get; set; } = new RandomChooser();
+
     public override string Name => "Bat Room";
+
+    /// <summary>
+    /// The text for the bat carrying the player off is shared between entering the room without
+    /// garlic, and provoking the bat (attacking/taking it) while it's still here.
+    /// </summary>
+    internal const string CarryOffText = """
+                                          Fweep!
+                                              Fweep!
+                                              Fweep!
+                                              Fweep!
+
+                                          The bat grabs you by the scruff of your neck and lifts you away....
+                                          """;
 
     protected override Dictionary<Direction, MovementParameters> Map(IContext context)
     {
@@ -28,22 +46,49 @@ internal class BatRoom : DarkLocation
         return "You are in a small room which has doors only to the east and south. ";
     }
 
+    /// <summary>
+    /// The bat is repelled by garlic, whether it's in the adventurer's inventory or loose on the
+    /// floor of this room. Garlic stashed inside a closed container (like the sack) doesn't count -
+    /// HasItem&lt;T&gt;() is intentionally non-recursive.
+    /// </summary>
+    internal bool IsSafeFromBat(IContext context)
+    {
+        return context.HasItem<Garlic>() || HasItem<Garlic>();
+    }
+
+    /// <summary>
+    /// Picks one of the eight BAT-DROPS rooms at random and relocates the player there.
+    /// </summary>
+    internal ILocation CarryPlayerOff(IContext context)
+    {
+        var destination = Chooser.Choose(DropLocations());
+        context.CurrentLocation = destination;
+        return destination;
+    }
+
+    private List<ILocation> DropLocations()
+    {
+        return
+        [
+            GetLocation<CoalMineOne>(),
+            GetLocation<CoalMineTwo>(),
+            GetLocation<CoalMineThree>(),
+            GetLocation<CoalMineFour>(),
+            GetLocation<LadderTop>(),
+            GetLocation<LadderBottom>(),
+            GetLocation<SqueakyRoom>(),
+            GetLocation<MineEntrance>()
+        ];
+    }
+
     public override string BeforeEnterLocation(IContext context, ILocation previousLocation)
     {
-        if (!context.HasItem<Garlic>())
+        if (!IsSafeFromBat(context))
         {
-            context.CurrentLocation = GetLocation<MineEntrance>();
-            var batText = """
-                          A large vampire bat, hanging from the ceiling, swoops down at you!
-                           
-                              Fweep!
-                              Fweep!
-                              Fweep!
-                           
-                          The bat grabs you by the scruff of your neck and lifts you away....
-                          """;
-
-            return $"{batText}\n\n{context.CurrentLocation.GetDescription(context)} ";
+            // Relocate now - LookProcessor.LookAround (called next by MoveEngine.Go) will describe
+            // the drop room, so we must not also append a description here or it prints twice.
+            CarryPlayerOff(context);
+            return CarryOffText;
         }
 
         return base.BeforeEnterLocation(context, previousLocation);
@@ -54,7 +99,7 @@ internal class BatRoom : DarkLocation
     {
         var response = "";
 
-        if (context.HasItem<Garlic>())
+        if (IsSafeFromBat(context))
             response +=
                 "\nIn the corner of the room on the ceiling is a large vampire bat who is obviously deranged and holding his nose. ";
 


### PR DESCRIPTION
- The bat now drops the player in a randomly chosen room from the 8 BAT-DROPS rooms (CoalMineOne-Four, LadderTop, LadderBottom, SqueakyRoom, MineEntrance) via IRandomChooser, instead of always going to MineEntrance.
- Attacking or taking the bat without garlic while in the Bat Room now triggers the same carry-off, matching the original FLY-ME logic.
- Garlic loose on the Bat Room floor (not just in inventory) now counts as "safe" from the bat.
- Removed the duplicate room description after carry-off; the engine's normal post-move look already renders the new location.