### PR TITLE
Fix #248: resolve "them" to item collections; keep pronoun antecedents across movement

### DIFF
--- a/GameEngine/Context.cs
+++ b/GameEngine/Context.cs
@@ -72,6 +72,8 @@ public abstract class Context<T> : IContext where T : IInfocomGame, new()
 
     public string LastNoun { get; set; } = "";
 
+    public List<string> LastNouns { get; set; } = new();
+
     public int Moves { get; set; }
 
     /// <summary>

--- a/GameEngine/Context.cs
+++ b/GameEngine/Context.cs
@@ -74,6 +74,24 @@ public abstract class Context<T> : IContext where T : IInfocomGame, new()
 
     public List<string> LastNouns { get; set; } = new();
 
+    public void RememberAntecedentNoun(string? noun)
+    {
+        if (!string.IsNullOrEmpty(noun) && !LastNouns.Contains(noun, StringComparer.OrdinalIgnoreCase))
+            LastNouns.Add(noun);
+    }
+
+    public void RememberAntecedentNouns(IEnumerable<string?> nouns)
+    {
+        var set = nouns
+            .Where(n => !string.IsNullOrEmpty(n))
+            .Select(n => n!)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        if (set.Count > 0)
+            LastNouns = set;
+    }
+
     public int Moves { get; set; }
 
     /// <summary>

--- a/GameEngine/IntentEngine/MoveEngine.cs
+++ b/GameEngine/IntentEngine/MoveEngine.cs
@@ -37,7 +37,7 @@ public class MoveEngine : IIntentEngine
         // item after walking to the next room (issue #248).
         if (!context.HasMatchingNoun(context.LastNoun).HasItem)
             context.LastNoun = "";
-        context.LastNouns = (context.LastNouns ?? [])
+        context.LastNouns = context.LastNouns
             .Where(n => context.HasMatchingNoun(n).HasItem).ToList();
 
         return (null, await Go(context, generationClient, movement));

--- a/GameEngine/IntentEngine/MoveEngine.cs
+++ b/GameEngine/IntentEngine/MoveEngine.cs
@@ -32,9 +32,14 @@ public class MoveEngine : IIntentEngine
                 ? movement.CustomFailureMessage + Environment.NewLine
                 : await GetGeneratedCantGoThatWayResponse(generationClient, moveTo.Direction.ToString(), context));
 
-        // Let's reset the noun context, so we don't get confused with "it" between locations
-        context.LastNoun = "";
-        
+        // Forget pronoun antecedents for items we left behind in the previous room, but keep them
+        // for items the player is still carrying — "it"/"them" should still resolve to a carried
+        // item after walking to the next room (issue #248).
+        if (!context.HasMatchingNoun(context.LastNoun).HasItem)
+            context.LastNoun = "";
+        context.LastNouns = (context.LastNouns ?? [])
+            .Where(n => context.HasMatchingNoun(n).HasItem).ToList();
+
         return (null, await Go(context, generationClient, movement));
     }
 

--- a/GameEngine/IntentEngine/MultiNounEngine.cs
+++ b/GameEngine/IntentEngine/MultiNounEngine.cs
@@ -25,8 +25,10 @@ public class MultiNounEngine : IIntentEngine
         if (context.ItIsDarkHere)
             return (null, "It's too dark to see! ");
 
-        // After a multi-noun interaction, we will lose the ability to understand "it". 
+        // After a multi-noun interaction, we lose the ability to understand "it". It isn't a
+        // take/drop either, so it also ends any "them" group (issue #248).
         context.LastNoun = "";
+        context.LastNouns = [];
 
         var requireDisambiguation = CheckDisambiguation(interaction, context, interaction.MatchNounOne);
         if (requireDisambiguation is not null)

--- a/GameEngine/IntentEngine/SimpleInteractionEngine.cs
+++ b/GameEngine/IntentEngine/SimpleInteractionEngine.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using Model;
 using Model.AIGeneration;
 using Model.AIGeneration.Requests;
 using Model.Interface;
@@ -22,6 +23,13 @@ internal class SimpleInteractionEngine(IItemProcessorFactory itemProcessorFactor
 
         Debug.WriteLine(intent);
         context.LastNoun = simpleInteraction.Noun ?? "";
+
+        // "them" tracks only a contiguous run of take/drop commands; any other interaction (examine,
+        // open, push, ...) ends that group, mirroring how LastNoun is overwritten every turn. Without
+        // this, an item taken long ago would be swept into a later "drop them" (issue #248).
+        var verb = simpleInteraction.Verb?.ToLowerInvariant().Trim() ?? string.Empty;
+        if (!Verbs.TakeVerbs.Contains(verb) && !Verbs.DropVerbs.Contains(verb))
+            context.LastNouns = [];
 
         DisambiguationInteractionResult? requireDisambiguation = CheckDisambiguation(simpleInteraction, context);
         if (requireDisambiguation is not null)

--- a/GameEngine/Item/ItemProcessor/TakeOrDropInteractionProcessor.cs
+++ b/GameEngine/Item/ItemProcessor/TakeOrDropInteractionProcessor.cs
@@ -172,6 +172,18 @@ public class TakeOrDropInteractionProcessor : IVerbProcessor
         return new PositiveInteractionResult(await TakeEverythingProcessor.TakeAll(context, itemsWithFeedback, client));
     }
 
+    /// <summary>
+    /// Records an individually taken or dropped item as part of the "them" antecedent set, so that a
+    /// following plural pronoun command ("drop them" after several takes) refers to all of them (issue #248).
+    /// Batch operations (take all / drop all) overwrite this set wholesale instead.
+    /// </summary>
+    internal static void RememberAsAntecedent(IContext context, IItem item)
+    {
+        var noun = item.NounsForMatching.FirstOrDefault();
+        if (!string.IsNullOrEmpty(noun) && !context.LastNouns.Contains(noun, StringComparer.OrdinalIgnoreCase))
+            context.LastNouns.Add(noun);
+    }
+
     public static InteractionResult DropIt(IContext context, IItem? castItem)
     {
         if (castItem is null) return new NoNounMatchInteractionResult();
@@ -186,6 +198,7 @@ public class TakeOrDropInteractionProcessor : IVerbProcessor
             return specialLocation.DropSpecial(castItem, context);
 
         context.Drop(castItem);
+        RememberAsAntecedent(context, castItem);
         return new PositiveInteractionResult("Dropped");
     }
 
@@ -212,9 +225,10 @@ public class TakeOrDropInteractionProcessor : IVerbProcessor
             return new PositiveInteractionResult("Your load is too heavy. ");
 
         context.Take(castItem);
+        RememberAsAntecedent(context, castItem);
 
         // This happens if you try to take something that is a legit object in the room,
-        // but it has not been marked with this interface because it cannot be taken. Think doors and engravings. 
+        // but it has not been marked with this interface because it cannot be taken. Think doors and engravings.
         if (castItem is not ICanBeTakenAndDropped takeItem)
             return new NoNounMatchInteractionResult();
 

--- a/GameEngine/Item/ItemProcessor/TakeOrDropInteractionProcessor.cs
+++ b/GameEngine/Item/ItemProcessor/TakeOrDropInteractionProcessor.cs
@@ -1,4 +1,5 @@
 using GameEngine.StaticCommand.Implementation;
+using Model;
 using Model.AIGeneration;
 using Model.AIGeneration.Requests;
 using Model.AIParsing;
@@ -44,20 +45,13 @@ public class TakeOrDropInteractionProcessor : IVerbProcessor
         if (item is not ICanBeTakenAndDropped)
             throw new Exception();
 
-        switch (action.Verb.ToLowerInvariant().Trim())
-        {
-            case "hold":
-            case "take":
-            case "pick up":
-            case "grab":
-            case "get":
-            case "acquire":
-            case "snatch":
-                return await GetItemsToTake(context, action, client);
+        var verb = action.Verb.ToLowerInvariant().Trim();
 
-            case "drop":
-                return await GetItemsToDrop(context, action, client);
-        }
+        if (Verbs.TakeVerbs.Contains(verb))
+            return await GetItemsToTake(context, action, client);
+
+        if (Verbs.DropVerbs.Contains(verb))
+            return await GetItemsToDrop(context, action, client);
 
         return null;
     }
@@ -172,18 +166,6 @@ public class TakeOrDropInteractionProcessor : IVerbProcessor
         return new PositiveInteractionResult(await TakeEverythingProcessor.TakeAll(context, itemsWithFeedback, client));
     }
 
-    /// <summary>
-    /// Records an individually taken or dropped item as part of the "them" antecedent set, so that a
-    /// following plural pronoun command ("drop them" after several takes) refers to all of them (issue #248).
-    /// Batch operations (take all / drop all) overwrite this set wholesale instead.
-    /// </summary>
-    internal static void RememberAsAntecedent(IContext context, IItem item)
-    {
-        var noun = item.NounsForMatching.FirstOrDefault();
-        if (!string.IsNullOrEmpty(noun) && !context.LastNouns.Contains(noun, StringComparer.OrdinalIgnoreCase))
-            context.LastNouns.Add(noun);
-    }
-
     public static InteractionResult DropIt(IContext context, IItem? castItem)
     {
         if (castItem is null) return new NoNounMatchInteractionResult();
@@ -198,7 +180,9 @@ public class TakeOrDropInteractionProcessor : IVerbProcessor
             return specialLocation.DropSpecial(castItem, context);
 
         context.Drop(castItem);
-        RememberAsAntecedent(context, castItem);
+        // Record this item as part of the "them" antecedent so a following "drop/take them" spans
+        // a contiguous run of individual takes/drops (issue #248).
+        context.RememberAntecedentNoun(castItem.NounsForMatching.FirstOrDefault());
         return new PositiveInteractionResult("Dropped");
     }
 
@@ -225,7 +209,7 @@ public class TakeOrDropInteractionProcessor : IVerbProcessor
             return new PositiveInteractionResult("Your load is too heavy. ");
 
         context.Take(castItem);
-        RememberAsAntecedent(context, castItem);
+        context.RememberAntecedentNoun(castItem.NounsForMatching.FirstOrDefault());
 
         // This happens if you try to take something that is a legit object in the room,
         // but it has not been marked with this interface because it cannot be taken. Think doors and engravings.

--- a/GameEngine/StaticCommand/Implementation/DropEverythingProcessor.cs
+++ b/GameEngine/StaticCommand/Implementation/DropEverythingProcessor.cs
@@ -21,13 +21,35 @@ public class DropEverythingProcessor : IGlobalCommand
     public static string DropAll(IContext context, List<IItem?> items)
     {
         var sb = new StringBuilder();
+        var dropped = new List<string>();
 
         foreach (var nextItem in items.ToList())
             if (nextItem is ICanBeTakenAndDropped)
+            {
                 sb.AppendLine(
                     $"{nextItem.Name}: {TakeOrDropInteractionProcessor.DropIt(context, nextItem).InteractionMessage}");
+                RememberDropped(dropped, nextItem);
+            }
 
+        SetAntecedent(context, dropped);
         return sb.ToString();
+    }
+
+    /// <summary>
+    /// Records the items just dropped as the "them" antecedent so a following "take them" can pick
+    /// them back up. A batch drop overwrites the set wholesale rather than appending (issue #248).
+    /// </summary>
+    private static void RememberDropped(List<string> dropped, IItem item)
+    {
+        var noun = item.NounsForMatching.FirstOrDefault();
+        if (!string.IsNullOrEmpty(noun))
+            dropped.Add(noun);
+    }
+
+    private static void SetAntecedent(IContext context, List<string> nouns)
+    {
+        if (nouns.Count > 0)
+            context.LastNouns = nouns;
     }
 
     /// <summary>
@@ -40,6 +62,7 @@ public class DropEverythingProcessor : IGlobalCommand
     public static async Task<string> DropAll(IContext context, List<(string noun, IItem? item)> itemsWithNouns, IGenerationClient client)
     {
         var sb = new StringBuilder();
+        var dropped = new List<string>();
 
         foreach (var (noun, item) in itemsWithNouns)
         {
@@ -61,10 +84,14 @@ public class DropEverythingProcessor : IGlobalCommand
             }
 
             if (item is ICanBeTakenAndDropped)
+            {
                 sb.AppendLine(
                     $"{item.Name}: {TakeOrDropInteractionProcessor.DropIt(context, item).InteractionMessage}");
+                RememberDropped(dropped, item);
+            }
         }
 
+        SetAntecedent(context, dropped);
         return sb.ToString();
     }
 }

--- a/GameEngine/StaticCommand/Implementation/DropEverythingProcessor.cs
+++ b/GameEngine/StaticCommand/Implementation/DropEverythingProcessor.cs
@@ -49,7 +49,7 @@ public class DropEverythingProcessor : IGlobalCommand
     private static void SetAntecedent(IContext context, List<string> nouns)
     {
         if (nouns.Count > 0)
-            context.LastNouns = nouns;
+            context.LastNouns = nouns.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
     }
 
     /// <summary>

--- a/GameEngine/StaticCommand/Implementation/DropEverythingProcessor.cs
+++ b/GameEngine/StaticCommand/Implementation/DropEverythingProcessor.cs
@@ -21,35 +21,20 @@ public class DropEverythingProcessor : IGlobalCommand
     public static string DropAll(IContext context, List<IItem?> items)
     {
         var sb = new StringBuilder();
-        var dropped = new List<string>();
+        var dropped = new List<string?>();
 
         foreach (var nextItem in items.ToList())
             if (nextItem is ICanBeTakenAndDropped)
             {
                 sb.AppendLine(
                     $"{nextItem.Name}: {TakeOrDropInteractionProcessor.DropIt(context, nextItem).InteractionMessage}");
-                RememberDropped(dropped, nextItem);
+                dropped.Add(nextItem.NounsForMatching.FirstOrDefault());
             }
 
-        SetAntecedent(context, dropped);
+        // The items just dropped become the "them" antecedent so a following "take them" can pick
+        // them back up; a batch drop overwrites the set wholesale rather than appending (issue #248).
+        context.RememberAntecedentNouns(dropped);
         return sb.ToString();
-    }
-
-    /// <summary>
-    /// Records the items just dropped as the "them" antecedent so a following "take them" can pick
-    /// them back up. A batch drop overwrites the set wholesale rather than appending (issue #248).
-    /// </summary>
-    private static void RememberDropped(List<string> dropped, IItem item)
-    {
-        var noun = item.NounsForMatching.FirstOrDefault();
-        if (!string.IsNullOrEmpty(noun))
-            dropped.Add(noun);
-    }
-
-    private static void SetAntecedent(IContext context, List<string> nouns)
-    {
-        if (nouns.Count > 0)
-            context.LastNouns = nouns.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
     }
 
     /// <summary>
@@ -62,7 +47,7 @@ public class DropEverythingProcessor : IGlobalCommand
     public static async Task<string> DropAll(IContext context, List<(string noun, IItem? item)> itemsWithNouns, IGenerationClient client)
     {
         var sb = new StringBuilder();
-        var dropped = new List<string>();
+        var dropped = new List<string?>();
 
         foreach (var (noun, item) in itemsWithNouns)
         {
@@ -87,11 +72,11 @@ public class DropEverythingProcessor : IGlobalCommand
             {
                 sb.AppendLine(
                     $"{item.Name}: {TakeOrDropInteractionProcessor.DropIt(context, item).InteractionMessage}");
-                RememberDropped(dropped, item);
+                dropped.Add(item.NounsForMatching.FirstOrDefault());
             }
         }
 
-        SetAntecedent(context, dropped);
+        context.RememberAntecedentNouns(dropped);
         return sb.ToString();
     }
 }

--- a/GameEngine/StaticCommand/Implementation/ItProcessor.cs
+++ b/GameEngine/StaticCommand/Implementation/ItProcessor.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using Model;
 using Model.AIGeneration;
 using Model.Interface;
 using Model.Item;
@@ -99,14 +100,12 @@ internal class ItProcessor : IStatefulProcessor
         return Resolved(Regex.Replace(input, @"\bit\b", lastNoun, RegexOptions.IgnoreCase));
     }
 
-    // Verbs whose direct object must be in the player's hand. Used to scope "them" so "drop them"
-    // never resolves to an item that is no longer being carried.
-    private static readonly string[] DropVerbs = ["drop"];
-
     private static List<string> ItemsStillInScope(string input, IContext context)
     {
+        // Dropping requires the item in hand, so scope "them" to carried items for a drop. Uses the
+        // shared verb table so it stays in sync with the take/drop processor.
         var verb = input.TrimStart().Split(' ', StringSplitOptions.RemoveEmptyEntries).FirstOrDefault() ?? string.Empty;
-        var dropping = DropVerbs.Contains(verb, StringComparer.OrdinalIgnoreCase);
+        var dropping = Verbs.DropVerbs.Contains(verb, StringComparer.OrdinalIgnoreCase);
 
         // Dropping needs the item carried; for everything else (take/put/...) it only needs to be
         // reachable — carried, or present in the current room.

--- a/GameEngine/StaticCommand/Implementation/ItProcessor.cs
+++ b/GameEngine/StaticCommand/Implementation/ItProcessor.cs
@@ -66,30 +66,45 @@ internal class ItProcessor : IStatefulProcessor
             return (false, input);
         }
 
-        if (
-            string.IsNullOrEmpty(lastNoun)
-            || (PronounUsed == Pronoun.Them && item is not IPluralNoun)
-        )
+        if (PronounUsed == Pronoun.Them)
         {
-            _lastInput = input;
-            Completed = false;
-            ContinueProcessing = false;
-            // This will trigger the "Process" method above to be called on their next input.
-            return (true, "What item are you referring to?\n");
+            // "them" refers to the collection of items the player last handled as a group (e.g.
+            // "take all" or several individual takes). Expand it into a conjoined noun list so the
+            // existing take/drop list handling does the rest — a single noun string can't represent
+            // a set of distinct singular items, which is why this used to dead-end (issue #248).
+            if (context.LastNouns.Count >= 2)
+                return Resolved(Regex.Replace(input, @"\bthem\b",
+                    string.Join(" and ", context.LastNouns), RegexOptions.IgnoreCase));
+
+            // A lone item is only a valid "them" antecedent if it is intrinsically plural (candles,
+            // matches, ...). Otherwise we still have to ask which item they mean.
+            if (string.IsNullOrEmpty(lastNoun) || item is not IPluralNoun)
+                return AskForClarification(input);
+
+            return Resolved(Regex.Replace(input, @"\bthem\b", lastNoun, RegexOptions.IgnoreCase));
         }
 
-        input = PronounUsed switch
-        {
-            Pronoun.It => Regex.Replace(input, @"\bit\b", lastNoun, RegexOptions.IgnoreCase),
-            Pronoun.Them => Regex.Replace(input, @"\bthem\b", lastNoun, RegexOptions.IgnoreCase),
-            _ => input
-        };
+        // Pronoun.It
+        if (string.IsNullOrEmpty(lastNoun))
+            return AskForClarification(input);
 
-        // Reset.
+        return Resolved(Regex.Replace(input, @"\bit\b", lastNoun, RegexOptions.IgnoreCase));
+    }
+
+    private (bool, string) Resolved(string input)
+    {
         Completed = true;
         PronounUsed = Pronoun.Unknown;
-
         return (false, input);
+    }
+
+    private (bool, string) AskForClarification(string input)
+    {
+        _lastInput = input;
+        Completed = false;
+        ContinueProcessing = false;
+        // This will trigger the "Process" method above to be called on their next input.
+        return (true, "What item are you referring to?\n");
     }
 
     private bool DidWeUseItOrThem(string input)

--- a/GameEngine/StaticCommand/Implementation/ItProcessor.cs
+++ b/GameEngine/StaticCommand/Implementation/ItProcessor.cs
@@ -56,7 +56,6 @@ internal class ItProcessor : IStatefulProcessor
     public (bool, string) Check(string input, IContext context)
     {
         var lastNoun = context.LastNoun;
-        var item = Repository.GetItem(lastNoun);
 
         var usedItOrThem = DidWeUseItOrThem(input);
 
@@ -73,15 +72,24 @@ internal class ItProcessor : IStatefulProcessor
             // existing take/drop list handling does the rest — a single noun string can't represent
             // a set of distinct singular items, which is why this used to dead-end (issue #248).
             if (context.LastNouns.Count >= 2)
-                return Resolved(Regex.Replace(input, @"\bthem\b",
-                    string.Join(" and ", context.LastNouns), RegexOptions.IgnoreCase));
+            {
+                // Resolve only to members still relevant to *this* command — you can only drop what
+                // you're holding — so a remembered item that has since left scope (already dropped,
+                // eaten, left in another room) doesn't drag a spurious "you don't have it" into an
+                // otherwise successful "drop them".
+                var inScope = ItemsStillInScope(input, context);
+                return inScope.Count > 0
+                    ? Resolved(Regex.Replace(input, @"\bthem\b", string.Join(" and ", inScope), RegexOptions.IgnoreCase))
+                    : AskForClarification(input);
+            }
 
             // A lone item is only a valid "them" antecedent if it is intrinsically plural (candles,
             // matches, ...). Otherwise we still have to ask which item they mean.
-            if (string.IsNullOrEmpty(lastNoun) || item is not IPluralNoun)
+            var soleNoun = context.LastNouns.Count == 1 ? context.LastNouns[0] : lastNoun;
+            if (string.IsNullOrEmpty(soleNoun) || Repository.GetItem(soleNoun) is not IPluralNoun)
                 return AskForClarification(input);
 
-            return Resolved(Regex.Replace(input, @"\bthem\b", lastNoun, RegexOptions.IgnoreCase));
+            return Resolved(Regex.Replace(input, @"\bthem\b", soleNoun, RegexOptions.IgnoreCase));
         }
 
         // Pronoun.It
@@ -89,6 +97,23 @@ internal class ItProcessor : IStatefulProcessor
             return AskForClarification(input);
 
         return Resolved(Regex.Replace(input, @"\bit\b", lastNoun, RegexOptions.IgnoreCase));
+    }
+
+    // Verbs whose direct object must be in the player's hand. Used to scope "them" so "drop them"
+    // never resolves to an item that is no longer being carried.
+    private static readonly string[] DropVerbs = ["drop"];
+
+    private static List<string> ItemsStillInScope(string input, IContext context)
+    {
+        var verb = input.TrimStart().Split(' ', StringSplitOptions.RemoveEmptyEntries).FirstOrDefault() ?? string.Empty;
+        var dropping = DropVerbs.Contains(verb, StringComparer.OrdinalIgnoreCase);
+
+        // Dropping needs the item carried; for everything else (take/put/...) it only needs to be
+        // reachable — carried, or present in the current room.
+        return context.LastNouns
+            .Where(noun => context.HasMatchingNoun(noun).HasItem ||
+                           (!dropping && context.CurrentLocation.HasMatchingNoun(noun).HasItem))
+            .ToList();
     }
 
     private (bool, string) Resolved(string input)

--- a/GameEngine/StaticCommand/Implementation/TakeEverythingProcessor.cs
+++ b/GameEngine/StaticCommand/Implementation/TakeEverythingProcessor.cs
@@ -28,6 +28,7 @@ public class TakeEverythingProcessor : IGlobalCommand
     public static string TakeAll(IContext context, List<IItem?> items)
     {
         var sb = new StringBuilder();
+        var taken = new List<string>();
         foreach (var nextItem in items)
         {
             if(nextItem is null) continue;
@@ -43,9 +44,27 @@ public class TakeEverythingProcessor : IGlobalCommand
 
             sb.AppendLine($"{nextItem.Name}: Taken. ");
             context.ItemPlacedHere(nextItem);
+            RememberTaken(taken, nextItem);
         }
 
+        SetAntecedent(context, taken);
         return sb.ToString();
+    }
+
+    /// <summary>
+    /// Records the items just taken as the "them" antecedent, so "take all. drop them" works (issue #248).
+    /// </summary>
+    private static void RememberTaken(List<string> taken, IItem item)
+    {
+        var noun = item.NounsForMatching.FirstOrDefault();
+        if (!string.IsNullOrEmpty(noun))
+            taken.Add(noun);
+    }
+
+    private static void SetAntecedent(IContext context, List<string> nouns)
+    {
+        if (nouns.Count > 0)
+            context.LastNouns = nouns;
     }
 
     /// <summary>
@@ -58,6 +77,7 @@ public class TakeEverythingProcessor : IGlobalCommand
     public static async Task<string> TakeAll(IContext context, List<(string noun, IItem? item)> itemsWithNouns, IGenerationClient client)
     {
         var sb = new StringBuilder();
+        var taken = new List<string>();
         foreach (var (noun, item) in itemsWithNouns)
         {
             if (item is null)
@@ -90,8 +110,10 @@ public class TakeEverythingProcessor : IGlobalCommand
 
             sb.AppendLine($"{item.Name}: Taken. ");
             context.ItemPlacedHere(item);
+            RememberTaken(taken, item);
         }
 
+        SetAntecedent(context, taken);
         return sb.ToString();
     }
 }

--- a/GameEngine/StaticCommand/Implementation/TakeEverythingProcessor.cs
+++ b/GameEngine/StaticCommand/Implementation/TakeEverythingProcessor.cs
@@ -64,7 +64,7 @@ public class TakeEverythingProcessor : IGlobalCommand
     private static void SetAntecedent(IContext context, List<string> nouns)
     {
         if (nouns.Count > 0)
-            context.LastNouns = nouns;
+            context.LastNouns = nouns.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
     }
 
     /// <summary>

--- a/GameEngine/StaticCommand/Implementation/TakeEverythingProcessor.cs
+++ b/GameEngine/StaticCommand/Implementation/TakeEverythingProcessor.cs
@@ -28,7 +28,7 @@ public class TakeEverythingProcessor : IGlobalCommand
     public static string TakeAll(IContext context, List<IItem?> items)
     {
         var sb = new StringBuilder();
-        var taken = new List<string>();
+        var taken = new List<string?>();
         foreach (var nextItem in items)
         {
             if(nextItem is null) continue;
@@ -44,27 +44,12 @@ public class TakeEverythingProcessor : IGlobalCommand
 
             sb.AppendLine($"{nextItem.Name}: Taken. ");
             context.ItemPlacedHere(nextItem);
-            RememberTaken(taken, nextItem);
+            taken.Add(nextItem.NounsForMatching.FirstOrDefault());
         }
 
-        SetAntecedent(context, taken);
+        // The items just taken become the "them" antecedent, so "take all. drop them" works (issue #248).
+        context.RememberAntecedentNouns(taken);
         return sb.ToString();
-    }
-
-    /// <summary>
-    /// Records the items just taken as the "them" antecedent, so "take all. drop them" works (issue #248).
-    /// </summary>
-    private static void RememberTaken(List<string> taken, IItem item)
-    {
-        var noun = item.NounsForMatching.FirstOrDefault();
-        if (!string.IsNullOrEmpty(noun))
-            taken.Add(noun);
-    }
-
-    private static void SetAntecedent(IContext context, List<string> nouns)
-    {
-        if (nouns.Count > 0)
-            context.LastNouns = nouns.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
     }
 
     /// <summary>
@@ -77,7 +62,7 @@ public class TakeEverythingProcessor : IGlobalCommand
     public static async Task<string> TakeAll(IContext context, List<(string noun, IItem? item)> itemsWithNouns, IGenerationClient client)
     {
         var sb = new StringBuilder();
-        var taken = new List<string>();
+        var taken = new List<string?>();
         foreach (var (noun, item) in itemsWithNouns)
         {
             if (item is null)
@@ -110,10 +95,10 @@ public class TakeEverythingProcessor : IGlobalCommand
 
             sb.AppendLine($"{item.Name}: Taken. ");
             context.ItemPlacedHere(item);
-            RememberTaken(taken, item);
+            taken.Add(item.NounsForMatching.FirstOrDefault());
         }
 
-        SetAntecedent(context, taken);
+        context.RememberAntecedentNouns(taken);
         return sb.ToString();
     }
 }

--- a/Model/Interface/IContext.cs
+++ b/Model/Interface/IContext.cs
@@ -62,6 +62,18 @@ public interface IContext : ICanContainItems
     List<string> LastNouns { get; set; }
 
     /// <summary>
+    ///     Appends a noun to the <see cref="LastNouns" /> antecedent set (case-insensitive, de-duplicated).
+    ///     Used as individual items are taken/dropped so a following "them" spans the whole run.
+    /// </summary>
+    void RememberAntecedentNoun(string? noun);
+
+    /// <summary>
+    ///     Replaces the <see cref="LastNouns" /> antecedent set wholesale (case-insensitive, de-duplicated),
+    ///     ignoring empties. Used by batch take/drop ("take all", "take X and Y").
+    /// </summary>
+    void RememberAntecedentNouns(IEnumerable<string?> nouns);
+
+    /// <summary>
     ///     Tracks the last player input for pronoun resolution.
     /// </summary>
     /// <remarks>

--- a/Model/Interface/IContext.cs
+++ b/Model/Interface/IContext.cs
@@ -51,6 +51,17 @@ public interface IContext : ICanContainItems
     string LastNoun { get; set; }
 
     /// <summary>
+    ///     The set of nouns the player most recently referred to as a group — populated by "take all",
+    ///     "drop all", "take/drop X and Y", or several consecutive individual takes/drops.
+    /// </summary>
+    /// <remarks>
+    ///     This is the antecedent for the plural pronoun "them", which a single <see cref="LastNoun" />
+    ///     string cannot represent. Without it, a command like "take all. drop them" dead-ends because
+    ///     a collection of distinct singular items has no single plural noun to resolve against (issue #248).
+    /// </remarks>
+    List<string> LastNouns { get; set; }
+
+    /// <summary>
     ///     Tracks the last player input for pronoun resolution.
     /// </summary>
     /// <remarks>

--- a/Model/Verbs.cs
+++ b/Model/Verbs.cs
@@ -5,6 +5,18 @@
 /// </summary>
 public static class Verbs
 {
+    /// <summary>
+    ///     The "pick it up" family. Kept here as the single source of truth so the take/drop processor,
+    ///     the pronoun resolver, and the "them" antecedent tracking all agree on what counts as taking.
+    /// </summary>
+    public static readonly string[] TakeVerbs = ["take", "get", "grab", "pick up", "hold", "acquire", "snatch"];
+
+    /// <summary>
+    ///     The "put it down" family. A short list today (the engine only acts on "drop"), but centralized
+    ///     so adding a synonym updates the processor and pronoun scoping together rather than drifting.
+    /// </summary>
+    public static readonly string[] DropVerbs = ["drop"];
+
     public static readonly string[] DrinkVerbs = ["swallow", "sip", "drink", "consume", "gulp", "guzzle", "slurp"];
     public static readonly string[] FixVerbs = ["fix", "repair", "seal", "patch", "stop", "block", "mend", "plug"];
     public static readonly string[] ApplyVerbs = ["use", "apply", "stick", "put", "place", "spread", "smear", "press"];

--- a/UnitTests/EngineTestsBase.cs
+++ b/UnitTests/EngineTestsBase.cs
@@ -31,18 +31,10 @@ public class EngineTestsBase : EngineTestsBaseCommon<ZorkIContext>
 
         TakeAndDropParser = new Mock<IAITakeAndAndDropParser>();
         TakeAndDropParser.Setup(s => s.GetListOfItemsToDrop(It.IsAny<string>(), It.IsAny<string>()))
-            .ReturnsAsync((string input, string context) =>
-            {
-                var words = input.Split(' ', StringSplitOptions.RemoveEmptyEntries);
-                return words.Length > 1 ? [words[1]] : [];
-            });
+            .ReturnsAsync((string input, string context) => ParseItemList(input));
 
         TakeAndDropParser.Setup(s => s.GetListOfItemsToTake(It.IsAny<string>(), It.IsAny<string>()))
-            .ReturnsAsync((string input, string context) =>
-            {
-                var words = input.Split(' ', StringSplitOptions.RemoveEmptyEntries);
-                return words.Length > 1 ? [words[1]] : [];
-            });
+            .ReturnsAsync((string input, string context) => ParseItemList(input));
 
         // Create a mock ParseConversation that mimics the old pattern behavior
         var mockParseConversation = CreateMockParseConversation();
@@ -59,6 +51,26 @@ public class EngineTestsBase : EngineTestsBaseCommon<ZorkIContext>
         return engine;
     }
     
+    /// <summary>
+    /// Stands in for the real AI take/drop list parser. A multi-item command ("drop lamp and sword")
+    /// is split on "and"/commas into its individual nouns, mirroring what the LLM does; a single-item
+    /// command keeps the original second-word behavior so existing tests are unaffected.
+    /// </summary>
+    private static string[] ParseItemList(string input)
+    {
+        var words = input.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        if (words.Length <= 1)
+            return [];
+
+        var afterVerb = string.Join(' ', words.Skip(1));
+        var parts = afterVerb
+            .Split([" and ", " & ", ","], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Where(s => !string.IsNullOrWhiteSpace(s))
+            .ToArray();
+
+        return parts.Length > 1 ? parts : [words[1]];
+    }
+
     private static Mock<IParseConversation> CreateMockParseConversation()
     {
         var mockParseConversation = new Mock<IParseConversation>();

--- a/UnitTests/GlobalCommands/ItProcessorTests.cs
+++ b/UnitTests/GlobalCommands/ItProcessorTests.cs
@@ -1,4 +1,5 @@
 using GameEngine;
+using Model.AIGeneration.Requests;
 
 namespace UnitTests.GlobalCommands;
 
@@ -112,5 +113,28 @@ public class ItProcessorTests : EngineTestsBase
         result.Should().Contain("Dropped");
         target.Context.HasItem<Lantern>().Should().BeFalse();
         target.Context.HasItem<Sword>().Should().BeFalse();
+    }
+
+    // Issue #248 (review follow-up): "them" must only resolve to members still relevant to the
+    // command. An item dropped between takes is no longer held, so "drop them" should drop only what
+    // is still in hand — not drag the already-dropped item back in and trigger a spurious
+    // "you don't have it" narration.
+    [Test]
+    public async Task Them_DoesNotReferToItemsNoLongerInScope()
+    {
+        var target = GetTarget();
+        target.Context.CurrentLocation = Repository.GetLocation<LivingRoom>();
+
+        await target.GetResponse("take lantern");
+        await target.GetResponse("take sword");
+        await target.GetResponse("drop lantern"); // lantern leaves inventory, but was remembered
+
+        var result = await target.GetResponse("drop them");
+
+        result.Should().Contain("Dropped");
+        target.Context.HasItem<Sword>().Should().BeFalse();
+        // No AI narration should fire for the stale lantern that is no longer held.
+        Client.Verify(c => c.GenerateNarration(
+            It.IsAny<DropSomethingTheyDoNotHave>(), It.IsAny<string>()), Times.Never);
     }
 }

--- a/UnitTests/GlobalCommands/ItProcessorTests.cs
+++ b/UnitTests/GlobalCommands/ItProcessorTests.cs
@@ -115,6 +115,25 @@ public class ItProcessorTests : EngineTestsBase
         target.Context.HasItem<Sword>().Should().BeFalse();
     }
 
+    // Issue #248 (review follow-up): "them" must span only a *contiguous* run of take/drop
+    // commands. An unrelated interaction between two takes ends the group, so an item taken before
+    // that interaction is not swept into a later "drop them".
+    [Test]
+    public async Task Them_DoesNotSpanUnrelatedInterveningCommands()
+    {
+        var target = GetTarget();
+        target.Context.CurrentLocation = Repository.GetLocation<LivingRoom>();
+
+        await target.GetResponse("take lantern");  // group so far: [lantern]
+        await target.GetResponse("examine sword"); // unrelated action ends the group
+        await target.GetResponse("take sword");    // fresh group: [sword]
+
+        await target.GetResponse("drop them");
+
+        target.Context.HasItem<Lantern>().Should().BeTrue(
+            because: "the lantern was taken before an intervening non-take/drop command, so it is not part of \"them\"");
+    }
+
     // Issue #248 (review follow-up): "them" must only resolve to members still relevant to the
     // command. An item dropped between takes is no longer held, so "drop them" should drop only what
     // is still in hand — not drag the already-dropped item back in and trigger a spurious

--- a/UnitTests/GlobalCommands/ItProcessorTests.cs
+++ b/UnitTests/GlobalCommands/ItProcessorTests.cs
@@ -73,4 +73,44 @@ public class ItProcessorTests : EngineTestsBase
         target.Context.HasItem<Lantern>().Should().BeTrue();
         result.Should().Contain("Taken");
     }
+
+    // Issue #248: "them" must resolve to a *collection* of items, not just a single
+    // intrinsically-plural item (like candles). After "take all" the player should be
+    // able to say "drop them" and have everything they just took be dropped.
+    [Test]
+    public async Task Them_AfterTakeAll_DropsEverythingTaken()
+    {
+        var target = GetTarget();
+        target.Context.CurrentLocation = Repository.GetLocation<LivingRoom>();
+
+        await target.GetResponse("take all");
+        target.Context.HasItem<Lantern>().Should().BeTrue();
+        target.Context.HasItem<Sword>().Should().BeTrue();
+
+        var result = await target.GetResponse("drop them");
+
+        result.Should().NotContain("What item are you referring to");
+        result.Should().Contain("Dropped");
+        target.Context.HasItem<Lantern>().Should().BeFalse();
+        target.Context.HasItem<Sword>().Should().BeFalse();
+    }
+
+    // Issue #248: a collection built up from several individual takes should also be
+    // addressable as "them".
+    [Test]
+    public async Task Them_AfterSeveralIndividualTakes_DropsAllOfThem()
+    {
+        var target = GetTarget();
+        target.Context.CurrentLocation = Repository.GetLocation<LivingRoom>();
+
+        await target.GetResponse("take lantern");
+        await target.GetResponse("take sword");
+
+        var result = await target.GetResponse("drop them");
+
+        result.Should().NotContain("What item are you referring to");
+        result.Should().Contain("Dropped");
+        target.Context.HasItem<Lantern>().Should().BeFalse();
+        target.Context.HasItem<Sword>().Should().BeFalse();
+    }
 }

--- a/UnitTests/GlobalCommands/PronounResolutionTests.cs
+++ b/UnitTests/GlobalCommands/PronounResolutionTests.cs
@@ -318,11 +318,7 @@ public class PronounResolutionTests : EngineTestsBase
             target.Context.LastNoun.Should().BeEmpty(
                 because: "An item left behind in the previous room is no longer the antecedent");
         }
-    }
 
-    [TestFixture]
-    public class AntecedentSurvivesMovement : PronounResolutionTests
-    {
         [Test]
         public async Task It_AfterMove_StillResolves_ForCarriedItem()
         {

--- a/UnitTests/GlobalCommands/PronounResolutionTests.cs
+++ b/UnitTests/GlobalCommands/PronounResolutionTests.cs
@@ -287,8 +287,10 @@ public class PronounResolutionTests : EngineTestsBase
         }
 
         [Test]
-        public async Task LastNoun_ShouldBeClearedAfterSuccessfulMove()
+        public async Task LastNoun_ShouldSurviveMove_WhenItemIsStillCarried()
         {
+            // Issue #248: moving used to clear the antecedent unconditionally, even for an item
+            // the player is still holding. "it" should keep referring to a carried item after a move.
             var target = GetTarget();
             target.Context.CurrentLocation = Repository.GetLocation<LivingRoom>();
 
@@ -297,8 +299,47 @@ public class PronounResolutionTests : EngineTestsBase
 
             // Move east (to Kitchen) - this is a valid move
             await target.GetResponse("east");
+            target.Context.LastNoun.Should().Be("lantern",
+                because: "Movement keeps the antecedent for items the player is still carrying");
+        }
+
+        [Test]
+        public async Task LastNoun_ShouldBeClearedAfterMove_WhenItemWasLeftBehind()
+        {
+            // Issue #248: the antecedent should only be forgotten for items left behind in the
+            // previous room. The rug stays in the Living Room, so "it" no longer refers to it.
+            var target = GetTarget();
+            target.Context.CurrentLocation = Repository.GetLocation<LivingRoom>();
+
+            await target.GetResponse("examine rug");
+            target.Context.LastNoun.Should().Be("rug");
+
+            await target.GetResponse("east");
             target.Context.LastNoun.Should().BeEmpty(
-                because: "Successful movement should clear LastNoun");
+                because: "An item left behind in the previous room is no longer the antecedent");
+        }
+    }
+
+    [TestFixture]
+    public class AntecedentSurvivesMovement : PronounResolutionTests
+    {
+        [Test]
+        public async Task It_AfterMove_StillResolves_ForCarriedItem()
+        {
+            // Issue #248: "take lantern; examine it; <move>; drop it" should drop the lantern,
+            // because it is still in the player's hand after walking to the next room.
+            var target = GetTarget();
+            target.Context.CurrentLocation = Repository.GetLocation<LivingRoom>();
+
+            await target.GetResponse("take lantern");
+            await target.GetResponse("examine it");
+            await target.GetResponse("east");
+
+            var result = await target.GetResponse("drop it");
+
+            result.Should().NotContain("What item are you referring to");
+            result.Should().Contain("Dropped");
+            target.Context.HasItem<Lantern>().Should().BeFalse();
         }
     }
 }

--- a/UnitTests/IntentEngine/MoveEngineTests.cs
+++ b/UnitTests/IntentEngine/MoveEngineTests.cs
@@ -27,6 +27,9 @@ public class MoveEngineTests
         _mockContext.Setup(c => c.CurrentLocation).Returns(_mockCurrentLocation.Object);
         _mockContext.Setup(c => c.CarryingWeight).Returns(0);
         _mockContext.SetupProperty(c => c.LastNoun);
+        // LastNouns is non-nullable on the real Context (initialized to new()); mirror that here so
+        // the move-time antecedent prune has a list to filter.
+        _mockContext.SetupProperty(c => c.LastNouns, new List<string>());
     }
 
     private MoveEngine _moveEngine;


### PR DESCRIPTION
Fixes #248.

## Problem

Pronoun resolution was built on a single `context.LastNoun` string that can't represent a *set* of items, and movement cleared it unconditionally. Two natural commands broke (confirmed deterministically, no AI):

**A. `them` never resolved to a collection.** After acting on multiple items, `them` fell through to the clarification prompt:
```
take all              ; drop them   ->  "What item are you referring to?"
take lantern ; take sword ; drop them  ->  "What item are you referring to?"
```
It only worked for a single item that was intrinsically `IPluralNoun` (e.g. candles), because `ItProcessor.Check` resolved `them` against a single noun string.

**B. Movement cleared the antecedent even for carried items.**
```
take lantern ; examine it ; <go> ; drop it   ->  "What item are you referring to?"
```
`MoveEngine` did `context.LastNoun = ""` unconditionally, so `it` stopped resolving to an item the player was still holding.

## Fix

- Added `IContext.LastNouns` — the set of nouns the player last referred to as a group.
- Populate it from `take all` / `drop all`, multi-item take/drop, and several consecutive individual takes/drops.
- `ItProcessor` now resolves `them` against that set, expanding it into a conjoined noun list (`"sword and lantern"`) that the existing take/drop list handling already understands. The previous single-`IPluralNoun` behavior (candles) is preserved as a fallback.
- `MoveEngine` now only forgets antecedents for items left behind in the previous room; items still carried keep resolving via `it`/`them` after a move.

## Tests (TDD)

Added deterministic, no-AI tests that were red before the fix and green after:

- `ItProcessorTests`: `take all` → `drop them` drops everything taken; `take lantern; take sword; drop them` drops both.
- `PronounResolutionTests`: `it` survives a move for a carried item (`take lantern; examine it; east; drop it` → `Dropped`); an item left behind is correctly forgotten; updated the old test that asserted the buggy unconditional clear.

The default take/drop list-parser test mock now splits multi-item commands on `and`/commas, mirroring the real AI parser (existing multi-item tests that override the mock are unaffected).

### Verification

All affected suites pass locally:

| Suite | Result |
| --- | --- |
| UnitTests | 838 passed |
| ZorkOne.Tests | 1226 passed |
| Planetfall.Tests | 2232 passed |
| EscapeRoom.Tests | 7 passed |

(The `Lambda.Tests` project fails to NuGet-restore in this environment due to a pre-existing `Amazon.Lambda.Core` version conflict (NU1605), unrelated to these source-only changes.)

### Notes / out of scope

The issue also lists `take all. put them in the case`. `them` now *resolves* to the collection there too, but multi-item `put` is a separate engine limitation (`MultiNounEngine` handles a single direct object), so that command isn't fully wired up by this PR. The deterministic, high-value `drop them` / `take them` failures from the issue are fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jq5zWs11mtLpkSzYBWgtW4)_