### PR TITLE
Node 24 action bumps + auto-deploy to production on release

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,7 +27,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,10 +21,10 @@ jobs:
     environment: production
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.0.x
 
@@ -54,29 +54,25 @@ jobs:
           dotnet lambda deploy-serverless -sb planetfallai-assets -sn PlanetfallStack --region us-east-1
 
       - name: Overwrite file Zork
-        uses: "DamianReeves/write-file-action@master"
-        with:
-          path: /home/runner/work/ZorkAI/ZorkAI/zorkweb.client/config.json
-          write-mode: overwrite
-          contents: |
-            {
-              "base_url": "https://bxqzfka0hc.execute-api.us-east-1.amazonaws.com/Prod/ZorkOne",
-              "version": "${{ github.event.inputs.version }}"
-            }
+        run: |
+          cat > /home/runner/work/ZorkAI/ZorkAI/zorkweb.client/config.json <<'EOF'
+          {
+            "base_url": "https://bxqzfka0hc.execute-api.us-east-1.amazonaws.com/Prod/ZorkOne",
+            "version": "${{ github.event.inputs.version }}"
+          }
+          EOF
 
       - name: Overwrite file Planetfall
-        uses: "DamianReeves/write-file-action@master"
-        with:
-          path: /home/runner/work/ZorkAI/ZorkAI/planetfallweb.client/config.json
-          write-mode: overwrite
-          contents: |
-            {
-              "base_url": "https://6kvs9n5pj4.execute-api.us-east-1.amazonaws.com/Prod/Planetfall",
-              "version": "${{ github.event.inputs.version }}"
-            }
+        run: |
+          cat > /home/runner/work/ZorkAI/ZorkAI/planetfallweb.client/config.json <<'EOF'
+          {
+            "base_url": "https://6kvs9n5pj4.execute-api.us-east-1.amazonaws.com/Prod/Planetfall",
+            "version": "${{ github.event.inputs.version }}"
+          }
+          EOF
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24'
 
@@ -90,7 +86,7 @@ jobs:
         run: npm run build -w planetfall.client
 
       - name: Setup AWS CLI
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -113,13 +109,10 @@ jobs:
           aws cloudfront create-invalidation --distribution-id EJYJYZ3BM3O3Z --paths "/*"    
           
       - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ github.event.inputs.version }}
-          release_name: Release ${{ github.event.inputs.version }}
+          name: Release ${{ github.event.inputs.version }}
           body: |
             ${{ steps.Changelog.outputs.changelog }}
           draft: false

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,11 @@
 name: Deploy To AWS
 
 on:
+  # Deploy automatically whenever a GitHub release is published. The release
+  # tag (e.g. 1.2.3) becomes the deployed version number.
+  release:
+    types: [published]
+  # Still allow a manual deploy (e.g. to re-deploy without cutting a new release).
   workflow_dispatch:
     inputs:
       version:
@@ -12,13 +17,17 @@ on:
         default: '1.0.0'
 
 permissions:
-  contents: write   # This is required to create/push the new git tag
+  contents: read
 
 jobs:
   deployment:
 
     runs-on: ubuntu-latest
     environment: production
+    # On a release trigger this is the release tag; on a manual dispatch it is
+    # the version input. Used everywhere the deployed version number is needed.
+    env:
+      DEPLOY_VERSION: ${{ github.event.release.tag_name || github.event.inputs.version }}
 
     steps:
       - uses: actions/checkout@v5
@@ -58,7 +67,7 @@ jobs:
           cat > /home/runner/work/ZorkAI/ZorkAI/zorkweb.client/config.json <<'EOF'
           {
             "base_url": "https://bxqzfka0hc.execute-api.us-east-1.amazonaws.com/Prod/ZorkOne",
-            "version": "${{ github.event.inputs.version }}"
+            "version": "${{ env.DEPLOY_VERSION }}"
           }
           EOF
 
@@ -67,7 +76,7 @@ jobs:
           cat > /home/runner/work/ZorkAI/ZorkAI/planetfallweb.client/config.json <<'EOF'
           {
             "base_url": "https://6kvs9n5pj4.execute-api.us-east-1.amazonaws.com/Prod/Planetfall",
-            "version": "${{ github.event.inputs.version }}"
+            "version": "${{ env.DEPLOY_VERSION }}"
           }
           EOF
 
@@ -108,12 +117,3 @@ jobs:
         run: |
           aws cloudfront create-invalidation --distribution-id EJYJYZ3BM3O3Z --paths "/*"    
           
-      - name: Create Release
-        uses: softprops/action-gh-release@v3
-        with:
-          tag_name: ${{ github.event.inputs.version }}
-          name: Release ${{ github.event.inputs.version }}
-          body: |
-            ${{ steps.Changelog.outputs.changelog }}
-          draft: false
-          prerelease: false

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 10.0.x
 
@@ -41,10 +41,10 @@ jobs:
     env:
       HOME: /root
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: '24'
 
@@ -57,7 +57,7 @@ jobs:
 
     - name: Upload Playwright test results
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: zorkweb-playwright-report
         path: zorkweb.client/playwright-report/
@@ -77,10 +77,10 @@ jobs:
     env:
       HOME: /root
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: '24'
 
@@ -93,7 +93,7 @@ jobs:
 
     - name: Upload Playwright test results
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: planetfallweb-playwright-report
         path: planetfallweb.client/playwright-report/


### PR DESCRIPTION
Two related changes to the GitHub Actions workflows.

## 1. Fix Node 20 deprecation warnings

GitHub is deprecating the **Node 20 runtime** on Actions runners ([Sept 2025 changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). The production deploy run ([27957394316](https://github.com/arsindelve/ZorkAI/actions/runs/27957394316)) warned that `actions/checkout@v4`, `actions/create-release@v1`, `actions/setup-dotnet@v4`, `actions/setup-node@v4`, `aws-actions/configure-aws-credentials@v1`, and `DamianReeves/write-file-action@master` all target Node 20.

Each action's `runs.using` was verified to be `node24` before pinning (several "latest" majors are *still* node20):

| Action | Before | After | Note |
|---|---|---|---|
| checkout | `@v4` | `@v5` | also in dotnet/claude/claude-code-review |
| setup-dotnet | `@v4` | `@v5` | |
| setup-node | `@v4` | `@v5` | |
| upload-artifact | `@v4` | `@v6` | v5 still node20 (dotnet.yml) |
| configure-aws-credentials | `@v1` | `@v6` | v5 still node20 |
| create-release | `@v1` | removed (see below) | archived; no node24 version |
| write-file-action | `@master` | plain shell heredoc | no node24 release; drops the dependency |

`anthropics/claude-code-action@v1` is a composite action (no Node runtime), so it does not warn and is left unchanged.

## 2. Auto-deploy to production when a release is published

The deploy workflow was manual-only (`workflow_dispatch`) and *created* a GitHub release as its final step. That's inverted:

- **`on: release: [published]`** now triggers the deploy; `workflow_dispatch` is kept as a manual fallback.
- The deployed version is the release tag: `DEPLOY_VERSION = github.event.release.tag_name || github.event.inputs.version`. Both web `config.json` files stamp `env.DEPLOY_VERSION`.
- The redundant **Create Release** step is removed — the release already exists (it's the trigger). This also resolves the prior `Validation Failed: already_exists tag_name` failure.
- `permissions` dropped from `contents: write` to `contents: read` (nothing writes to the repo anymore).

**To deploy:** publish a GitHub release with the tag set to the version (e.g. `1.2.3`). Note `published` also fires for pre-releases — switch the trigger to `types: [released]` if you want pre-releases excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)