### PR TITLE
Fix #227: Infirmary bed GetOut returns safe message instead of throwing

### DIFF
--- a/Planetfall.Tests/InfirmaryTests.cs
+++ b/Planetfall.Tests/InfirmaryTests.cs
@@ -418,6 +418,20 @@ public class InfirmaryTests : EngineTestsBase
     }
 
     [Test]
+    public void GetOutOfBed_DoesNotThrow_AndReturnsSafeMessage()
+    {
+        GetTarget();
+        var bed = GetItem<InfirmaryBed>();
+
+        // Getting into the bed triggers an immediate death, so GetOut is unreachable
+        // in normal play. It must still return a safe message rather than throw.
+        var act = () => bed.GetOut(Context);
+
+        act.Should().NotThrow();
+        bed.GetOut(Context).Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Test]
     public async Task GiveBreastplateToFloyd_BreastplateDroppedInCurrentRoom()
     {
         var target = GetTarget();

--- a/Planetfall/Location/Lawanda/Infirmary.cs
+++ b/Planetfall/Location/Lawanda/Infirmary.cs
@@ -120,6 +120,9 @@ internal class InfirmaryBed : ItemBase, ISubLocation
 
     public string GetOut(IContext context)
     {
-        throw new NotImplementedException();
+        // Climbing into this bed triggers an immediate death (the rusty diagnostic robot),
+        // so the player can never actually occupy it and this is unreachable in normal play.
+        // Return a safe message rather than throwing, so any unexpected call path can't crash.
+        return "You're not in the bed. ";
     }
 }


### PR DESCRIPTION
## Summary

Fixes #227.

`Planetfall/Location/Lawanda/Infirmary.cs` — `InfirmaryBed.GetOut(IContext)` was `throw new NotImplementedException();`. Climbing *into* the infirmary bed triggers an immediate death (the rusty diagnostic robot), so `GetOut` is unreachable in normal play — but it threw rather than returning a safe message, so any path that called it would crash.

This makes the method defensive: it now returns `"You're not in the bed. "`, matching the defensive get-out fallbacks used elsewhere (e.g. `SafetyWeb.GetOut`'s `"You're not in the safety web. "` and `ExitSubLocationEngine`'s `"You're not in the {noun}. "`).

## Test (TDD)

Added `GetOutOfBed_DoesNotThrow_AndReturnsSafeMessage` to `Planetfall.Tests/InfirmaryTests.cs`:
- **Before the fix:** fails — `act.Should().NotThrow()` catches the `NotImplementedException`.
- **After the fix:** passes — returns a non-empty safe message.

All 2,229 Planetfall.Tests pass with no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)