### PR TITLE
Fix #217: Deep Canyon description reflects dam/tide state

### DIFF
--- a/ZorkOne.Tests/Places/DeepCanyonTests.cs
+++ b/ZorkOne.Tests/Places/DeepCanyonTests.cs
@@ -43,7 +43,9 @@ public class DeepCanyonTests : EngineTestsBase
 
         var response = await target.GetResponse("look");
 
-        response.Should().NotContain("water from below");
+        // Both water variants start with "You can hear ..." — asserting on "hear" is more robust
+        // than a phrase match if the water copy ever changes but still mentions water.
+        response.Should().NotContain("hear");
     }
 
     [Test]

--- a/ZorkOne.Tests/Places/DeepCanyonTests.cs
+++ b/ZorkOne.Tests/Places/DeepCanyonTests.cs
@@ -1,0 +1,74 @@
+using FluentAssertions;
+using GameEngine;
+using ZorkOne.Item;
+using ZorkOne.Location;
+
+namespace ZorkOne.Tests.Places;
+
+[TestFixture]
+public class DeepCanyonTests : EngineTestsBase
+{
+    // The Deep Canyon water-sound line varies with two pieces of world state in the original
+    // (zork1/1actions.zil DEEP-CANYON-F, lines 1730-1745): GATES-OPEN and LOW-TIDE.
+    // GATES-OPEN <-> Dam.SluiceGatesOpen, LOW-TIDE <-> ReservoirSouth.IsDrained.
+
+    private GameEngine<ZorkI, ZorkIContext> GetLitTargetInDeepCanyon()
+    {
+        var target = GetTarget();
+        target.Context.CurrentLocation = Repository.GetLocation<DeepCanyon>();
+        target.Context.Take(Repository.GetItem<Lantern>());
+        Repository.GetItem<Lantern>().IsOn = true;
+        return target;
+    }
+
+    [Test]
+    public async Task GatesOpen_NotDrained_LoudRoaringSound()
+    {
+        var target = GetLitTargetInDeepCanyon();
+        Repository.GetLocation<Dam>().SluiceGatesOpen = true;
+        Repository.GetLocation<ReservoirSouth>().IsDrained = false;
+
+        var response = await target.GetResponse("look");
+
+        response.Should().Contain("loud roaring sound");
+        response.Should().Contain("rushing water");
+    }
+
+    [Test]
+    public async Task GatesClosed_Drained_NoWaterSound()
+    {
+        var target = GetLitTargetInDeepCanyon();
+        Repository.GetLocation<Dam>().SluiceGatesOpen = false;
+        Repository.GetLocation<ReservoirSouth>().IsDrained = true;
+
+        var response = await target.GetResponse("look");
+
+        response.Should().NotContain("water from below");
+    }
+
+    [Test]
+    public async Task GatesOpen_Drained_FlowingWater()
+    {
+        var target = GetLitTargetInDeepCanyon();
+        Repository.GetLocation<Dam>().SluiceGatesOpen = true;
+        Repository.GetLocation<ReservoirSouth>().IsDrained = true;
+
+        var response = await target.GetResponse("look");
+
+        response.Should().Contain("sound of flowing water");
+    }
+
+    [Test]
+    public async Task DefaultState_FlowingWater()
+    {
+        // Game start: gates closed, reservoir full (not drained). This is the "other" bucket,
+        // so the original (and current) behavior prints the flowing-water sentence.
+        var target = GetLitTargetInDeepCanyon();
+        Repository.GetLocation<Dam>().SluiceGatesOpen = false;
+        Repository.GetLocation<ReservoirSouth>().IsDrained = false;
+
+        var response = await target.GetResponse("look");
+
+        response.Should().Contain("sound of flowing water");
+    }
+}

--- a/ZorkOne/Location/DeepCanyon.cs
+++ b/ZorkOne/Location/DeepCanyon.cs
@@ -21,8 +21,23 @@ public class DeepCanyon : DarkLocation
 
     protected override string GetContextBasedDescription(IContext context)
     {
-        return "You are on the south edge of a deep canyon. Passages lead off to the east, " +
-               "northwest and southwest. A stairway leads down. You can hear the sound of flowing water from below.";
+        // The water-sound line varies with two pieces of world state, mirroring the original
+        // (zork1/1actions.zil DEEP-CANYON-F, lines 1730-1745): whether the dam's sluice gates are
+        // open (GATES-OPEN) and whether the reservoir has drained to low tide (LOW-TIDE).
+        const string baseText =
+            "You are on the south edge of a deep canyon. Passages lead off to the east, " +
+            "northwest and southwest. A stairway leads down.";
+
+        var gatesOpen = GetLocation<Dam>().SluiceGatesOpen;          // ZIL GATES-OPEN
+        var lowTide = GetLocation<ReservoirSouth>().IsDrained;       // ZIL LOW-TIDE
+
+        if (gatesOpen && !lowTide)
+            return baseText + " You can hear a loud roaring sound, like that of rushing water, from below.";
+
+        if (!gatesOpen && lowTide)
+            return baseText; // reservoir drained and gates shut — no water sound
+
+        return baseText + " You can hear the sound of flowing water from below.";
     }
 
     public override void Init()


### PR DESCRIPTION
## Summary

Fixes #217. The Deep Canyon `look` description had a single fixed water-sound line. In the original (`zork1/1actions.zil` `DEEP-CANYON-F`, lines 1730–1745), that line varies with two pieces of world state — whether the dam's **sluice gates are open** (`GATES-OPEN`) and whether the reservoir has drained to **low tide** (`LOW-TIDE`). This restores the three-state behavior.

| `GATES-OPEN` | `LOW-TIDE` | Water-sound sentence |
|---|---|---|
| open | not low | `You can hear a loud roaring sound, like that of rushing water, from below.` |
| closed | low | *(none — no water sentence)* |
| any other combo | | `You can hear the sound of flowing water from below.` |

The "other combo" bucket covers gates open + low tide and gates closed + not low tide. The latter is the game's starting state, so the **default `look` text is unchanged**.

## State mapping (ZIL → C#)

No new state needed — both globals already have C# homes:

- `GATES-OPEN` ↔ `Dam.SluiceGatesOpen`
- `LOW-TIDE` ↔ `ReservoirSouth.IsDrained`

`IsDrained` flips to `true` only when the reservoir finishes emptying and back to `false` when it refills, matching the ZIL timing for `LOW-TIDE` (set in `I-REMPTY` line 1269, cleared in `I-RFILL` line 1233).

## Changes

- `ZorkOne/Location/DeepCanyon.cs` — `GetContextBasedDescription` now appends the water-sound sentence conditionally based on `SluiceGatesOpen`/`IsDrained`.
- `ZorkOne.Tests/Places/DeepCanyonTests.cs` — new test class (mirrors `DamTests`, inherits `EngineTestsBase`) covering all four state combos.

## TDD (per CLAUDE.md)

Wrote the failing tests first. Against the old static implementation, the two new-behavior cases (gates-open/not-drained → roaring; gates-closed/drained → silent) failed for the right reason, while the two "other bucket" cases passed (default behavior preserved). After the fix all four pass.

- ✅ `ZorkOne.Tests` — 1216 passed, 0 failed
- ✅ `UnitTests` — 825 passed, 0 failed

## Evidence

- `zork1/1actions.zil:1730–1745` — `DEEP-CANYON-F` (the three-state description)
- `zork1/1actions.zil:1269` — `I-REMPTY` sets `LOW-TIDE T`
- `zork1/1actions.zil:1233` — `I-RFILL` clears `LOW-TIDE`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019yZtFfLhkKNa3fxqudszdz)_