### PR TITLE
Fix #238: hide location exits and action chips in the dark in structured payload

### DIFF
--- a/Model/Web/GameResponse.cs
+++ b/Model/Web/GameResponse.cs
@@ -31,8 +31,11 @@ public record GameResponse(
         gameEngine.Inventory,
         // Issue #238: in the dark the prose hides the room, so the structured payload must not leak
         // the location's exits or action chips either. Inventory-derived fields stay populated —
-        // the player can still feel what they're carrying.
-        gameEngine.Context?.ItIsDarkHere == true ? new List<Direction>() : gameEngine.Exits,
+        // the player can still feel what they're carrying. (Context is always initialized in
+        // GameEngine and never null in production; the null fall-throughs here exist only because
+        // IGameEngine.Context is annotated nullable. Both darkness checks use the same idiom so a
+        // future third location-derived field can copy the pattern without re-introducing skew.)
+        gameEngine.Context is { ItIsDarkHere: true } ? new List<Direction>() : gameEngine.Exits,
         gameEngine.Context is { ItIsDarkHere: false } litContext
             ? litContext.CurrentLocation.GetAvailableActionsInLocation()
             : new Dictionary<string, List<string>>(),

--- a/Model/Web/GameResponse.cs
+++ b/Model/Web/GameResponse.cs
@@ -30,12 +30,9 @@ public record GameResponse(
         gameEngine.LastMovementDirection.ToString(),
         gameEngine.Inventory,
         // Issue #238: in the dark the prose hides the room, so the structured payload must not leak
-        // the location's exits or action chips either. Both location-derived fields populate only
-        // when the room is lit; inventory-derived fields stay populated (the player can still feel
-        // what they're carrying). Both checks use the same `is { ItIsDarkHere: false }` polarity so
-        // a future location-derived field can copy the pattern without re-introducing skew. Context
-        // is never null in production (GameEngine.Exits would NRE first), so the non-lit branch also
-        // safely covers the nullable IGameEngine.Context interface contract.
+        // the location's exits or action chips either — both location-derived fields populate only
+        // when the room is lit (same `is { ItIsDarkHere: false }` polarity on each). Inventory-derived
+        // fields stay populated: the player can still feel what they're carrying.
         gameEngine.Context is { ItIsDarkHere: false } ? gameEngine.Exits : new List<Direction>(),
         gameEngine.Context is { ItIsDarkHere: false } litContext
             ? litContext.CurrentLocation.GetAvailableActionsInLocation()

--- a/Model/Web/GameResponse.cs
+++ b/Model/Web/GameResponse.cs
@@ -30,12 +30,13 @@ public record GameResponse(
         gameEngine.LastMovementDirection.ToString(),
         gameEngine.Inventory,
         // Issue #238: in the dark the prose hides the room, so the structured payload must not leak
-        // the location's exits or action chips either. Inventory-derived fields stay populated —
-        // the player can still feel what they're carrying. (Context is always initialized in
-        // GameEngine and never null in production; the null fall-throughs here exist only because
-        // IGameEngine.Context is annotated nullable. Both darkness checks use the same idiom so a
-        // future third location-derived field can copy the pattern without re-introducing skew.)
-        gameEngine.Context is { ItIsDarkHere: true } ? new List<Direction>() : gameEngine.Exits,
+        // the location's exits or action chips either. Both location-derived fields populate only
+        // when the room is lit; inventory-derived fields stay populated (the player can still feel
+        // what they're carrying). Both checks use the same `is { ItIsDarkHere: false }` polarity so
+        // a future location-derived field can copy the pattern without re-introducing skew. Context
+        // is never null in production (GameEngine.Exits would NRE first), so the non-lit branch also
+        // safely covers the nullable IGameEngine.Context interface contract.
+        gameEngine.Context is { ItIsDarkHere: false } ? gameEngine.Exits : new List<Direction>(),
         gameEngine.Context is { ItIsDarkHere: false } litContext
             ? litContext.CurrentLocation.GetAvailableActionsInLocation()
             : new Dictionary<string, List<string>>(),

--- a/Model/Web/GameResponse.cs
+++ b/Model/Web/GameResponse.cs
@@ -29,8 +29,13 @@ public record GameResponse(
         gameEngine.PreviousLocationName,
         gameEngine.LastMovementDirection.ToString(),
         gameEngine.Inventory,
-        gameEngine.Exits,
-        gameEngine.Context?.CurrentLocation.GetAvailableActionsInLocation() ?? new Dictionary<string, List<string>>(),
+        // Issue #238: in the dark the prose hides the room, so the structured payload must not leak
+        // the location's exits or action chips either. Inventory-derived fields stay populated —
+        // the player can still feel what they're carrying.
+        gameEngine.Context?.ItIsDarkHere == true ? new List<Direction>() : gameEngine.Exits,
+        gameEngine.Context is { ItIsDarkHere: false } litContext
+            ? litContext.CurrentLocation.GetAvailableActionsInLocation()
+            : new Dictionary<string, List<string>>(),
         gameEngine.Context?.GetAvailableActionsForInventory() ?? new Dictionary<string, List<string>>())
     {
     }

--- a/UnitTests/Models/GameResponseTests.cs
+++ b/UnitTests/Models/GameResponseTests.cs
@@ -215,6 +215,9 @@ public class GameResponseTests
         mockGameEngine.Setup(ge => ge.LastMovementDirection).Returns(expectedDirectionEnum);
         mockGameEngine.Setup(ge => ge.Inventory).Returns(expectedInventory);
         mockGameEngine.Setup(ge => ge.Exits).Returns(expectedExits);
+        // Explicit: this test exercises the lit branch of the issue #238 darkness gating. Without
+        // this, it would rely on Moq's implicit default (false) for the unconfigured bool.
+        mockGameEngine.Setup(ge => ge.Context!.ItIsDarkHere).Returns(false);
         mockGameEngine.Setup(ge => ge.Context!.GetAvailableActionsForInventory())
             .Returns(availablleActionsFromInventory);
         mockGameEngine.Setup(ge => ge.Context!.CurrentLocation.GetAvailableActionsInLocation())

--- a/UnitTests/Models/GameResponseTests.cs
+++ b/UnitTests/Models/GameResponseTests.cs
@@ -236,6 +236,64 @@ public class GameResponseTests
     }
 
     [Test]
+    public void GameResponse_GameEngineConstructor_WhenDark_ShouldHideLocationExitsAndActions()
+    {
+        // Issue #238: in an unlit dark room the prose hides everything ("It is pitch black..."),
+        // but the structured payload was still leaking the location's exits and action chips.
+        // The location-derived fields must be empty in the dark, mirroring the engine's
+        // existing "too dark to see" prose gating.
+        var populatedExits = new List<Direction> { Direction.S, Direction.N };
+        var locationActions = ApplicableVerbsAttribute.GetAvailableActions([new Lamp()]);
+        var inventoryActions = ApplicableVerbsAttribute.GetAvailableActions([new Lamp()]);
+        List<string> inventory = new() { "lamp" };
+
+        var mockGameEngine = new Mock<IGameEngine>();
+        mockGameEngine.Setup(ge => ge.LocationName).Returns("Cellar");
+        mockGameEngine.Setup(ge => ge.Inventory).Returns(inventory);
+        mockGameEngine.Setup(ge => ge.Exits).Returns(populatedExits);
+        mockGameEngine.Setup(ge => ge.Context!.ItIsDarkHere).Returns(true);
+        mockGameEngine.Setup(ge => ge.Context!.GetAvailableActionsForInventory()).Returns(inventoryActions);
+        mockGameEngine.Setup(ge => ge.Context!.CurrentLocation.GetAvailableActionsInLocation())
+            .Returns(locationActions);
+
+        // Act
+        var gameResponse = new GameResponse(
+            "It is pitch black. You are likely to be eaten by a grue.", mockGameEngine.Object);
+
+        // Assert — location-derived fields are hidden in the dark...
+        gameResponse.Exits.Should().BeEmpty();
+        gameResponse.ActionsAvailableFromLocation.Should().BeEmpty();
+        // ...but inventory-derived fields remain (the player can still feel what they carry).
+        gameResponse.Inventory.Should().BeEquivalentTo(inventory);
+        gameResponse.ActionsAvailableFromInventory.Should().BeEquivalentTo(inventoryActions);
+    }
+
+    [Test]
+    public void GameResponse_GameEngineConstructor_WhenLit_ShouldExposeLocationExitsAndActions()
+    {
+        // Control for issue #238: when the room is lit, the location-derived fields populate normally.
+        var populatedExits = new List<Direction> { Direction.S, Direction.N };
+        var locationActions = ApplicableVerbsAttribute.GetAvailableActions([new Lamp()]);
+        var inventoryActions = ApplicableVerbsAttribute.GetAvailableActions([new Lamp()]);
+
+        var mockGameEngine = new Mock<IGameEngine>();
+        mockGameEngine.Setup(ge => ge.LocationName).Returns("Cellar");
+        mockGameEngine.Setup(ge => ge.Inventory).Returns(new List<string> { "lamp" });
+        mockGameEngine.Setup(ge => ge.Exits).Returns(populatedExits);
+        mockGameEngine.Setup(ge => ge.Context!.ItIsDarkHere).Returns(false);
+        mockGameEngine.Setup(ge => ge.Context!.GetAvailableActionsForInventory()).Returns(inventoryActions);
+        mockGameEngine.Setup(ge => ge.Context!.CurrentLocation.GetAvailableActionsInLocation())
+            .Returns(locationActions);
+
+        // Act
+        var gameResponse = new GameResponse("You are in the cellar.", mockGameEngine.Object);
+
+        // Assert
+        gameResponse.Exits.Should().BeEquivalentTo(populatedExits);
+        gameResponse.ActionsAvailableFromLocation.Should().BeEquivalentTo(locationActions);
+    }
+
+    [Test]
     public void GameResponse_Equality_DifferentValues_ShouldNotBeEqual()
     {
         // Arrange


### PR DESCRIPTION
## Summary

Fixes #238.

When the player is in an unlit dark room, the **prose** correctly hides everything (`It is pitch black. You are likely to be eaten by a grue.`), but the **structured `GameResponse`** still returned the room's `exits` and `actionsAvailableFromLocation`. The web client renders movement/action chips from those fields, so darkness — which is supposed to hide the room — leaked the exits and what's present.

## Root cause

The prose paths respect the canonical darkness predicate `Context.ItIsDarkHere` (`GameEngine/Context.cs:411`), but the structured payload did not:

- `GameResponse.cs` → `Exits = gameEngine.Exits` → `GameEngine.Exits => Context.CurrentLocation.Exits(Context)` (no darkness check).
- `GameResponse.cs` → `ActionsAvailableFromLocation = Context.CurrentLocation.GetAvailableActionsInLocation()` (no darkness check).

## Fix

Gate the location-derived fields on darkness at the single chokepoint that builds the web payload — the `GameResponse(string, IGameEngine)` constructor — returning empty collections when `context.ItIsDarkHere`:

- `Exits` → empty `List<Direction>` in the dark.
- `ActionsAvailableFromLocation` → empty dictionary in the dark.

Inventory-derived fields (`Inventory`, `ActionsAvailableFromInventory`) stay populated — the player can still feel what they're carrying; the leak is specifically the *location's* exits and contents. This mirrors the engine's existing "too dark to see" prose gating in `SimpleInteractionEngine`, `MultiNounEngine`, and `LookProcessor`.

## Tests (TDD)

Added two deterministic tests (no RNG/AI) to `UnitTests/Models/GameResponseTests.cs`, alongside the existing `GameResponse` tests:

- `GameResponse_GameEngineConstructor_WhenDark_ShouldHideLocationExitsAndActions` — with `Context.ItIsDarkHere == true`, asserts `Exits` and `ActionsAvailableFromLocation` are empty while inventory fields remain populated. **Fails before the fix** (leaked `Direction.S`), passes after.
- `GameResponse_GameEngineConstructor_WhenLit_ShouldExposeLocationExitsAndActions` — control: with `ItIsDarkHere == false`, the location fields populate normally.

### Verification

- `dotnet test UnitTests` → **844 passed, 1 skipped, 0 failed** (includes all 9 `GameResponseTests`).

> Note: the `Lambda.Tests` / `Planetfall-Lambda.Tests` projects currently fail to NuGet-restore due to a pre-existing `Amazon.Lambda.Core` (2.2.0 vs 2.8.0 transitive) `NU1605` version conflict, unrelated to this change. The chokepoint itself is fully covered by `UnitTests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018iF31gjD8hx2Z3988s9qne)_