### PR TITLE
Fix #225: ConferenceRoomDoor.NowOpen() no longer throws NotImplementedException

### DIFF
--- a/Planetfall.Tests/ConferenceRoomTests.cs
+++ b/Planetfall.Tests/ConferenceRoomTests.cs
@@ -73,6 +73,35 @@ public class ConferenceRoomTests : EngineTestsBase
     }
     
     [Test]
+    public void NowOpen_DoesNotThrow_AndReturnsAMessage()
+    {
+        // Regression for #225: NowOpen() used to throw NotImplementedException. Even though the
+        // CannotBeOpenedDescription guard normally shields it from the "open" verb, the throw is a
+        // landmine that crashes the turn if that guard ever stops returning a reason. NowOpen must
+        // return a safe message, never throw.
+        var door = GetItem<ConferenceRoomDoor>();
+        var location = GetLocation<RecArea>();
+
+        var act = () => door.NowOpen(location);
+
+        act.Should().NotThrow();
+        door.NowOpen(location).Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Test]
+    public async Task OpenConferenceDoor_ReturnsMessage_AndDoesNotThrow()
+    {
+        // Regression for #225: "open conference door" must return a message and never crash the turn.
+        var target = GetTarget();
+        StartHere<RecArea>();
+
+        Func<Task> act = async () => await target.GetResponse("open conference door");
+
+        await act.Should().NotThrowAsync();
+        GetItem<ConferenceRoomDoor>().IsOpen.Should().BeFalse();
+    }
+
+    [Test]
     public async Task CloseDoor_FromConferenceRoom()
     {
         var target = GetTarget();

--- a/Planetfall/Item/Kalamontee/ConferenceRoomDoor.cs
+++ b/Planetfall/Item/Kalamontee/ConferenceRoomDoor.cs
@@ -36,8 +36,12 @@ public class ConferenceRoomDoor : ItemBase, IOpenAndClose, ICanBeExamined
 
     public string NowOpen(ILocation currentLocation)
     {
-        // The door can never be opened directly. It opens automatically when the dial has the correct code. 
-        throw new NotImplementedException();
+        // The door has no handle or latch and can never be opened directly — it only opens when the
+        // dial is set to the correct code (AttemptUnlock sets IsOpen itself). The "open" verb is
+        // normally shielded by CannotBeOpenedDescription always returning a reason, so this message
+        // isn't shown in normal play. We return it instead of throwing so a future change to that
+        // guard can never crash the turn (#225).
+        return "The door has no handle or latch; it opens only when the dial is set to the right number. ";
     }
 
     public override Task<InteractionResult?> RespondToSimpleInteraction(SimpleIntent action, IContext context,


### PR DESCRIPTION
## Summary

Fixes #225. `ConferenceRoomDoor.NowOpen()` was `throw new NotImplementedException()`.

`OpenAndCloseInteractionProcessor.OpenMe` calls `NowOpen()` for its success message after checking `CannotBeOpenedDescription`. In practice the throw was **not reachable** through the `open` verb today, because `ConferenceRoomDoor.CannotBeOpenedDescription` always returns a non-empty reason ("The door is locked…" / "…locked from the other side."), which short-circuits `OpenMe` before it reaches `NowOpen()`. So `open door` / `open conference door` already returned the lock hint safely.

But the throw was a latent landmine: it would crash the turn the instant that guard ever changed to return empty/null — exactly what a `NotImplementedException` census flags.

## Fix

Replace the throw with a safe, dial-hint message and a comment explaining the trap so it isn't reintroduced. The door has no handle/latch and only opens via the dial (`AttemptUnlock` sets `IsOpen` itself).

## Tests (TDD)

- `NowOpen_DoesNotThrow_AndReturnsAMessage` — calls `NowOpen()` directly. **Red before the fix** with `Did not expect any exception, but found System.NotImplementedException` at `ConferenceRoomDoor.cs:40`; green after.
- `OpenConferenceDoor_ReturnsMessage_AndDoesNotThrow` — the literal "open conference door" scenario from the issue; documents that the open path is shielded and never crashes.

All 54 `ConferenceRoomTests` and the full `Planetfall.Tests` suite (2230 passed, 1 pre-existing skip) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)