### PR TITLE
Fix #240: decelerating the shuttle to a stop mid-tunnel advances a position and prints contradictory text

### DIFF
--- a/Planetfall.Tests/ShuttleTests.cs
+++ b/Planetfall.Tests/ShuttleTests.cs
@@ -394,6 +394,40 @@ public class ShuttleTests : EngineTestsBase
     }
 
     [Test]
+    public async Task Decelerate_ToStop_OnePositionShortOfPlatform_StopsShortDoesNotDock()
+    {
+        // Boundary companion to issue #240: stopping at EndOfTunnel - 1 (position 23, still
+        // strictly mid-tunnel) must behave like any other mid-tunnel stop -- the car halts in
+        // place and does NOT advance into the platform / dock. This pins the exact
+        // "TunnelPosition != EndOfTunnel" boundary the fix hinges on (the off-by-one risk).
+        var target = GetTarget();
+        Take<ShuttleAccessCard>();
+        StartHere<AlfieControlEast>();
+        var controls = GetLocation<AlfieControlEast>();
+
+        await target.GetResponse("slide shuttle access card through slot");
+        await target.GetResponse("push lever"); // speed 5
+        await target.GetResponse("pull lever"); // lever to center, coasting at 5
+
+        // Coast until exactly one position short of the platform (EndOfTunnel is 24).
+        while (controls.TunnelPosition < 23)
+            await target.GetResponse("wait");
+
+        controls.TunnelPosition.Should().Be(23);
+        controls.Speed.Should().Be(5);
+
+        var response = await target.GetResponse("pull lever");
+
+        response.Should().Contain("The shuttle car comes to a stop and the lever pops back to the central position");
+        response.Should().NotContain("continues to move");
+        response.Should().NotContain("glides into the station");
+        controls.Speed.Should().Be(0);
+        controls.LeverPosition.Should().Be(ShuttleLeverPosition.Neutral);
+        controls.TunnelPosition.Should().Be(23);
+        controls.DoorIsClosed.Should().BeTrue();
+    }
+
+    [Test]
     public async Task MiddleOfTrack_CannotLeave()
     {
         var target = GetTarget();

--- a/Planetfall.Tests/ShuttleTests.cs
+++ b/Planetfall.Tests/ShuttleTests.cs
@@ -359,6 +359,41 @@ public class ShuttleTests : EngineTestsBase
     }
 
     [Test]
+    public async Task Decelerate_ToStop_MidTunnel_DoesNotAdvanceOrContradict()
+    {
+        // Regression test for issue #240: decelerating to a full stop while between
+        // stations (speed 5 -> 0) must NOT advance the tunnel position by one more
+        // step, and must NOT print the contradictory "continues to move ... reads 0"
+        // line on the same turn the car comes to rest.
+        var target = GetTarget();
+        Take<ShuttleAccessCard>();
+        StartHere<AlfieControlEast>();
+        var controls = GetLocation<AlfieControlEast>();
+
+        await target.GetResponse("slide shuttle access card through slot");
+        await target.GetResponse("push lever"); // speed 5, lever up
+        await target.GetResponse("pull lever"); // lever to center, still rolling at 5
+        await target.GetResponse("wait");
+        await target.GetResponse("wait");
+
+        // We are mid-tunnel, coasting at speed 5.
+        controls.Speed.Should().Be(5);
+        controls.LeverPosition.Should().Be(ShuttleLeverPosition.Neutral);
+        controls.TunnelPosition.Should().BeGreaterThan(0).And.BeLessThan(24);
+        var positionBeforeStop = controls.TunnelPosition;
+
+        // This "pull lever" sets the lever to decelerate; the same turn's Act() drops
+        // speed 5 -> 0 and the car comes to rest right here.
+        var response = await target.GetResponse("pull lever");
+
+        response.Should().Contain("The shuttle car comes to a stop and the lever pops back to the central position");
+        response.Should().NotContain("continues to move");
+        controls.Speed.Should().Be(0);
+        controls.LeverPosition.Should().Be(ShuttleLeverPosition.Neutral);
+        controls.TunnelPosition.Should().Be(positionBeforeStop);
+    }
+
+    [Test]
     public async Task MiddleOfTrack_CannotLeave()
     {
         var target = GetTarget();

--- a/Planetfall/Location/Shuttle/ShuttleControl.cs
+++ b/Planetfall/Location/Shuttle/ShuttleControl.cs
@@ -271,6 +271,15 @@ public abstract class ShuttleControl<TCabin, TControl> : LocationWithNoStartingI
         if (Speed == 0)
         {
             LeverPosition = ShuttleLeverPosition.Neutral;
+            // Issue #240: decelerating to a full stop mid-tunnel must NOT trigger another
+            // Move() this turn. The "|| SpeedChanged" clause in Act() lets a speed change move
+            // the car even when Speed == 0; without this guard the decel-to-stop case would
+            // advance one extra tunnel position and print a contradictory "continues to move"
+            // line on the same turn the car comes to rest. At the very end of the tunnel we
+            // deliberately keep SpeedChanged set so Move() still runs and the car docks at the
+            // platform (the perfect-landing path, which relies on this extra Move()).
+            if (TunnelPosition != EndOfTunnel)
+                SpeedChanged = false;
             return Task.FromResult("The shuttle car comes to a stop and the lever pops back to the central position. ");
         }
 


### PR DESCRIPTION
## Summary

Fixes #240.

When the player pulled the shuttle lever to **decelerate to a full stop while between stations** (speed `5 → 0`), the engine on that single turn:

1. advanced the shuttle **one more tunnel position** (`TunnelPosition++`), and
2. printed **two contradictory messages** — *"The shuttle car comes to a stop and the lever pops back to the central position."* immediately followed by *"The shuttle car continues to move. The display blinks, and now reads 0."*

## Root cause

In `Planetfall/Location/Shuttle/ShuttleControl.cs`, `ChangeSpeed()` set `SpeedChanged = true` for any lever-driven speed change, even when deceleration brought `Speed` to 0. `Act()`'s `if (Speed != 0 || SpeedChanged)` guard then ran `Move()` anyway; mid-tunnel `Move()` took its `default` branch, printed the contradictory line, and advanced `TunnelPosition`.

## The fix

`ChangeSpeed()` now clears `SpeedChanged` when a deceleration brings `Speed` to 0 **mid-tunnel**, so no extra `Move()` fires and only the stop message is shown.

⚠️ **Important nuance not in the original issue's suggested fix:** the guard is conditional on `TunnelPosition != EndOfTunnel`. At the very end of the tunnel, that extra `Move()` is exactly what drives `Arrived()` / docking — the **perfect-landing** path (decelerate to a stop right as you reach the platform). An unconditional `SpeedChanged = false` (as the issue suggested) breaks that path; the existing `FullTrip_ConstantSpeed_PerfectLanding` and `RoundTrip` tests caught the regression, so the fix preserves end-of-tunnel behavior.

## Testing (TDD)

- Added a deterministic regression test, `Decelerate_ToStop_MidTunnel_DoesNotAdvanceOrContradict`, that drives the engine to a mid-tunnel coast at speed 5, decelerates to a stop, and asserts `TunnelPosition` is unchanged, `Speed == 0`, and the response contains the stop message but **not** "continues to move". It fails before the fix and passes after.
- Full `ShuttleTests` suite (37 tests) passes, including the perfect-landing and round-trip flows.
- Full `Planetfall.Tests` suite (2233 tests) passes — no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jg3eGPJ1RzsXunj4sayboB)_