### PR TITLE
Fix #255: Floyd lab-death message no longer repeats every turn

### DIFF
--- a/Planetfall.Tests/BioLockEastTests.cs
+++ b/Planetfall.Tests/BioLockEastTests.cs
@@ -511,6 +511,33 @@ public class BioLockEastTests : EngineTestsBase
     }
 
     [Test]
+    public async Task Wait_AfterFloydDiesInLab_DeathMessageDoesNotRepeatEveryTurn()
+    {
+        var target = GetTarget();
+        var floyd = GetItem<Floyd>();
+        floyd.IsOn = true;
+        var bioLockEast = StartHere<BioLockEast>();
+        bioLockEast.ItemPlacedHere(floyd);
+        bioLockEast.StateMachine.HasWaitedOneTurnInBioLockEast = true; // Skip the one-turn delay
+        bioLockEast.StateMachine.LabSequenceState = FloydLabSequenceState.NeedToReopenDoor;
+        target.Context.RegisterActor(bioLockEast);
+
+        // Turn 1: the player never reopened the door, so Floyd dies trapped in the lab.
+        var first = await target.GetResponse("wait");
+        first.Should().Contain(FloydConstants.FloydDies);
+        floyd.HasDied.Should().BeTrue();
+
+        // The death must be announced exactly once. Previously the state stayed NeedToReopenDoor
+        // and BioLockEast remained a registered actor, so "...Floyd is dead." re-fired on every
+        // subsequent turn forever.
+        var second = await target.GetResponse("wait");
+        second.Should().NotContain(FloydConstants.FloydDies);
+
+        var third = await target.GetResponse("wait");
+        third.Should().NotContain(FloydConstants.FloydDies);
+    }
+
+    [Test]
     public async Task SuccessfulSequence_FloydReturnsWithCard_FloydHasDiedFlagSet()
     {
         var target = GetTarget();

--- a/Planetfall/Location/Lawanda/Lab/BioLockStateMachineManager.cs
+++ b/Planetfall/Location/Lawanda/Lab/BioLockStateMachineManager.cs
@@ -100,10 +100,15 @@ public class BioLockStateMachineManager
             return string.Empty; // Give player one turn to close the door
         }
 
-        // Player failed to reopen door after InTheLabThree - Floyd dies
+        // Player failed to reopen door after InTheLabThree - Floyd dies trapped in the lab (the
+        // mini access card is lost with him). Make the sequence terminal and stop the BioLockEast
+        // actor; otherwise the state stays NeedToReopenDoor and this branch re-announces Floyd's
+        // death on every subsequent turn forever.
         if (LabSequenceState == FloydLabSequenceState.NeedToReopenDoor)
         {
             floyd.HasDied = true;
+            LabSequenceState = FloydLabSequenceState.Completed;
+            context.RemoveActor(Repository.GetLocation<BioLockEast>());
             return FloydConstants.FloydDies;
         }
 


### PR DESCRIPTION
Fixes #255.

## Bug
In the bio-lock Floyd sacrifice sequence, if the player **never reopens the door** after Floyd knocks (`NeedToReopenDoor`), Floyd dies — but `"...Floyd is dead."` re-fired on **every subsequent turn forever**. The branch set `HasDied` and returned the message but never advanced `LabSequenceState` nor unregistered the `BioLockEast` actor, so `Act()` kept hitting the same branch.

## Fix
Make the branch terminal: `LabSequenceState = Completed` + unregister the `BioLockEast` actor → the death is announced exactly once. Floyd died trapped, so no card/body/points are placed (only the success path delivers those). The player-death non-solution paths were already clean (they route through `DeathProcessor`).

## TDD
`BioLockEastTests.Wait_AfterFloydDiesInLab_DeathMessageDoesNotRepeatEveryTurn` — fails before (2nd `wait` still contains the death text), passes after. Full `Planetfall.Tests` green: **2240 passed**.

Found by the AdventureBreaker harness probing every bio-lock non-solution (don't-reopen, don't-close, open-while-fighting, open-when-not-ready). Logged as AB-014.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DsEMy2gYe2qexc95aJR4KR

---
_Generated by [Claude Code](https://claude.ai/code/session_01DsEMy2gYe2qexc95aJR4KR)_