### PR TITLE
Fix "them" antecedent for multi-item single commands (#248 follow-up)

### DIFF
--- a/GameEngine/StaticCommand/Implementation/DropEverythingProcessor.cs
+++ b/GameEngine/StaticCommand/Implementation/DropEverythingProcessor.cs
@@ -47,7 +47,6 @@ public class DropEverythingProcessor : IGlobalCommand
     public static async Task<string> DropAll(IContext context, List<(string noun, IItem? item)> itemsWithNouns, IGenerationClient client)
     {
         var sb = new StringBuilder();
-        var dropped = new List<string?>();
 
         foreach (var (noun, item) in itemsWithNouns)
         {
@@ -69,14 +68,12 @@ public class DropEverythingProcessor : IGlobalCommand
             }
 
             if (item is ICanBeTakenAndDropped)
-            {
+                // DropIt records each item in the "them" group (append), so a "drop X and Y" command
+                // extends the player's contiguous drop run rather than replacing it (issue #248).
                 sb.AppendLine(
                     $"{item.Name}: {TakeOrDropInteractionProcessor.DropIt(context, item).InteractionMessage}");
-                dropped.Add(item.NounsForMatching.FirstOrDefault());
-            }
         }
 
-        context.RememberAntecedentNouns(dropped);
         return sb.ToString();
     }
 }

--- a/GameEngine/StaticCommand/Implementation/TakeEverythingProcessor.cs
+++ b/GameEngine/StaticCommand/Implementation/TakeEverythingProcessor.cs
@@ -62,7 +62,6 @@ public class TakeEverythingProcessor : IGlobalCommand
     public static async Task<string> TakeAll(IContext context, List<(string noun, IItem? item)> itemsWithNouns, IGenerationClient client)
     {
         var sb = new StringBuilder();
-        var taken = new List<string?>();
         foreach (var (noun, item) in itemsWithNouns)
         {
             if (item is null)
@@ -95,10 +94,11 @@ public class TakeEverythingProcessor : IGlobalCommand
 
             sb.AppendLine($"{item.Name}: Taken. ");
             context.ItemPlacedHere(item);
-            taken.Add(item.NounsForMatching.FirstOrDefault());
+            // A "take X and Y" command is part of the player's contiguous take run, so append each
+            // item to the "them" group rather than replacing it (issue #248 review follow-up).
+            context.RememberAntecedentNoun(item.NounsForMatching.FirstOrDefault());
         }
 
-        context.RememberAntecedentNouns(taken);
         return sb.ToString();
     }
 }

--- a/UnitTests/GlobalCommands/ItProcessorTests.cs
+++ b/UnitTests/GlobalCommands/ItProcessorTests.cs
@@ -134,6 +134,26 @@ public class ItProcessorTests : EngineTestsBase
             because: "the lantern was taken before an intervening non-take/drop command, so it is not part of \"them\"");
     }
 
+    // Issue #248 (review follow-up): a multi-item single command ("take sword and ...") is part of
+    // the same contiguous run as a preceding single take, so "them" must span both. The per-command
+    // multi-item path must append to the group, not replace it wholesale.
+    [Test]
+    public async Task Them_SpansSingleTakeThenMultiItemTake()
+    {
+        var target = GetTarget();
+        target.Context.CurrentLocation = Repository.GetLocation<LivingRoom>();
+
+        await target.GetResponse("take lantern");           // [lantern]
+        await target.GetResponse("take sword and unicorn"); // sword taken; unicorn doesn't exist
+
+        var result = await target.GetResponse("drop them");
+
+        result.Should().NotContain("What item are you referring to");
+        target.Context.HasItem<Lantern>().Should().BeFalse(
+            because: "the lantern is part of the same contiguous take run and must stay in \"them\"");
+        target.Context.HasItem<Sword>().Should().BeFalse();
+    }
+
     // Issue #248 (review follow-up): "them" must only resolve to members still relevant to the
     // command. An item dropped between takes is no longer held, so "drop them" should drop only what
     // is still in hand — not drag the already-dropped item back in and trigger a spurious


### PR DESCRIPTION
Follow-up to #253 (merged), addressing the last automated-review finding that arrived as that PR merged.

## Problem

A multi-item **single** command like `take sword and rope` routes through the batch take/drop helpers (`TakeAll`/`DropAll` `itemsWithNouns` overloads), which **replaced** the `LastNouns` "them" group wholesale. But such a command is part of the player's contiguous take/drop run, so replacing wipes earlier items:

```
take lantern            ; LastNouns = [lantern]
take sword and unicorn  ; multi-item path REPLACED -> LastNouns = [sword]  (lantern lost; unicorn doesn't exist)
drop them               ; Count == 1, sword isn't plural -> "What item are you referring to?"
```

That's the exact dead-end #248 set out to fix, reached via a slightly different path (a multi-item command instead of a plain single one). It only bit the multi-item branch — genuine consecutive single takes already appended correctly.

## Fix

The per-command multi-item helpers now **append** each item to the group, reserving wholesale-replace for the genuine `take all` / `drop all` processors (the `List<IItem?>` overloads):

- `TakeEverythingProcessor.TakeAll(itemsWithNouns, …)` appends via `context.RememberAntecedentNoun(...)`.
- `DropEverythingProcessor.DropAll(itemsWithNouns, …)` relies on `DropIt`'s existing per-item append rather than a trailing wholesale replace (removing a redundant double-write in the process).

So `take lantern. take sword and rope. drop them` now drops all three.

## Tests (TDD)

New `ItProcessorTests.Them_SpansSingleTakeThenMultiItemTake` — red before, green after. Full suites green: UnitTests 842, ZorkOne.Tests 1226, Planetfall.Tests 2239, EscapeRoom.Tests 7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jq5zWs11mtLpkSzYBWgtW4)_