### PR TITLE
Fix #250: restore previousLocationName on GET rehydrate path

### DIFF
--- a/GameEngine/Context.cs
+++ b/GameEngine/Context.cs
@@ -306,6 +306,8 @@ public abstract class Context<T> : IContext where T : IInfocomGame, new()
 
     public Direction? LastMovementDirection { get; set; }
 
+    public string? PreviousLocationName { get; set; }
+
     /// <summary>
     ///     Adds the specified item to the inventory of the game context and removes it from the current location
     /// </summary>

--- a/GameEngine/GameEngine.cs
+++ b/GameEngine/GameEngine.cs
@@ -160,7 +160,11 @@ public class GameEngine<TInfocomGame, TContext> : IGameEngine
 
     public string LocationName => Context.CurrentLocation.Name;
 
-    public string? PreviousLocationName { get; private set; }
+    // Projection of Context.PreviousLocationName (mirrors LastMovementDirection below). It must
+    // live on Context, not as an engine-only field, so it serializes/restores — otherwise the GET
+    // no-turn rehydrate path leaves it null while POST returns it, losing the "came from" location
+    // on reconnect (issue #250).
+    public string? PreviousLocationName => Context.PreviousLocationName;
 
     public Direction? LastMovementDirection => Context.LastMovementDirection;
 
@@ -254,7 +258,7 @@ public class GameEngine<TInfocomGame, TContext> : IGameEngine
         if (string.IsNullOrEmpty(playerInput))
             return PostProcessing(await GetGeneratedNoCommandResponse());
 
-        PreviousLocationName = LocationName;
+        Context.PreviousLocationName = LocationName;
 
         // 3. ------- System, or "meta" commands - like save, restore, quit, verbose etc. Does not count as a turn. No actor or turn processing.
         var systemCommand = _parser.DetermineSystemIntentType(playerInput);

--- a/Model/Interface/IContext.cs
+++ b/Model/Interface/IContext.cs
@@ -138,6 +138,14 @@ public interface IContext : ICanContainItems
     Direction? LastMovementDirection { get; set; }
 
     /// <summary>
+    ///     The name of the location the adventurer was in at the start of the most recent turn —
+    ///     i.e. where they "came from". Lives on the context (rather than on the engine) so it is
+    ///     serialized and restored, keeping the GET no-turn rehydrate path in parity with POST
+    ///     (issue #250).
+    /// </summary>
+    string? PreviousLocationName { get; set; }
+
+    /// <summary>
     ///     For debugging purposes, will list everything in inventory.
     /// </summary>
     /// <returns></returns>

--- a/UnitTests/Engine/SaveGameSerializationTests.cs
+++ b/UnitTests/Engine/SaveGameSerializationTests.cs
@@ -30,6 +30,31 @@ public class SaveGameSerializationTests : EngineTestsBase
     }
 
     [Test]
+    public async Task RestoreGame_RepopulatesPreviousLocationName_FromContext()
+    {
+        // Arrange: move the player so the engine records a "came from" location, then save.
+        var engine = GetTarget();
+        engine.Context.CurrentLocation = Repository.GetLocation<WestOfHouse>();
+        await engine.GetResponse("N");
+        engine.LocationName.Should().Be("North of House");
+        engine.PreviousLocationName.Should().Be("West Of House", "the player just came from West Of House");
+
+        var saved = engine.SaveGame();
+
+        // Act: restore into a fresh engine, exactly like the GET rehydrate path, which runs
+        // no engine turn (so the engine-only PreviousLocationName is never re-assigned).
+        var restoredEngine = GetTarget();
+        restoredEngine.PreviousLocationName.Should().BeNull("a fresh engine has no prior location");
+        restoredEngine.RestoreGame(saved);
+
+        // Assert: PreviousLocationName must survive the no-turn GET rehydrate path so a
+        // reconnecting client still knows where the player came from. It now lives on Context
+        // (mirroring LastMovementDirection) so it serializes/restores and GET matches POST
+        // (issue #250).
+        restoredEngine.PreviousLocationName.Should().Be("West Of House");
+    }
+
+    [Test]
     public void SaveGame_Contains_TypeAndReferenceMetadata()
     {
         // Arrange


### PR DESCRIPTION
## Summary

Fixes #250. On the **GET** session-rehydrate path, `previousLocationName` came back **`null`**, while the **POST** path returned it correctly (`lastMovementDirection` was fine on both). A client rehydrating via GET on reconnect lost the "came from" location.

## Root cause

`PreviousLocationName` was an engine-only field on `GameEngine` with a `private set`, assigned **only while processing a turn** (`GameEngine.cs`). It was **not** part of `Context`, so `RestoreGame` never restored it, and the GET controller path (restore session, then build `GameResponse` with no turn) left it at its default `null`.

`LastMovementDirection`, by contrast, lives on `Context` (which is serialized and restored), so it survives the GET path. This is the same shape as #230 — a GET no-turn path failing to populate an engine-level projection that isn't in `Context`.

## Fix

Mirror `LastMovementDirection`:
- Add `PreviousLocationName` to `IContext` / `Context` (an auto-property that serializes & restores with the rest of the context).
- The engine's `PreviousLocationName` is now a live projection of `Context.PreviousLocationName` (`=> Context.PreviousLocationName`), so it can never drift.
- The per-turn write now targets `Context.PreviousLocationName`.

GET and POST now agree.

## Test (TDD)

Added `RestoreGame_RepopulatesPreviousLocationName_FromContext` next to the analogous #230 inventory test in `SaveGameSerializationTests`. It moves the player (so a prior location is recorded), saves, restores into a fresh engine via the no-turn `RestoreGame` path, and asserts `PreviousLocationName` survives.

- **Red before the fix:** `Expected restoredEngine.PreviousLocationName to be "West Of House", but found <null>.`
- **Green after.**

## Verification

- `UnitTests`: 835 passed, 1 skipped
- `ZorkOne.Tests`: 1226 passed
- `Planetfall.Tests`: 2232 passed

(The Lambda test projects fail to restore due to a pre-existing `NU1605` transitive-package conflict unrelated to this change; the Lambda controller GET/POST tests that build `GameResponse` live in `UnitTests` and pass.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016W51sGwanfyMdeM7j5G5d1

---
_Generated by [Claude Code](https://claude.ai/code/session_016W51sGwanfyMdeM7j5G5d1)_