### PR TITLE
Fix #244: take/drop/put noun resolution now honors adjectives

### DIFF
--- a/GameEngine/Repository.cs
+++ b/GameEngine/Repository.cs
@@ -86,6 +86,16 @@ public static class Repository
 
         noun = noun.ToLowerInvariant().Trim();
 
+        // Issue #244: an exact match against an item's *precise* (adjective-qualified) nouns must
+        // beat the word-boundary containment fallback in ItemBase.HasMatchingNoun - regardless of
+        // whether the precise match is in the room or in inventory. Without this, "good bedistor"
+        // resolved to the FUSED bedistor, because its bare noun "bedistor" is contained in the
+        // input and the location (searched first) won on a containment match while the adjective
+        // was ignored. Trap: do this pass BEFORE the location-first search below.
+        var preciseMatch = GetPreciseMatchInScope(noun, context);
+        if (preciseMatch != null)
+            return preciseMatch;
+
         // First search in the current room (including all nested containers)
         if (context.CurrentLocation != null)
         {
@@ -108,6 +118,28 @@ public static class Repository
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Finds the single accessible item in scope (room first, then inventory) whose
+    /// <see cref="IItem.NounsForPreciseMatching"/> contains an exact match for the noun. This is
+    /// the adjective-aware pass that lets "good bedistor" win over a bare "bedistor" containment
+    /// match (issue #244). Returns null when no precise match is in scope, leaving the broader
+    /// containment fallback in <see cref="GetItemInScope"/> to do its job.
+    /// </summary>
+    private static IItem? GetPreciseMatchInScope(string noun, IContext context)
+    {
+        // Room before inventory, mirroring the search order in GetItemInScope. Guard against null:
+        // production always returns a real list, but under-configured test mocks of IContext /
+        // ICanContainItems return null for GetAllItemsRecursively.
+        var candidates = new List<IItem>();
+        if (context.CurrentLocation is ICanContainItems locationItems)
+            candidates.AddRange(locationItems.GetAllItemsRecursively ?? []);
+        candidates.AddRange(context.GetAllItemsRecursively ?? []);
+
+        return candidates.FirstOrDefault(item =>
+            IsItemAccessible(item, context) &&
+            item.NounsForPreciseMatching.Any(n => n.Equals(noun, StringComparison.InvariantCultureIgnoreCase)));
     }
 
     /// <summary>

--- a/Planetfall.Tests/CourseControlTests.cs
+++ b/Planetfall.Tests/CourseControlTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using GameEngine;
 using Planetfall.Item.Kalamontee.Mech;
 using Planetfall.Item.Lawanda;
 using Planetfall.Location.Kalamontee.Admin;
@@ -342,6 +343,25 @@ public class CourseControlTests : EngineTestsBase
         GetLocation<SystemsMonitors>().Fixed.Count.Should().Be(4);
         GetLocation<SystemsMonitors>().Busted.Count.Should().Be(3);
         GetLocation<CourseControl>().Fixed.Should().BeTrue();
+    }
+
+    [Test]
+    public void GetItemInScope_GoodBedistor_ResolvesToGoodNotFused()
+    {
+        // Issue #244: when the good bedistor (inventory) and the fused bedistor (the open cube,
+        // in scope) are both present, "good bedistor" must resolve to the GOOD one. The fused
+        // bedistor's bare noun "bedistor" is contained in the input "good bedistor", and the
+        // resolver used to search the location first and return that containment match - ignoring
+        // the adjective. An exact precise-noun match must beat a containment match.
+        var target = GetTarget();
+        StartHere<CourseControl>();
+        Take<GoodBedistor>();                    // good in inventory
+        GetItem<LargeMetalCube>().IsOpen = true; // fused in the open cube, in scope
+
+        var good = GetItem<GoodBedistor>();
+
+        Repository.GetItemInScope("good bedistor", target.Context).Should().Be(good);
+        Repository.GetItemInScope("good ninety-ohm bedistor", target.Context).Should().Be(good);
     }
 
     [Test]


### PR DESCRIPTION
## Summary

Fixes #244. `Repository.GetItemInScope` (the resolver behind take / drop / put) ignored adjectives: with the **good** bedistor in inventory and the **fused** bedistor in the open cube, the reference `"good bedistor"` resolved to the **fused** one.

### Root cause
- `ItemBase.HasMatchingNoun` falls back to word-boundary **containment**, so the fused bedistor's bare noun `"bedistor"` matches the input `"good bedistor"` (`" good bedistor "`.Contains(`" bedistor "`)).
- `GetItemInScope` searches the **location first** and returns the first `HasMatchingNoun` hit — so that containment match won, with no adjective precision.
- The **examine** path (`MatchNounAndAdjective`) honors the adjective, so the two disagreed.

### Fix
Added an adjective-aware **precise-match pass** (`GetPreciseMatchInScope`) that runs **before** the location-first containment fallback. An exact match against an item's `NounsForPreciseMatching` (e.g. `"good bedistor"`, which is excluded from the fused bedistor's precise nouns) now beats a containment match, regardless of whether the precise match is in the room or in inventory. When no precise match is in scope, it falls through to the existing fallback, so `"take bedistor"` / `"take fused"` and every other current phrasing keep working.

A null-guard on `GetAllItemsRecursively` keeps under-configured `IContext` test mocks happy (production always returns a real list).

## TDD
Per the issue, the test exercises the `GetItemInScope` seam directly (a `GetResponse` test can't reproduce this — the deterministic test parser doesn't parse `"take the good bedistor"`).

- **Red:** `GetItemInScope("good bedistor", ctx)` returned the `FusedBedistor`.
- **Green:** both `"good bedistor"` and `"good ninety-ohm bedistor"` now resolve to the `GoodBedistor`.

New test: `Planetfall.Tests/CourseControlTests.GetItemInScope_GoodBedistor_ResolvesToGoodNotFused` (next to `FullSolution`).

## Verification (run each project separately)
- `Planetfall.Tests`: **2232 passed** (incl. the new test)
- `UnitTests`: **834 passed**
- `ZorkOne.Tests`: **1226 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UrDy7tGGoi7B3uUY1kHnqa

---
_Generated by [Claude Code](https://claude.ai/code/session_01UrDy7tGGoi7B3uUY1kHnqa)_