### PR TITLE
Stop the narrator inventing objects on deflection responses

### DIFF
--- a/Model/AIGeneration/Requests/CannotGoThatWayRequest.cs
+++ b/Model/AIGeneration/Requests/CannotGoThatWayRequest.cs
@@ -8,5 +8,8 @@ public class CannotGoThatWayRequest : Request
             $"The player is in this location: \"{location}\". They tried to go {direction} but going that way is  " +
             $"not possible from this location. Respond with a very short, sarcastic and simple message informing them " +
             $"that they cannot go that way. Do not be creative about why or what is preventing them, do not alter the state of the game or provide additional information. ";
+
+        // Same "stay in room state" deflection category as the no-effect prompts: keep creativity low.
+        Temperature = DeflectionTemperature;
     }
 }

--- a/Model/AIGeneration/Requests/CommandHasNoEffectOperationRequest.cs
+++ b/Model/AIGeneration/Requests/CommandHasNoEffectOperationRequest.cs
@@ -21,11 +21,10 @@ public class CommandHasNoEffectOperationRequest : Request
             Player input: ""break the window""
             AI response: ""You consider breaking the window, but then think better of it. Maybe there's another way to solve this problem.""
 
-            Please follow these guidelines when generating responses. Do not invent, name, or describe any object, item,
-            scenery, exit, or character that is not already explicitly present in the location description above; refer only to
-            things actually present, or keep it generic, and do not alter the state of the game or add new information. ";
+            Please follow these guidelines when generating responses. " + NoInventionGuard + @" When you describe a
+            benign or atmospheric action creatively (like dancing or singing), that creativity applies to tone and flavor only
+            — never to introducing new concrete objects, characters, exits, or state. ";
 
-        // Deflection responses should not embellish; keep creativity low to avoid invented detail.
-        Temperature = 0.4f;
+        Temperature = DeflectionTemperature;
     }
 }

--- a/Model/AIGeneration/Requests/CommandHasNoEffectOperationRequest.cs
+++ b/Model/AIGeneration/Requests/CommandHasNoEffectOperationRequest.cs
@@ -21,6 +21,11 @@ public class CommandHasNoEffectOperationRequest : Request
             Player input: ""break the window""
             AI response: ""You consider breaking the window, but then think better of it. Maybe there's another way to solve this problem.""
 
-            Please follow these guidelines when generating responses. ";
+            Please follow these guidelines when generating responses. Do not invent, name, or describe any object, item,
+            scenery, exit, or character that is not already explicitly present in the location description above; refer only to
+            things actually present, or keep it generic, and do not alter the state of the game or add new information. ";
+
+        // Deflection responses should not embellish; keep creativity low to avoid invented detail.
+        Temperature = 0.4f;
     }
 }

--- a/Model/AIGeneration/Requests/NounNotPresentOperationRequest.cs
+++ b/Model/AIGeneration/Requests/NounNotPresentOperationRequest.cs
@@ -6,6 +6,15 @@ public class NounNotPresentOperationRequest : Request
     {
         UserMessage = $"The player is in this location: \"{location}\". " +
                       $"They reference the object: \"{noun}\", but there is no \"{noun}\" here. " +
-                      $"Provide the narrator's very succinct response";
+                      $"Provide the narrator's very succinct response telling them it isn't here. " +
+                      // Anti-hallucination guard: the narrator must stay inside the room state and
+                      // not substitute a made-up object for the one the player named.
+                      "Do not invent, name, substitute, or describe any object, item, scenery, exit, " +
+                      "or character that is not already explicitly present in the location description " +
+                      "above. Refer only to things actually present, or keep it generic. Do not alter " +
+                      "the state of the game or add new information.";
+
+        // Deflection responses should not embellish; keep creativity low to avoid invented detail.
+        Temperature = 0.4f;
     }
 }

--- a/Model/AIGeneration/Requests/NounNotPresentOperationRequest.cs
+++ b/Model/AIGeneration/Requests/NounNotPresentOperationRequest.cs
@@ -7,14 +7,9 @@ public class NounNotPresentOperationRequest : Request
         UserMessage = $"The player is in this location: \"{location}\". " +
                       $"They reference the object: \"{noun}\", but there is no \"{noun}\" here. " +
                       $"Provide the narrator's very succinct response telling them it isn't here. " +
-                      // Anti-hallucination guard: the narrator must stay inside the room state and
-                      // not substitute a made-up object for the one the player named.
-                      "Do not invent, name, substitute, or describe any object, item, scenery, exit, " +
-                      "or character that is not already explicitly present in the location description " +
-                      "above. Refer only to things actually present, or keep it generic. Do not alter " +
-                      "the state of the game or add new information.";
+                      // Anti-hallucination guard: don't substitute a made-up object for the named one.
+                      NoInventionGuard;
 
-        // Deflection responses should not embellish; keep creativity low to avoid invented detail.
-        Temperature = 0.4f;
+        Temperature = DeflectionTemperature;
     }
 }

--- a/Model/AIGeneration/Requests/Request.cs
+++ b/Model/AIGeneration/Requests/Request.cs
@@ -2,6 +2,22 @@ namespace Model.AIGeneration.Requests;
 
 public abstract class Request
 {
+    /// <summary>
+    /// Shared anti-hallucination guard for "negative"/deflection prompts (object-not-present,
+    /// verb-has-no-effect, command-has-no-effect, can't-go-that-way). The narrator must stay
+    /// inside the room state and not substitute or invent things that aren't there.
+    /// </summary>
+    protected const string NoInventionGuard =
+        "Do not invent, name, substitute, or describe any object, item, scenery, exit, or character " +
+        "that is not already explicitly present in the location description above. Refer only to things " +
+        "actually present, or keep it generic. Do not alter the state of the game or add new information.";
+
+    /// <summary>
+    /// Low creativity for deflection responses, so they don't embellish with invented detail.
+    /// Normal narration keeps the higher default (<see cref="Temperature"/>).
+    /// </summary>
+    protected const float DeflectionTemperature = 0.4f;
+
     public virtual string? UserMessage { get; protected init; }
 
     public float Temperature { get; set; } = 0.8f;

--- a/Model/AIGeneration/Requests/VerbHasNoEffectOperationRequest.cs
+++ b/Model/AIGeneration/Requests/VerbHasNoEffectOperationRequest.cs
@@ -8,6 +8,13 @@ public class VerbHasNoEffectOperationRequest : Request
             $"The player is in this location: \"{location}\". " +
             $"They wrote \"{verb} the {noun}\", and while there is a \"{noun}\" here, " +
             $"that action has no effect on the story. Provide the narrator's response " +
-            $"indicating that their action is silly or pointless and so they change their mind and don't bother. ";
+            $"indicating that their action is silly or pointless and so they change their mind and don't bother. " +
+            // Anti-hallucination guard: don't embellish the deflection with new objects/characters.
+            "Do not invent, name, or describe any object, item, scenery, exit, or character that is " +
+            "not already explicitly present in the location description above. Do not alter the state " +
+            "of the game or add new information.";
+
+        // Deflection responses should not embellish; keep creativity low to avoid invented detail.
+        Temperature = 0.4f;
     }
 }

--- a/Model/AIGeneration/Requests/VerbHasNoEffectOperationRequest.cs
+++ b/Model/AIGeneration/Requests/VerbHasNoEffectOperationRequest.cs
@@ -10,11 +10,8 @@ public class VerbHasNoEffectOperationRequest : Request
             $"that action has no effect on the story. Provide the narrator's response " +
             $"indicating that their action is silly or pointless and so they change their mind and don't bother. " +
             // Anti-hallucination guard: don't embellish the deflection with new objects/characters.
-            "Do not invent, name, or describe any object, item, scenery, exit, or character that is " +
-            "not already explicitly present in the location description above. Do not alter the state " +
-            "of the game or add new information.";
+            NoInventionGuard;
 
-        // Deflection responses should not embellish; keep creativity low to avoid invented detail.
-        Temperature = 0.4f;
+        Temperature = DeflectionTemperature;
     }
 }

--- a/UnitTests/Models/RequestTests.cs
+++ b/UnitTests/Models/RequestTests.cs
@@ -260,14 +260,59 @@ public class RequestTests
     {
         // Arrange
         string input = "drop king's crown";
-        
+
         // Act
         var request = new DropSomethingTheyDoNotHave(input);
-        
+
         // Assert
         request.UserMessage.Should().Contain($"The player said '{input}'");
         request.UserMessage.Should().Contain("sarcastic response");
         request.UserMessage.Should().NotBeNullOrEmpty();
     }
 
+    // The narrator was observed inventing concrete objects that do not exist in the room
+    // (e.g. deflecting "examine the wizard" by claiming "it's just a paint-splattered broom"
+    // in a room that contains no broom). These "negative" deflection prompts must explicitly
+    // forbid the model from introducing objects/characters not already present, and must not
+    // run at the high creative temperature used for normal narration.
+
+    [Test]
+    public void NounNotPresentOperationRequest_ForbidsInventingObjects_AndIsLowTemperature()
+    {
+        // Arrange / Act
+        var request = new NounNotPresentOperationRequest(
+            "Studio. A zork owner's manual is here.", "wizard");
+
+        // Assert
+        request.UserMessage.Should().Contain("there is no \"wizard\" here");
+        request.UserMessage.Should().Contain("Do not invent");
+        request.UserMessage.Should().Contain("not already explicitly present");
+        request.Temperature.Should().BeLessThan(0.8f);
+    }
+
+    [Test]
+    public void VerbHasNoEffectOperationRequest_ForbidsInventingObjects_AndIsLowTemperature()
+    {
+        // Arrange / Act
+        var request = new VerbHasNoEffectOperationRequest(
+            "Studio. A zork owner's manual is here.", "manual", "rub");
+
+        // Assert
+        request.UserMessage.Should().Contain("Do not invent");
+        request.UserMessage.Should().Contain("not already explicitly present");
+        request.Temperature.Should().BeLessThan(0.8f);
+    }
+
+    [Test]
+    public void CommandHasNoEffectOperationRequest_ForbidsInventingObjects_AndIsLowTemperature()
+    {
+        // Arrange / Act
+        var request = new CommandHasNoEffectOperationRequest(
+            "Studio. A zork owner's manual is here.", "examine the wizard");
+
+        // Assert
+        request.UserMessage.Should().Contain("Do not invent");
+        request.UserMessage.Should().Contain("not already explicitly present");
+        request.Temperature.Should().BeLessThan(0.8f);
+    }
 }

--- a/UnitTests/Models/RequestTests.cs
+++ b/UnitTests/Models/RequestTests.cs
@@ -313,6 +313,19 @@ public class RequestTests
         // Assert
         request.UserMessage.Should().Contain("Do not invent");
         request.UserMessage.Should().Contain("not already explicitly present");
+        // The benign/atmospheric branch ("describe it creatively") must not contradict the guard:
+        // creativity is for tone only, never for introducing concrete objects.
+        request.UserMessage.Should().Contain("tone and flavor only");
+        request.Temperature.Should().BeLessThan(0.8f);
+    }
+
+    [Test]
+    public void CannotGoThatWayRequest_UsesLowDeflectionTemperature()
+    {
+        // This is the same category of "stay in room state" deflection as the no-effect prompts,
+        // so it should not run at the embellishment-prone 0.8 default either.
+        var request = new CannotGoThatWayRequest("Forest", "north");
+
         request.Temperature.Should().BeLessThan(0.8f);
     }
 }


### PR DESCRIPTION
## Problem

The AI narrator fabricates concrete objects that don't exist in the room. Found live by the AdventureBreaker harness: deflecting `examine the wizard standing in the corner` in the **Studio**, the narrator replied *"…it's just a paint-splattered broom."* There is **no broom anywhere in Zork I** (verified: `grep -rin broom ZorkOne/` → no matches; the Studio only `StartWithItem<Manual>` at `ZorkOne/Location/Studio.cs:58`). A player could then `take broom` and fail — a trust-breaking hallucination.

## Root cause

The three "negative" deflection prompts —
`NounNotPresentOperationRequest`, `VerbHasNoEffectOperationRequest`, `CommandHasNoEffectOperationRequest` —
gave the model **no instruction to stay inside the room state** and ran at the base **`Temperature = 0.8`**, which is tuned for creative narration and rewards embellishment on exactly these responses. (The model already receives the real room contents via `GetDescriptionForGeneration()`; it just wasn't constrained to them.)

The codebase already has the idiom for this: `CannotGoThatWayRequest` and the sub-location prompts say *"Do not be creative about why… do not alter the state of the game or provide additional information"* (see `RequestTests.cs`). These deflection prompts simply never got the same guard.

## Fix

- Add an explicit guard to all three prompts: do **not** invent/name/substitute any object, item, scenery, exit, or character that isn't already present in the supplied location description; refer only to what's actually there.
- Lower `Temperature` to `0.4` on these deflections so they don't embellish.

This is per-response (it doesn't dampen normal creative narration) and mirrors the existing convention. A complementary global rule could live in the system prompt (AWS Secrets Manager), but that's config, not code, so it's out of scope here.

## Tests (TDD)

The end-to-end symptom is **stochastic LLM output**, which can't be a deterministic unit test. The deterministic seam is the **prompt contract**, tested in the existing `UnitTests/Models/RequestTests.cs`: three new cases assert the guard text is present and `Temperature < 0.8`. They are **red before** this change (confirmed: failing on the missing `"Do not invent"` clause) and **green after**.

No regressions — each suite run separately:
- `UnitTests` — 828 passed, 1 skipped
- `ZorkOne.Tests` — 1212 passed
- `Planetfall.Tests` — 2219 passed

Closes the `narrator_hallucination` finding from the AdventureBreaker run. Related inventory bug tracked in #230.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DsEMy2gYe2qexc95aJR4KR

---
_Generated by [Claude Code](https://claude.ai/code/session_01DsEMy2gYe2qexc95aJR4KR)_