### PR TITLE
Fix Floyd activation points farmed during wake-up countdown

### DIFF
--- a/Planetfall.Tests/FloydTests.cs
+++ b/Planetfall.Tests/FloydTests.cs
@@ -433,6 +433,26 @@ public class FloydTests : EngineTestsBase
     }
 
     [Test]
+    public async Task Activate_RepeatedDuringCountdown_AwardsPointsOnce()
+    {
+        var target = GetTarget();
+        StartHere<RobotShop>();
+        var floyd = GetItem<Floyd>();
+
+        // Turning Floyd on is worth 2 points, exactly once. He doesn't actually wake until a
+        // 3-turn countdown elapses, and HasEverBeenOn isn't set until then -- so a guard keyed on
+        // HasEverBeenOn re-awards the 2 points on every repeated "activate floyd" issued during the
+        // countdown (score climbs 2 -> 4 -> 6). The score must stay at 2 no matter how many times
+        // the player re-issues the command before Floyd comes alive.
+        await target.GetResponse("activate floyd"); // countdown 3 -> 2
+        await target.GetResponse("activate floyd"); // countdown 2 -> 1
+        await target.GetResponse("activate floyd"); // countdown 1 -> wake
+
+        floyd.IsOn.Should().BeTrue();
+        target.Context.Score.Should().Be(2);
+    }
+
+    [Test]
     public async Task FloydWakesUp_PlayerStaysInRoom_NormalMessage()
     {
         var target = GetTarget();

--- a/Planetfall.Tests/FloydTests.cs
+++ b/Planetfall.Tests/FloydTests.cs
@@ -453,6 +453,30 @@ public class FloydTests : EngineTestsBase
     }
 
     [Test]
+    public async Task Activate_AfterWaking_DeactivateReactivate_DoesNotReAwardPoints()
+    {
+        var target = GetTarget();
+        StartHere<RobotShop>();
+        var floyd = GetItem<Floyd>();
+
+        // Wake Floyd normally (the one-time +2 is paid here).
+        await target.GetResponse("activate floyd"); // countdown 3 -> 2
+        await target.GetResponse("wait");           // 2 -> 1
+        await target.GetResponse("wait");           // 1 -> wake
+        floyd.IsOn.Should().BeTrue();
+        target.Context.Score.Should().Be(2);
+
+        // Turning him off and back on (now that he's already woken once) must never re-award the
+        // activation bonus -- the one-shot flag is set and never reset.
+        await target.GetResponse("turn off floyd");
+        await target.GetResponse("turn on floyd");
+        await target.GetResponse("turn off floyd");
+        await target.GetResponse("turn on floyd");
+
+        target.Context.Score.Should().Be(2);
+    }
+
+    [Test]
     public async Task FloydWakesUp_PlayerStaysInRoom_NormalMessage()
     {
         var target = GetTarget();

--- a/Planetfall/Item/Kalamontee/Mech/FloydPart/Floyd.cs
+++ b/Planetfall/Item/Kalamontee/Mech/FloydPart/Floyd.cs
@@ -43,6 +43,12 @@ public class Floyd : QuirkyCompanion, IAmANamedPerson, ICanHoldItems, ICanBeGive
 
     [UsedImplicitly] public bool HasEverBeenOn { get; set; }
 
+    // Tracks whether the one-time +2 award for turning Floyd on has already been granted. We can't
+    // key this off HasEverBeenOn: that flag only flips when Floyd actually wakes (after a 3-turn
+    // countdown), so during the countdown every repeated "activate floyd" would otherwise re-award
+    // the points (score 2 -> 4 -> 6). This dedicated guard makes the award strictly once.
+    [UsedImplicitly] public bool HasAwardedActivationPoints { get; set; }
+
     [UsedImplicitly] public bool HasEverGoneThroughTheLittleDoor { get; set; }
 
     [UsedImplicitly] public bool HasGottenTheFromitzBoard { get; set; }

--- a/Planetfall/Item/Kalamontee/Mech/FloydPart/FloydPowerManager.cs
+++ b/Planetfall/Item/Kalamontee/Mech/FloydPart/FloydPowerManager.cs
@@ -12,8 +12,14 @@ public class FloydPowerManager(Floyd floyd)
 
         context.RegisterActor(floyd);
 
-        if (!floyd.HasEverBeenOn)
+        // Award the activation points exactly once. HasEverBeenOn isn't set until Floyd finishes
+        // his wake-up countdown, so guarding on it would re-award on every repeated activation
+        // during the countdown. Use the dedicated one-shot flag instead.
+        if (!floyd.HasAwardedActivationPoints)
+        {
             context.AddPoints(2);
+            floyd.HasAwardedActivationPoints = true;
+        }
 
         if (floyd.TurnOnCountdown > 0)
             return new PositiveInteractionResult("Nothing happens. ");


### PR DESCRIPTION
## Bug

Turning Floyd on is worth **2 points, once**. But when you `activate floyd`, he doesn't wake immediately — there's a 3-turn countdown, and `HasEverBeenOn` (the flag that guarded the point award) only flips when that countdown *completes*. So every repeated `activate floyd` issued **during** the countdown re-awarded the 2 points:

```
activate floyd   -> "Nothing happens."   score 0 -> 2
activate floyd   -> "Nothing happens."   score 2 -> 4
activate floyd   -> "...the robot comes to life..."  score 4 -> 6
```

A player could pad their score by +4 by spamming the command before Floyd wakes. Found by the AdventureBreaker playtest harness.

## Fix

Add a dedicated one-shot `HasAwardedActivationPoints` flag and gate the `AddPoints(2)` on it. `HasEverBeenOn` is left untouched because it also drives Floyd's wake-up timing and the room-description flavor — repurposing it would prematurely change those. Deactivate/reactivate after waking already awarded nothing, and still does.

## TDD

- `Activate_RepeatedDuringCountdown_AwardsPointsOnce` (new) — fails before the fix (`score 6`), passes after.
- Full `Planetfall.Tests` suite green: **2233 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DsEMy2gYe2qexc95aJR4KR

---
_Generated by [Claude Code](https://claude.ai/code/session_01DsEMy2gYe2qexc95aJR4KR)_