### PR TITLE
Fix #252: library terminal ignores keypresses while turned off

### DIFF
--- a/Planetfall.Tests/ComputerTerminalTests.cs
+++ b/Planetfall.Tests/ComputerTerminalTests.cs
@@ -95,6 +95,24 @@ public class ComputerTerminalTests : EngineTestsBase
     }
 
     [Test]
+    public async Task Off_TypeNonNumericKey_DoesNotNavigateMenu_AndScreenIsDark()
+    {
+        var target = GetTarget();
+        StartHere<LibraryLobby>();
+
+        var terminal = GetItem<ComputerTerminal>();
+        terminal.IsOn.Should().BeFalse();
+
+        // Even garbage input reports a dark screen: the IsOn guard sits *before* the
+        // keyPress.HasValue check, so an off terminal can't even complain about a bad keystroke.
+        var response = await target.GetResponse("type dude");
+
+        terminal.MenuState.CurrentItem.Should().BeOfType<MainMenu>();
+        response.Should().Contain("screen is dark");
+        response.Should().NotContain("keys 0 through 9");
+    }
+
+    [Test]
     public async Task Off_TypeKey_FloydDoesNotComment()
     {
         var target = GetTarget();
@@ -110,7 +128,8 @@ public class ComputerTerminalTests : EngineTestsBase
 
         await target.GetResponse("type 1");
 
-        // Floyd must not comment on "first use" while the screen is dark.
+        // Floyd must not comment on "first use" while the screen is dark, and the menu must not move.
+        GetItem<ComputerTerminal>().MenuState.CurrentItem.Should().BeOfType<MainMenu>();
         var pfContext = (PlanetfallContext)target.Context;
         pfContext.PendingFloydActionCommentPrompt.Should().BeNull();
     }

--- a/Planetfall.Tests/ComputerTerminalTests.cs
+++ b/Planetfall.Tests/ComputerTerminalTests.cs
@@ -64,6 +64,58 @@ public class ComputerTerminalTests : EngineTestsBase
     }
 
     [Test]
+    public async Task Off_TypeKey_DoesNotNavigateMenu_AndScreenIsDark()
+    {
+        var target = GetTarget();
+        StartHere<LibraryLobby>();
+
+        var terminal = GetItem<ComputerTerminal>();
+        terminal.IsOn.Should().BeFalse();
+
+        var response = await target.GetResponse("type 1");
+
+        // The keypress must not navigate the menu while the terminal is off.
+        terminal.MenuState.CurrentItem.Should().BeOfType<MainMenu>();
+        response.Should().Contain("screen is dark");
+    }
+
+    [Test]
+    public async Task Off_TypeKeyMultiNoun_DoesNotNavigateMenu_AndScreenIsDark()
+    {
+        var target = GetTarget();
+        StartHere<LibraryLobby>();
+
+        var terminal = GetItem<ComputerTerminal>();
+        terminal.IsOn.Should().BeFalse();
+
+        var response = await target.GetResponse("type 1 on the keyboard");
+
+        terminal.MenuState.CurrentItem.Should().BeOfType<MainMenu>();
+        response.Should().Contain("screen is dark");
+    }
+
+    [Test]
+    public async Task Off_TypeKey_FloydDoesNotComment()
+    {
+        var target = GetTarget();
+        var libraryLobby = GetLocation<LibraryLobby>();
+        target.Context.CurrentLocation = libraryLobby;
+
+        // Floyd present and active, but the terminal is off.
+        var floyd = GetItem<Floyd>();
+        floyd.IsOn = true;
+        floyd.HasEverBeenOn = true;
+        floyd.CurrentLocation = libraryLobby;
+        libraryLobby.ItemPlacedHere(floyd);
+
+        await target.GetResponse("type 1");
+
+        // Floyd must not comment on "first use" while the screen is dark.
+        var pfContext = (PlanetfallContext)target.Context;
+        pfContext.PendingFloydActionCommentPrompt.Should().BeNull();
+    }
+
+    [Test]
     public async Task On_Examine()
     {
         var target = GetTarget();

--- a/Planetfall/Item/Lawanda/Library/Computer/ComputerTerminal.cs
+++ b/Planetfall/Item/Lawanda/Library/Computer/ComputerTerminal.cs
@@ -79,6 +79,12 @@ public class ComputerTerminal : ItemBase, ICanBeExamined, ICanBeRead, ITurnOffAn
     /// </summary>
     private InteractionResult ProcessKeyPress(int? keyPress, IContext context)
     {
+        // A dark screen takes no input: gate keypresses on power so the menu can't be blind-navigated
+        // (and Floyd can't comment on "first use") while the terminal is off — matching how
+        // ExaminationDescription and ReadDescription already report "The screen is dark." when off.
+        if (!IsOn)
+            return new PositiveInteractionResult("Nothing happens; the screen is dark. ");
+
         if (!keyPress.HasValue)
             return new PositiveInteractionResult("The keyboard only has the keys 0 through 9");
 


### PR DESCRIPTION
## Summary

Fixes #252. The Library computer terminal (`LibraryLobby`) processed keypresses **even when it was turned off**. Typing a digit navigated the terminal's `MenuState` (and fired Floyd's "first use of the library computer" comment) while the screen reported "The screen is dark." — an inconsistent state. A player could blind-navigate the entire menu tree with the screen dark, then turn it on and land mid-tree instead of at the main menu.

The terminal's `ExaminationDescription` and `ReadDescription` already gate on `IsOn`; the keypress handler did not.

## Root cause

`ProcessKeyPress` — the shared entry point for both `RespondToSimpleInteraction` (`type 1`) and `RespondToMultiNounInteraction` (`type 1 on the keyboard`) — applied the keypress with no power check, mutating `MenuState` and prompting Floyd regardless of `IsOn`.

## Fix

Guard `ProcessKeyPress` on `IsOn` before mutating `MenuState` or prompting Floyd. When off, it now returns "Nothing happens; the screen is dark. ", mirroring how the examine/read descriptions already report a dark screen. Because both `RespondTo*` entry points funnel through `ProcessKeyPress`, the single guard covers the single-noun and multi-noun phrasings.

## Tests (TDD — red → green)

Added four deterministic tests to `ComputerTerminalTests` (no AI, no randomness). With the terminal off:

- `Off_TypeKey_DoesNotNavigateMenu_AndScreenIsDark` — `type 1` leaves `MenuState.CurrentItem` as `MainMenu` and reports a dark screen.
- `Off_TypeKeyMultiNoun_DoesNotNavigateMenu_AndScreenIsDark` — same for `type 1 on the keyboard`.
- `Off_TypeNonNumericKey_DoesNotNavigateMenu_AndScreenIsDark` — `type dude` reports a dark screen (not "keys 0 through 9"), locking in that the `IsOn` guard sits before the `keyPress.HasValue` check.
- `Off_TypeKey_FloydDoesNotComment` — Floyd does not fire his "first use" comment while the screen is dark.

The original three were red before the fix (menu advanced to `HistoryMenu`, Floyd commented) and are green after. Full `Planetfall.Tests` suite passes (2243 passed, 1 skipped), confirming no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QqQEfh147iEXLeKMKBXyEa