### PR TITLE
Document why BrownSpool.Contents is intentionally unreachable (#226)

### DIFF
--- a/Planetfall/Item/Lawanda/Library/BrownSpool.cs
+++ b/Planetfall/Item/Lawanda/Library/BrownSpool.cs
@@ -4,7 +4,19 @@ public class BrownSpool : SpoolBase
 {
     public override string[] NounsForMatching => ["brown spool", "spool", "brown"];
 
-    // You can NEVER get the spool to the library. You die first 
+    // Intentionally unreachable: the brown spool has no readable contents, by design.
+    //
+    // The spool starts in the Radiation Lab (RadiationLab.cs), where radiation poisoning kills
+    // the player a few turns after entering (RadiationLab.Act increments SickTurnCounter and
+    // triggers death on turn 7). You die long before you could carry the spool out and all the
+    // way to the library's SpoolReader, so a brown spool never actually ends up in the reader
+    // and Contents is never read (its only caller is SpoolReader.ReadDescription).
+    //
+    // This matches the original game. The ZIL spool reader handles only the green and red spools
+    // (planetfall-source/comptwo.zil:1224-1244) and rejects anything else with "It doesn't fit
+    // in the circular opening." (comptwo.zil:1245). There is no BROWN-TEXT global: the "repair
+    // robot instructions" exist only as the spool's label (see ExaminationDescription below),
+    // never as readable screen content. So there is deliberately nothing to return here.
     public override string Contents => throw new NotImplementedException();
 
     public override string ExaminationDescription => "The spool is labelled \"Instrukshunz foor Reepaareeng Reepaar Roobots.\"";

--- a/Planetfall/Item/Lawanda/Library/SpoolReader.cs
+++ b/Planetfall/Item/Lawanda/Library/SpoolReader.cs
@@ -31,6 +31,9 @@ public class SpoolReader : ContainerBase, ICanBeExamined, ICanBeTakenAndDropped,
 
     public override string CanOnlyHoldTheseTypesErrorMessage(string nameOfItemWeTriedToPlace) => "It doesn't fit in the circular opening. ";
     
+    // BrownSpool is listed for completeness, but in practice it can never reach the reader: the
+    // player dies of radiation poisoning before carrying it here from the Radiation Lab. Hence
+    // BrownSpool.Contents is never read (and deliberately throws). See BrownSpool.cs for details.
     public override Type[] CanOnlyHoldTheseTypes => [typeof(GreenSpool), typeof(RedSpool), typeof(BrownSpool)];
 
     public override string NoRoomMessage => "There's already a spool in the reader. ";


### PR DESCRIPTION
Closes #226.

`BrownSpool.Contents` throws `NotImplementedException`, guarded only by the terse comment *"You can NEVER get the spool to the library. You die first."* Per #226, the right resolution here is to **make that invariant understood in the comments** rather than change behavior — and the original ZIL gives us the full justification.

## What the ZIL confirms

- The brown spool starts in the Radiation Lab. `RadiationLab.Act` (`Planetfall/Location/Lawanda/Lab/RadiationLab.cs:62-84`) ticks `SickTurnCounter` every turn after entry and kills the player on turn 7 — long before the spool could be carried to the library `SpoolReader`.
- In the original, the reader's `PUT` handler (`planetfall-source/comptwo.zil:1224-1244`) only handles the **green** and **red** spools; everything else falls through to *"It doesn't fit in the circular opening."* (`comptwo.zil:1245`). The brown spool is never a valid spool for the reader.
- There is **no `BROWN-TEXT` global** — only `GREEN-TEXT`/`RED-TEXT` (`comptwo.zil:1252-1267`). The "repair robot instructions" exist only as the spool's printed label, never as readable screen content.

So `Contents` (whose only caller is `SpoolReader.ReadDescription`) is genuinely unreachable for the brown spool, and there is deliberately nothing to return.

## Changes

- `Planetfall/Item/Lawanda/Library/BrownSpool.cs` — replace the one-line comment with a full explanation of the invariant and its ZIL backing. The `throw` is left intact (it documents "this is never reached" and would surface loudly if the invariant ever broke).
- `Planetfall/Item/Lawanda/Library/SpoolReader.cs` — add a pointer at `CanOnlyHoldTheseTypes` (the one place that lists `BrownSpool` as accepted) noting it is unreachable in play.

## Testing

Comment-only change — no behavior is altered, so there is nothing new to assert. Existing `Planetfall.Tests/SpoolReaderTests.cs` continues to cover the green/red reader paths and the "doesn't fit" rejection for non-spools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)