### PR TITLE
Fix #246: multi-noun (put/give/slide X in/to Y) noun resolution now honors adjectives

### DIFF
--- a/GameEngine/IntentEngine/MultiNounEngine.cs
+++ b/GameEngine/IntentEngine/MultiNounEngine.cs
@@ -139,6 +139,13 @@ public class MultiNounEngine : IIntentEngine
         // giving the shared adjective-aware pass priority over the containment fallback below. The
         // existing inventory-first fallback is left untouched so plain, non-adjective nouns behave
         // exactly as before.
+        //
+        // Note the precise pass searches room-before-inventory (matching GetItemInScope), while the
+        // fallback below stays inventory-before-room - intentional, and not a contradiction to
+        // "fix": the two orders can only disagree when one noun is an exact precise-noun match on
+        // two different in-scope items at once, and Process() runs CheckDisambiguation (over the
+        // same scope) before we ever get here, so that collision is already turned into a "do you
+        // mean..." prompt rather than a silent pick.
         var preciseMatch = Repository.GetPreciseMatchInScope(item, context);
         if (preciseMatch is not null)
             return (true, preciseMatch);

--- a/GameEngine/IntentEngine/MultiNounEngine.cs
+++ b/GameEngine/IntentEngine/MultiNounEngine.cs
@@ -133,6 +133,16 @@ public class MultiNounEngine : IIntentEngine
 
     private static (bool IsHere, IItem? item) IsItemHere(IContext context, string item)
     {
+        // Issue #246: an adjective-qualified noun ("kitchen card", "good bedistor") must resolve to
+        // the precise item, not the first raw-containment match (a shuttle "card" is contained in
+        // "kitchen card"; a fused "bedistor" in "good bedistor"). Mirror the single-noun #244 fix by
+        // giving the shared adjective-aware pass priority over the containment fallback below. The
+        // existing inventory-first fallback is left untouched so plain, non-adjective nouns behave
+        // exactly as before.
+        var preciseMatch = Repository.GetPreciseMatchInScope(item, context);
+        if (preciseMatch is not null)
+            return (true, preciseMatch);
+
         var result = context.HasMatchingNoun(item);
         if (result.HasItem)
             return result;

--- a/GameEngine/Repository.cs
+++ b/GameEngine/Repository.cs
@@ -125,10 +125,21 @@ public static class Repository
     /// <see cref="IItem.NounsForPreciseMatching"/> contains an exact match for the noun. This is
     /// the adjective-aware pass that lets "good bedistor" win over a bare "bedistor" containment
     /// match (issue #244). Returns null when no precise match is in scope, leaving the broader
-    /// containment fallback in <see cref="GetItemInScope"/> to do its job.
+    /// containment fallback in the caller to do its job.
+    ///
+    /// Shared by every scope resolver so they agree on adjectives: <see cref="GetItemInScope"/>
+    /// (single-noun take/drop/put, #244) and <see cref="IntentEngine.MultiNounEngine"/>'s noun
+    /// resolution (multi-noun put/give/slide, #246). The raw <see cref="IItem.HasMatchingNoun"/> /
+    /// location matchers are adjective-blind containment matchers, so callers must run this pass
+    /// first to keep "kitchen card" from resolving to a shuttle "card".
     /// </summary>
-    private static IItem? GetPreciseMatchInScope(string noun, IContext context)
+    public static IItem? GetPreciseMatchInScope(string? noun, IContext context)
     {
+        if (string.IsNullOrEmpty(noun))
+            return null;
+
+        noun = noun.ToLowerInvariant().Trim();
+
         // Room before inventory, mirroring the search order in GetItemInScope. Guard against null:
         // production always returns a real list, but under-configured test mocks of IContext /
         // ICanContainItems return null for GetAllItemsRecursively.

--- a/Planetfall.Tests/CardTests.cs
+++ b/Planetfall.Tests/CardTests.cs
@@ -293,4 +293,36 @@ public class CardTests : EngineTestsBase
 
         response.Should().Contain("The kitchen door quietly slides open");
     }
+
+    [Test]
+    [TestCase(true)] // shuttle carried first - the issue's reported failing order
+    [TestCase(false)] // kitchen carried first
+    public void KitchenCard_ResolvesToKitchenNotShuttle_RegardlessOfInventoryOrder(bool shuttleFirst)
+    {
+        // Issue #246: the multi-noun path (put/give/slide X in/to Y) resolves each noun through
+        // MultiNounEngine.IsItemHere, which used the raw, adjective-blind containment matcher. The
+        // shuttle card's bare noun "card" is contained in "kitchen card", so when the shuttle card
+        // is first in inventory the raw matcher returned it - ignoring the "kitchen" adjective. Both
+        // the multi-noun resolver (GetPreciseMatchInScope, the pass IsItemHere now runs first) and
+        // the single-noun #244 resolver (GetItemInScope) must land on the KITCHEN card regardless of
+        // inventory order.
+        var engine = GetTarget();
+        engine.Context.CurrentLocation = Repository.GetLocation<MessHall>();
+
+        if (shuttleFirst)
+        {
+            engine.Context.ItemPlacedHere(Repository.GetItem<ShuttleAccessCard>());
+            engine.Context.ItemPlacedHere(Repository.GetItem<KitchenAccessCard>());
+        }
+        else
+        {
+            engine.Context.ItemPlacedHere(Repository.GetItem<KitchenAccessCard>());
+            engine.Context.ItemPlacedHere(Repository.GetItem<ShuttleAccessCard>());
+        }
+
+        var kitchen = Repository.GetItem<KitchenAccessCard>();
+
+        Repository.GetPreciseMatchInScope("kitchen card", engine.Context).Should().Be(kitchen);
+        Repository.GetItemInScope("kitchen card", engine.Context).Should().Be(kitchen);
+    }
 }

--- a/Planetfall.Tests/CardTests.cs
+++ b/Planetfall.Tests/CardTests.cs
@@ -299,13 +299,18 @@ public class CardTests : EngineTestsBase
     [TestCase(false)] // kitchen carried first
     public void KitchenCard_ResolvesToKitchenNotShuttle_RegardlessOfInventoryOrder(bool shuttleFirst)
     {
-        // Issue #246: the multi-noun path (put/give/slide X in/to Y) resolves each noun through
-        // MultiNounEngine.IsItemHere, which used the raw, adjective-blind containment matcher. The
-        // shuttle card's bare noun "card" is contained in "kitchen card", so when the shuttle card
-        // is first in inventory the raw matcher returned it - ignoring the "kitchen" adjective. Both
-        // the multi-noun resolver (GetPreciseMatchInScope, the pass IsItemHere now runs first) and
-        // the single-noun #244 resolver (GetItemInScope) must land on the KITCHEN card regardless of
-        // inventory order.
+        // Issue #246, resolver-level guard for the card-collision family. The shuttle card's bare
+        // noun "card" is contained in "kitchen card", so an adjective-blind matcher returns the
+        // shuttle card when it is first in inventory. This locks in that the SHARED adjective-aware
+        // resolver - GetPreciseMatchInScope (the pass MultiNounEngine.IsItemHere now runs first) and
+        // GetItemInScope (the single-noun #244 path) - lands on the KITCHEN card regardless of order,
+        // guarding the cards' NounsForPreciseMatching definitions against future drift.
+        //
+        // This asserts the resolver directly, not the engine turn: the end-to-end multi-noun engine
+        // path (IsItemHere) is proven red-before/green-after by the bedistor test
+        // CourseControlTests.PutGoodBedistorInCube_WhenFusedIsFirstInInventory... A card slide/put
+        // cannot stand in for it, because SlotBase resolves cards by type (Match<KitchenAccessCard,
+        // KitchenSlot> + HasItem<KitchenAccessCard>) and returns before IsItemHere is ever reached.
         var engine = GetTarget();
         engine.Context.CurrentLocation = Repository.GetLocation<MessHall>();
 

--- a/Planetfall.Tests/CourseControlTests.cs
+++ b/Planetfall.Tests/CourseControlTests.cs
@@ -365,6 +365,32 @@ public class CourseControlTests : EngineTestsBase
     }
 
     [Test]
+    public async Task PutGoodBedistorInCube_WhenFusedIsFirstInInventory_ActsOnTheNamedGoodBedistor()
+    {
+        // Issue #246: the multi-noun path (put/give/slide X in/to Y) resolved its nouns through
+        // MultiNounEngine.IsItemHere, which used the raw, adjective-blind containment matcher - so
+        // #244's single-noun fix did not cover it. With the fused bedistor FIRST in inventory, the
+        // fused bedistor's bare noun "bedistor" is contained in "good bedistor", and inventory-first
+        // containment returned the FUSED one. "put good in cube" must act on the GOOD bedistor (the
+        // adjective-qualified, precise match), not the fused one that merely shares the bare noun.
+        var target = GetTarget();
+        StartHere<CourseControl>();
+        GetItem<LargeMetalCube>().IsOpen = true;
+
+        // Force the failing order: fused (the wrong, containment-only match) ahead of good in inventory.
+        Take<FusedBedistor>();
+        Take<GoodBedistor>();
+
+        var response = await target.GetResponse("put good in cube");
+
+        response.Should().Contain("The warning lights go out");
+        GetItem<LargeMetalCube>().HasItem<GoodBedistor>().Should().BeTrue();
+        target.Context.HasItem<GoodBedistor>().Should().BeFalse();
+        target.Context.HasItem<FusedBedistor>().Should().BeTrue();
+        GetLocation<CourseControl>().Fixed.Should().BeTrue();
+    }
+
+    [Test]
     public async Task UsePliersOnBedistor_RemovesBedistor()
     {
         var target = GetTarget();


### PR DESCRIPTION
## Summary

Closes #246.

The #244 fix made **single-noun** take/drop/put adjective-aware (`Repository.GetItemInScope`), but the **multi-noun** path (`put X in Y`, `give X to Y`, `slide X through Y`) resolves its nouns through a different method — `MultiNounEngine.IsItemHere` — which the fix never touched. `IsItemHere` used the raw, adjective-blind containment matcher (`context.HasMatchingNoun` / `location.HasMatchingNoun`), so an adjective-qualified noun like `"kitchen card"` or `"good bedistor"` still resolved to the wrong item when more than one candidate was in scope.

Root cause is the same disagreement #244 fixed, now *within* the multi-noun path: `ItemBase.HasMatchingNoun` falls back to word-boundary containment, so a shuttle card's bare noun `"card"` is contained in `"kitchen card"` (and a fused bedistor's `"bedistor"` in `"good bedistor"`), and the **first** such match in inventory order won — ignoring the adjective. `MultiNounEngine`'s own disambiguation is precise (built from `NounsForPreciseMatching`), so a specific noun passes the ambiguity check with a single match and then `IsItemHere` mis-resolves it anyway.

## Fix

- Promote `Repository.GetPreciseMatchInScope` from `private` to a **shared public** adjective-aware resolver (with a null/normalization guard), and document it as the one helper every scope resolver runs first.
- Run that precise pass at the **start** of `MultiNounEngine.IsItemHere`, before the existing inventory-first containment fallback. An exact match against an item's `NounsForPreciseMatching` now beats a containment match in the multi-noun path too.
- The existing inventory-first containment + description fallback is left **untouched**, so plain non-adjective nouns (`"take bedistor"`, `"put leaflet in mailbox"`, etc.) behave exactly as before.

## Tests (TDD)

- **`CourseControlTests.PutGoodBedistorInCube_WhenFusedIsFirstInInventory_ActsOnTheNamedGoodBedistor`** — proving test, **red before / green after**. With the fused bedistor first in inventory, `put good in cube` used to put the *fused* bedistor in the cube (response `"Done."`, Course Control not fixed); it now acts on the named *good* bedistor (`"The warning lights go out…"`, Course Control fixed).
- **`CardTests.KitchenCard_ResolvesToKitchenNotShuttle_RegardlessOfInventoryOrder`** — guards the issue's named scenario: `"kitchen card"` resolves to the kitchen card via the shared resolver regardless of inventory order.

## Verification

- `dotnet test UnitTests` → 834 passed, 1 skipped
- `dotnet test ZorkOne.Tests` → 1226 passed
- `dotnet test Planetfall.Tests` → 2235 passed (includes the 2 new tests)
- `dotnet build Zork.sln` → 0 warnings, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1gWczxJHGfKHSwKG4Vjis

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q1gWczxJHGfKHSwKG4Vjis)_