### PR TITLE
Fix #190: moving through darkness can get you eaten by a grue

### DIFF
--- a/ZorkOne.Tests/GrueTests.cs
+++ b/ZorkOne.Tests/GrueTests.cs
@@ -1,0 +1,165 @@
+using FluentAssertions;
+using GameEngine;
+using Model.Interface;
+using Moq;
+using ZorkOne.Item;
+using ZorkOne.Location;
+using ZorkOne.Location.ForestLocation;
+
+namespace ZorkOne.Tests;
+
+/// <summary>
+///     Issue #190 — moving from one pitch-black room into another with no light source should get
+///     you eaten by a grue. The original makes a dark->dark move an 80% chance of death
+///     (zork1/gverbs.zil:2095). RoundRoom and NorthSouthPassage are adjacent dark rooms with no
+///     special entry behavior, which makes them a clean fixture for the move case.
+/// </summary>
+[TestFixture]
+public class GrueTests : EngineTestsBase
+{
+    private const string GrueDeath = "grue";
+    private const string Devoured = "devoured";
+
+    [TestFixture]
+    public class MovingThroughDarkness : GrueTests
+    {
+        [Test]
+        public async Task DarkToDark_NoLight_RollIsDeadly_GrueDevoursYou()
+        {
+            var target = GetTarget();
+            target.Context.CurrentLocation = Repository.GetLocation<RoundRoom>();
+            target.Context.Chooser = Roll(50); // <= 80 => death
+
+            var response = await target.GetResponse("north");
+
+            response.Should().Contain(GrueDeath);
+            response.Should().Contain(Devoured);
+            target.Context.DeathCounter.Should().Be(1);
+            target.Context.CurrentLocation.Should().Be(Repository.GetLocation<ForestOne>(),
+                "death reincarnates the player in the forest");
+        }
+
+        [Test]
+        public async Task DarkToDark_NoLight_RollMisses_YouStumbleThroughUnharmed()
+        {
+            var target = GetTarget();
+            target.Context.CurrentLocation = Repository.GetLocation<RoundRoom>();
+            target.Context.Chooser = Roll(81); // > 80 => survive
+
+            var response = await target.GetResponse("north");
+
+            response.Should().NotContain(Devoured);
+            target.Context.DeathCounter.Should().Be(0);
+            target.Context.CurrentLocation.Should().Be(Repository.GetLocation<NorthSouthPassage>());
+        }
+
+        // The 80% threshold from <PROB 80>: a roll of 80 is still deadly; 81 is the first safe roll.
+        [TestCase(1, true)]
+        [TestCase(80, true)]
+        [TestCase(81, false)]
+        [TestCase(100, false)]
+        public async Task DarkToDark_DeathProbabilityBoundaryIsEighty(int roll, bool shouldDie)
+        {
+            var target = GetTarget();
+            target.Context.CurrentLocation = Repository.GetLocation<RoundRoom>();
+            target.Context.Chooser = Roll(roll);
+
+            await target.GetResponse("north");
+
+            if (shouldDie)
+            {
+                target.Context.DeathCounter.Should().Be(1);
+                target.Context.CurrentLocation.Should().Be(Repository.GetLocation<ForestOne>());
+            }
+            else
+            {
+                target.Context.DeathCounter.Should().Be(0);
+                target.Context.CurrentLocation.Should().Be(Repository.GetLocation<NorthSouthPassage>());
+            }
+        }
+
+        [Test]
+        public async Task DarkToDark_WithALitLamp_TheGrueNeverGetsAChance()
+        {
+            var target = GetTarget();
+            target.Context.CurrentLocation = Repository.GetLocation<RoundRoom>();
+            var lamp = Repository.GetItem<Lantern>();
+            lamp.IsOn = true;
+            target.Context.Take(lamp);
+            var chooser = new Mock<IRandomChooser>();
+            target.Context.Chooser = chooser.Object;
+
+            await target.GetResponse("north");
+
+            target.Context.DeathCounter.Should().Be(0);
+            target.Context.CurrentLocation.Should().Be(Repository.GetLocation<NorthSouthPassage>());
+            chooser.Verify(c => c.RollDice(It.IsAny<int>()), Times.Never,
+                "with light there is no darkness, so the grue check must short-circuit before rolling");
+        }
+    }
+
+    [TestFixture]
+    public class WhenTheGrueShouldNotStrike : GrueTests
+    {
+        // Stepping from a lit room into your first dark room: you stumble in, warned but alive.
+        [Test]
+        public void FirstStepFromLightIntoDarkness_IsSafe()
+        {
+            var target = GetTarget();
+            var chooser = new Mock<IRandomChooser>();
+            target.Context.Chooser = chooser.Object;
+
+            target.Context.CurrentLocation = Repository.GetLocation<WestOfHouse>(); // lit
+            target.Context.ProcessBeginningOfTurn();
+            target.Context.CurrentLocation = Repository.GetLocation<RoundRoom>(); // moved into the dark
+            var result = target.Context.ProcessEndOfTurn();
+
+            result.Should().BeNull();
+            target.Context.DeathCounter.Should().Be(0);
+            chooser.Verify(c => c.RollDice(It.IsAny<int>()), Times.Never);
+        }
+
+        // Standing still in the dark (a non-move turn) does not move you, so no grue.
+        [Test]
+        public void StayingPutInTheDark_IsSafe()
+        {
+            var target = GetTarget();
+            var chooser = new Mock<IRandomChooser>();
+            target.Context.Chooser = chooser.Object;
+
+            target.Context.CurrentLocation = Repository.GetLocation<RoundRoom>(); // dark
+            target.Context.ProcessBeginningOfTurn();
+            // no movement this turn
+            var result = target.Context.ProcessEndOfTurn();
+
+            result.Should().BeNull();
+            target.Context.DeathCounter.Should().Be(0);
+            chooser.Verify(c => c.RollDice(It.IsAny<int>()), Times.Never);
+        }
+
+        // Escaping the dark into the light is safe: the destination must also be dark.
+        [Test]
+        public void MovingFromDarknessIntoTheLight_IsSafe()
+        {
+            var target = GetTarget();
+            var chooser = new Mock<IRandomChooser>();
+            target.Context.Chooser = chooser.Object;
+
+            target.Context.CurrentLocation = Repository.GetLocation<RoundRoom>(); // dark
+            target.Context.ProcessBeginningOfTurn();
+            target.Context.CurrentLocation = Repository.GetLocation<WestOfHouse>(); // moved into light
+            var result = target.Context.ProcessEndOfTurn();
+
+            result.Should().BeNull();
+            target.Context.DeathCounter.Should().Be(0);
+            chooser.Verify(c => c.RollDice(It.IsAny<int>()), Times.Never);
+        }
+    }
+
+    private static IRandomChooser Roll(int value)
+    {
+        var chooser = new Mock<IRandomChooser>();
+        chooser.Setup(c => c.RollDice(100)).Returns(value);
+        return chooser.Object;
+    }
+}

--- a/ZorkOne/ZorkIContext.cs
+++ b/ZorkOne/ZorkIContext.cs
@@ -1,4 +1,8 @@
 using GameEngine;
+using Model.Interface;
+using Model.Location;
+using Newtonsoft.Json;
+using ZorkOne.Command;
 
 namespace ZorkOne;
 
@@ -15,6 +19,18 @@ public class ZorkIContext : Context<ZorkI>
     ///     The Death Counter keeps track of the number of times the player character has died.
     /// </remarks>
     public int DeathCounter { get; set; }
+
+    /// <summary>
+    ///     Source of randomness for the grue. Mockable so darkness deaths are deterministic in tests.
+    /// </summary>
+    [JsonIgnore]
+    public IRandomChooser Chooser { get; set; } = new RandomChooser();
+
+    // Snapshot of where we were (and whether it was dark) at the start of the current turn,
+    // captured in ProcessBeginningOfTurn and read in ProcessEndOfTurn to detect movement
+    // through darkness. Transient (not serialized): it is re-captured every turn.
+    private ILocation? _locationAtTurnStart;
+    private bool _inDarknessAtTurnStart;
 
     /// <summary>
     ///     This flag is set once the score hits 350. The score can still go down again, if you take
@@ -62,11 +78,26 @@ public class ZorkIContext : Context<ZorkI>
         if (LightWoundCounter > 0)
             LightWoundCounter--;
 
+        // Remember where we are (and whether it's pitch black) before this turn's command runs,
+        // so ProcessEndOfTurn can tell whether we moved from one dark place into another.
+        _locationAtTurnStart = CurrentLocation;
+        _inDarknessAtTurnStart = ItIsDarkHere;
+
         return base.ProcessBeginningOfTurn();
     }
 
     public override string? ProcessEndOfTurn()
     {
+        // Grue: stumbling out of one pitch-black room into another with no light source gets you eaten.
+        // Faithful to the original, which makes a dark->dark move an 80% chance of death (zork1/gverbs.zil:2095).
+        if (_inDarknessAtTurnStart
+            && ItIsDarkHere
+            && !ReferenceEquals(CurrentLocation, _locationAtTurnStart)
+            && Chooser.RollDice(100) <= 80)
+            return new DeathProcessor()
+                .Process("Oh, no! A lurking grue slithered into the room and devoured you!", this)
+                .InteractionMessage;
+
         if (Score == 350 && !GameOver)
         {
             Repository.GetItem<TrophyCase>().ItemPlacedHere(Repository.GetItem<Map>());


### PR DESCRIPTION
Closes #190.

## The bug
Moving from one dark room to another with no light source never killed you — `GameEngine/IntentEngine/MoveEngine.cs` had a literal `// TODO: Move from a dark location to another dark location and you die.` The "It is pitch black. You are likely to be eaten by a grue." warning printed, but the grue never struck.

## Ground truth
`zork1/gverbs.zil:2095` — when the previous room was unlit **and** the current room is unlit, a move is an **80% chance** of death:

```zil
<COND (<AND <NOT .OLIT> <NOT ,LIT> <PROB 80>>
       ...
       <TELL "Oh, no! A lurking grue slithered into the " ... >
       <JIGS-UP " and devoured you!"> ...)>
```

So it's a probabilistic dark→dark move death (not 100%), which is what this implements.

## Design — no `MoveEngine` change (OCP)
`MoveEngine` is left untouched. The engine already calls `Context.ProcessBeginningOfTurn()` / `ProcessEndOfTurn()` every turn — those are the extension seams:

- `ProcessBeginningOfTurn` snapshots the current location and whether it's dark (`ItIsDarkHere`) **before** the turn's command runs.
- `ProcessEndOfTurn` checks: was I in darkness at turn start, am I still in darkness, did I actually move, and does the grue roll hit (≤80 of 100) → `DeathProcessor` (the existing Zork death/respawn).

Randomness goes through the repo's `IRandomChooser` (mockable), so the death is fully deterministic under test. The snapshot fields are transient (`[JsonIgnore]` chooser; private fields re-captured each turn).

## Tests (`ZorkOne.Tests/GrueTests.cs`) — full truth table + boundary
- dark→dark, no light, deadly roll → eaten, `DeathCounter == 1`, respawn in the forest
- dark→dark, no light, roll misses → survive, now in the destination
- **probability boundary** `[TestCase]` 1/80 → die, 81/100 → live (the `<PROB 80>` edge)
- dark→dark **with a lit lamp** → never eaten, and the chooser is `Verify`'d as never rolled (short-circuits before randomness)
- lit→dark first step → safe
- standing still in the dark (non-move turn) → safe
- dark→light (escaping into the light) → safe

Red→green was verified by temporarily disabling the grue check and watching the death/boundary tests fail for the right reason (`DeathCounter 0`, no "devoured"), then re-enabling.

## Test runs (no regressions)
- `ZorkOne.Tests`: 1176 passed (1166 + 10 new)
- `UnitTests`: 820 passed (1 pre-existing skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)