### PR TITLE
Fix matchbook to match original Zork I (issue #193)

### DIFF
--- a/UnitTests/MultiNounProcessors/LightMatchesWithTorchTests.cs
+++ b/UnitTests/MultiNounProcessors/LightMatchesWithTorchTests.cs
@@ -31,7 +31,7 @@ public class LightMatchesWithTorchTests : EngineTestsBase
         var matchbook = Take<Matchbook>();
         var torch = Take<Torch>();
         
-        matchbook.MatchesUsed = 5; // All matches used up
+        matchbook.MatchesUsed = 6; // All six matches used up
         
         engine.Context.CurrentLocation = Repository.GetLocation<LivingRoom>();
         

--- a/UnitTests/SingleNounProcessors/MatchbookTests.cs
+++ b/UnitTests/SingleNounProcessors/MatchbookTests.cs
@@ -1,0 +1,100 @@
+using GameEngine;
+using ZorkOne;
+using ZorkOne.Item;
+using ZorkOne.Location.CoalMineLocation;
+
+namespace UnitTests.SingleNounProcessors;
+
+/// <summary>
+///     Tests that the matchbook matches the original Zork I behavior: six usable matches,
+///     each lit match burns for two turns, and a match struck in a drafty room (the lower
+///     shaft / Drafty Room or the Timber Room) goes out instantly. See issue #193.
+/// </summary>
+[TestFixture]
+public class MatchbookTests : EngineTestsBase
+{
+    [Test]
+    public async Task SixthMatch_CanStillBeLit()
+    {
+        var engine = GetTarget();
+        var matchbook = Take<Matchbook>();
+        StartHere<LivingRoom>();
+
+        // Five matches already used - the sixth should still light.
+        matchbook.MatchesUsed = 5;
+
+        var result = await engine.GetResponse("light matchbook");
+
+        result.Should().Contain("One of the matches starts to burn.");
+        matchbook.IsOn.Should().BeTrue();
+        matchbook.MatchesUsed.Should().Be(6);
+    }
+
+    [Test]
+    public async Task SeventhMatch_RunsOut()
+    {
+        var engine = GetTarget();
+        var matchbook = Take<Matchbook>();
+        StartHere<LivingRoom>();
+
+        // All six matches have been used.
+        matchbook.MatchesUsed = 6;
+
+        var result = await engine.GetResponse("light matchbook");
+
+        result.Should().Contain("run out of matches");
+        matchbook.IsOn.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task LitMatch_BurnsForTwoTurns_BeforeGoingOut()
+    {
+        var engine = GetTarget();
+        var matchbook = Take<Matchbook>();
+        StartHere<LivingRoom>();
+
+        await engine.GetResponse("light matchbook");
+        matchbook.IsOn.Should().BeTrue("the match is burning on the turn it was struck");
+
+        await engine.GetResponse("wait");
+        matchbook.IsOn.Should().BeTrue("the match should still be burning one turn after being struck");
+
+        var result = await engine.GetResponse("wait");
+        matchbook.IsOn.Should().BeFalse("the match should burn out two turns after being struck");
+        result.Should().Contain("The match has gone out");
+    }
+
+    [Test]
+    public async Task LightingMatch_InDraftyRoom_GoesOutInstantly()
+    {
+        var engine = GetTarget();
+        var matchbook = Take<Matchbook>();
+        // The lantern keeps the drafty room lit so we can read the response plainly.
+        var lantern = Take<Lantern>();
+        lantern.IsOn = true;
+        engine.Context.CurrentLocation = Repository.GetLocation<DraftyRoom>();
+
+        var result = await engine.GetResponse("light matchbook");
+
+        result.Should().Contain("drafty");
+        matchbook.IsOn.Should().BeFalse();
+        // The match is still consumed even though the draft snuffs it instantly.
+        matchbook.MatchesUsed.Should().Be(1);
+    }
+
+    [Test]
+    public async Task LightingMatch_InTimberRoom_GoesOutInstantly()
+    {
+        var engine = GetTarget();
+        var matchbook = Take<Matchbook>();
+        var lantern = Take<Lantern>();
+        lantern.IsOn = true;
+        engine.Context.CurrentLocation = Repository.GetLocation<TimberRoom>();
+
+        var result = await engine.GetResponse("light matchbook");
+
+        result.Should().Contain("drafty");
+        matchbook.IsOn.Should().BeFalse();
+        matchbook.MatchesUsed.Should().Be(1);
+    }
+}

--- a/ZorkOne.Tests/Walkthrough/WalkthroughTestOne.cs
+++ b/ZorkOne.Tests/Walkthrough/WalkthroughTestOne.cs
@@ -192,10 +192,11 @@ public sealed class WalkthroughTestOne : WalkthroughTestBase
         "light candles with match",
         null,
         "candles are lit",
-        "The match has gone",
         "The flames flicker"
     )]
-    [TestCase("read book", null, "Each word of the prayer reverberates through")]
+    // The match burns for two turns (issue #193), so it goes out one turn after the candles
+    // are lit rather than on the same turn.
+    [TestCase("read book", null, "Each word of the prayer reverberates through", "The match has gone")]
     [TestCase("drop book", null, "Dropped")]
     [TestCase(
         "S",

--- a/ZorkOne/Item/Matchbook.cs
+++ b/ZorkOne/Item/Matchbook.cs
@@ -2,6 +2,7 @@
 using Model.AIGeneration;
 using Model.Intent;
 using Model.Interface;
+using ZorkOne.Location.CoalMineLocation;
 
 namespace ZorkOne.Item;
 
@@ -22,7 +23,9 @@ public class Matchbook
 
     public bool IsOn { get; set; }
 
-    public string NowOnText => "One of the matches starts to burn. ";
+    // The on-message is produced entirely by OnBeingTurnedOn so that a match struck in a
+    // drafty room can report that it went out instantly rather than that it started to burn.
+    public string NowOnText => string.Empty;
 
     public string NowOffText => "The match has gone out. ";
 
@@ -30,15 +33,30 @@ public class Matchbook
 
     public string AlreadyOnText => string.Empty;
 
+    // The matchbook holds six matches (original: MATCH-COUNT runs out after six). The count
+    // is incremented in OnBeingTurnedOn, so once six have been struck no more can be lit.
     public string CannotBeTurnedOnText =>
-        MatchesUsed == 5 ? "I'm afraid that you have run out of matches. " : "";
+        MatchesUsed >= 6 ? "I'm afraid that you have run out of matches. " : "";
 
     public string OnBeingTurnedOn(IContext context)
     {
-        TurnsRemainingLit = 1;
+        // Striking a match always consumes one, even if a draft snuffs it out instantly.
         MatchesUsed++;
+
+        // The lower shaft (the Drafty Room) and the Timber Room have a strong draft that
+        // blows the match out the moment it is struck. (Original: I-MATCH checks HERE for
+        // LOWER-SHAFT / TIMBER-ROOM in zork1/1actions.zil.)
+        if (context.CurrentLocation is DraftyRoom or TimberRoom)
+        {
+            IsOn = false;
+            context.RemoveActor(this);
+            return "This room is drafty, and the match goes out instantly. ";
+        }
+
+        // A struck match burns for two turns before going out. (Original: QUEUE I-MATCH 2.)
+        TurnsRemainingLit = 2;
         context.RegisterActor(this);
-        return "One of the matches starts to burn.";
+        return "One of the matches starts to burn. ";
     }
 
     public void OnBeingTurnedOff(IContext context)
@@ -80,9 +98,9 @@ public class Matchbook
             return string.Empty;
         }
 
-        if (TurnsRemainingLit == 1)
+        if (TurnsRemainingLit > 0)
         {
-            TurnsRemainingLit = 0;
+            TurnsRemainingLit--;
             return string.Empty;
         }
 
@@ -105,9 +123,9 @@ public class Matchbook
             return Task.FromResult<InteractionResult?>(new PositiveInteractionResult(CannotBeTurnedOnText));
         
         IsOn = true;
-        OnBeingTurnedOn(context);
-        
-        return Task.FromResult<InteractionResult?>(new PositiveInteractionResult(NowOnText));
+        var message = OnBeingTurnedOn(context);
+
+        return Task.FromResult<InteractionResult?>(new PositiveInteractionResult(message));
     }
     
     public override Task<InteractionResult?> RespondToMultiNounInteraction(MultiNounIntent action, IContext context)


### PR DESCRIPTION
Fixes #193.

The matchbook diverged from the original Zork I in three ways. This restores the original behavior, with deterministic tests per `CLAUDE.md`.

## Changes

| Behavior | Before | After (original) |
|---|---|---|
| Usable matches | 5 | **6** (original: `MATCH-COUNT` runs out after six strikes) |
| Burn duration | ~1 turn | **2 turns** (original: `QUEUE I-MATCH 2`) |
| Drafty room | provides light | **goes out instantly** (original: `I-MATCH` checks `HERE` for `LOWER-SHAFT` / `TIMBER-ROOM`) |

The "drafty rooms" are the Drafty Room (the lower shaft) and the Timber Room.

### Implementation notes
- The on-message is now produced entirely by `OnBeingTurnedOn`, so a match struck in a drafty room can report that it went out instantly rather than "starts to burn". As a side benefit this removes a pre-existing doubling of `"One of the matches starts to burn."` that came from `NowOnText` and the `OnBeingTurnedOn` return both contributing the same sentence.
- `Act` is now a countdown so the match stays lit for two turns before extinguishing.
- A struck match always consumes one match, even when the draft snuffs it instantly.

## Tests
- Added `UnitTests/SingleNounProcessors/MatchbookTests.cs`:
  - sixth match can still be lit; seventh runs out
  - a lit match burns for two turns before going out
  - lighting a match in the Drafty Room / Timber Room goes out instantly (and still consumes a match)
- Updated `LightMatchesWithTorchTests` (the old "out of matches" case used 5; now 6).
- Updated the temple/Hades candle-lighting step in `WalkthroughTestOne`: because the match now burns one turn longer, `"The match has gone out"` appears on the following turn (`read book`) instead of on the candle-lighting turn.

All of `UnitTests`, `ZorkOne.Tests` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017xm4wGjAJ6A6c6BDivZgjc)_