### PR TITLE
Fix #233: keep reservoir at low tide until refill completes

### DIFF
--- a/ZorkOne.Tests/Places/DamTests.cs
+++ b/ZorkOne.Tests/Places/DamTests.cs
@@ -149,6 +149,52 @@ public class DamTests : EngineTestsBase
     }
 
     [Test]
+    public async Task Refilling_StaysLowTideUntilFull()
+    {
+        // Issue #233: closing the gates starts the refill, but LOW-TIDE (IsDrained) must stay set
+        // for the whole refill and only clear when the reservoir is full again — mirroring the ZIL
+        // I-RFILL daemon, which is QUEUEd with a delay when the gates close and clears LOW-TIDE only
+        // when it fires (at completion), not the instant the gates are operated.
+        var target = GetTarget();
+        target.Context.CurrentLocation = Repository.GetLocation<MaintenanceRoom>();
+        target.Context.Take(Repository.GetItem<Wrench>());
+        target.Context.Take(Repository.GetItem<Lantern>());
+        Repository.GetItem<Lantern>().IsOn = true;
+
+        await target.GetResponse("press the yellow button");
+        await target.GetResponse("S");
+        await target.GetResponse("S");
+        await target.GetResponse("turn bolt with wrench"); // gates open, draining starts
+
+        var sr = Repository.GetLocation<ReservoirSouth>();
+
+        // Drain the reservoir completely.
+        await target.GetResponse("W");
+        await target.GetResponse("wait");
+        await target.GetResponse("wait");
+        await target.GetResponse("wait");
+        await target.GetResponse("wait");
+        await target.GetResponse("wait");
+        sr.IsDrained.Should().BeTrue();
+
+        // Close the gates -> refilling begins. Low tide must persist until the reservoir is full.
+        await target.GetResponse("E"); // back to the Dam
+        await target.GetResponse("turn bolt with wrench");
+
+        sr.IsFilling.Should().BeTrue();
+        sr.IsFull.Should().BeFalse();
+        sr.IsDrained.Should().BeTrue();
+
+        // Wait out the refill; only on completion does low tide end and the reservoir read full.
+        for (var i = 0; i < 8; i++)
+            await target.GetResponse("wait");
+
+        sr.IsFull.Should().BeTrue();
+        sr.IsFilling.Should().BeFalse();
+        sr.IsDrained.Should().BeFalse();
+    }
+
+    [Test]
     public async Task Dam_Red_Button()
     {
         var target = GetTarget();

--- a/ZorkOne/Location/ReservoirSouth.cs
+++ b/ZorkOne/Location/ReservoirSouth.cs
@@ -111,7 +111,11 @@ public class ReservoirSouth : DarkLocation, ITurnBasedActor
 
     public void StartFilling(IContext context)
     {
-        IsFull = IsDrained = IsDraining = false;
+        // Issue #233: do NOT clear IsDrained here. LOW-TIDE (IsDrained) must persist for the whole
+        // refill and only clear when the reservoir is full again — mirroring the ZIL I-RFILL daemon,
+        // which is QUEUEd with a delay when the gates close and clears LOW-TIDE only when it fires
+        // (at completion). Act() clears IsDrained on the turn the fill countdown reaches zero.
+        IsFull = IsDraining = false;
         IsFilling = true;
         FillingCountDown = 7;
         context.RegisterActor(this);


### PR DESCRIPTION
## Summary

Fixes #233. `ReservoirSouth.StartFilling` cleared `IsDrained` (the C# analogue of ZIL `LOW-TIDE`) **the instant the gates closed**, so the "gates closed + still low tide" world state was unreachable in normal play. In the original, the refill is a queued interrupt — `I-RFILL` is `<QUEUE>`d with a delay when the gates close and clears `LOW-TIDE` only when it *fires* (at completion). So low tide persists for the whole ~8-turn refill.

## The fix

`ReservoirSouth.StartFilling` no longer clears `IsDrained`:

```diff
-        IsFull = IsDrained = IsDraining = false;
+        IsFull = IsDraining = false;
```

`Act()` already clears `IsDrained` on the turn the fill countdown reaches zero (`ReservoirSouth.cs:50-51`), so low tide now ends exactly at refill completion. The **draining** side was already correct — it flips `IsDrained` to `true` at drain *completion* in `Act()` — so this just removes a one-sided asymmetry.

This also makes the `gates-closed + low-tide` → *"no water sound"* branch added for #217 (PR #231, Deep Canyon) reachable as the original intends, rather than only via its unit test.

## No other regressions

I checked every reader of `IsDrained` during the refill window (gates closed, not yet full):

- **`Dam.GatesDescription` (`Dam.cs:38`)** — gated by `&& SluiceGatesOpen` (false during refill), and the fall-through (`Dam.cs:46`) yields the same "water level… quite low, but rising quickly" text whether `IsDrained` is true or false. No change.
- **North-crossing `CanGo` (`ReservoirSouth.cs:74`)** — `IsDrained || (IsFilling && !IsFull)`; the `IsFilling` clause already made it `true` during refill, so still `true` (matches the ZIL crossable-during-refill window).
- **`ReservoirSouth` own description (`:86`)** — gated by `&& !IsFilling`, so unaffected during refill; the `IsFilling` branch (`:92`) renders the text.

## TDD (per CLAUDE.md)

Added `Refilling_StaysLowTideUntilFull` to `DamTests`, mirroring the existing `Draining` test (real `Repository`, lit lantern, full gameplay flow). Failing-test-first: before the fix it failed at the close-the-gates step with `Expected sr.IsDrained to be True, but found False`; after the fix it passes.

- ✅ `ZorkOne.Tests` — 1226 passed, 0 failed
- ✅ `UnitTests` — 825 passed, 0 failed

## Scope note

The fill/drain countdown is `7` here vs. the ZIL's queued `8` — a separate, pre-existing off-by-one that this PR intentionally leaves alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019yZtFfLhkKNa3fxqudszdz)_