### PR TITLE
Fix #192: stiletto and bloody axe puncture the inflatable boat

### DIFF
--- a/ZorkOne.Tests/BoatTests.cs
+++ b/ZorkOne.Tests/BoatTests.cs
@@ -27,6 +27,46 @@ public class BoatTests : EngineTestsBase
     }
 
     [Test]
+    public async Task GetInTheBoat_Stiletto_Punctures()
+    {
+        // ZIL RBOAT-FUNCTION lists STILETTO among the sharp items that puncture the boat
+        // on boarding (zork1/1actions.zil:2787-2799).
+        var target = GetTarget();
+        Take<Stiletto>();
+        target.Context.CurrentLocation = Repository.GetLocation<DamBase>();
+        var boat = Repository.GetItem<PileOfPlastic>();
+        boat.IsInflated = true;
+
+        var response = await target.GetResponse("get in the boat");
+
+        response.Should().Contain("Oops!");
+        response.Should().Contain("hissing");
+        boat.IsPunctured.Should().BeTrue();
+        boat.IsInflated.Should().BeFalse();
+        target.Context.CurrentLocation.SubLocation.Should().BeNull();
+    }
+
+    [Test]
+    public async Task GetInTheBoat_BloodyAxe_Punctures()
+    {
+        // ZIL RBOAT-FUNCTION lists AXE among the sharp items that puncture the boat
+        // on boarding (zork1/1actions.zil:2787-2799).
+        var target = GetTarget();
+        Take<BloodyAxe>();
+        target.Context.CurrentLocation = Repository.GetLocation<DamBase>();
+        var boat = Repository.GetItem<PileOfPlastic>();
+        boat.IsInflated = true;
+
+        var response = await target.GetResponse("get in the boat");
+
+        response.Should().Contain("Oops!");
+        response.Should().Contain("hissing");
+        boat.IsPunctured.Should().BeTrue();
+        boat.IsInflated.Should().BeFalse();
+        target.Context.CurrentLocation.SubLocation.Should().BeNull();
+    }
+
+    [Test]
     public async Task Deflated_OnTheGround()
     {
         var target = GetTarget();

--- a/ZorkOne/Item/BloodyAxe.cs
+++ b/ZorkOne/Item/BloodyAxe.cs
@@ -4,7 +4,9 @@ using Model.Interface;
 
 namespace ZorkOne.Item;
 
-public class BloodyAxe : ItemBase, ICanBeTakenAndDropped, IWeapon
+// IAmPointyAndPunctureThings: the axe is one of the sharp items that punctures the
+// inflatable boat on boarding (ZIL RBOAT-FUNCTION, zork1/1actions.zil:2787-2799).
+public class BloodyAxe : ItemBase, ICanBeTakenAndDropped, IWeapon, IAmPointyAndPunctureThings
 {
     public override string[] NounsForMatching => ["axe", "bloody axe"];
 

--- a/ZorkOne/Item/Stiletto.cs
+++ b/ZorkOne/Item/Stiletto.cs
@@ -3,7 +3,9 @@ using GameEngine.Item;
 
 namespace ZorkOne.Item;
 
-public class Stiletto : ItemBase, ICanBeTakenAndDropped, IWeapon
+// IAmPointyAndPunctureThings: the stiletto is one of the sharp items that punctures the
+// inflatable boat on boarding (ZIL RBOAT-FUNCTION, zork1/1actions.zil:2787-2799).
+public class Stiletto : ItemBase, ICanBeTakenAndDropped, IWeapon, IAmPointyAndPunctureThings
 {
     public override string[] NounsForMatching => ["stiletto"];
 


### PR DESCRIPTION
Fixes #192.

## Problem

Boarding the inflated magic boat while carrying a sharp object should puncture it. The boarding check in `PileOfPlastic.GetIn` (`ZorkOne/Item/PileOfPlastic.cs:58`) punctures the boat when the player carries any item marked with the `IAmPointyAndPunctureThings` marker interface.

Per the original ZIL (`RBOAT-FUNCTION`, `zork1/1actions.zil:2787-2799`), six sharp items qualify: `SCEPTRE`, `KNIFE`, `SWORD`, `RUSTY-KNIFE`, `AXE`, `STILETTO`. The C# port only carried the marker on four of them (`Sword`, `NastyKnife`, `RustyKnife`, `Sceptre`). `Stiletto` (STILETTO) and `BloodyAxe` (AXE) were missing it, so boarding while holding either silently boarded the boat instead of deflating it — a divergence from the original game.

## Fix

Add the `IAmPointyAndPunctureThings` marker to the `Stiletto` and `BloodyAxe` class declarations. The interface has no members, so nothing else is required. (`ZorkOne.Interface` is a global using in this project, so no new `using` directive is needed.)

## TDD

Added failing-first tests to `ZorkOne.Tests/BoatTests.cs`, mirroring the existing `GetInTheBoat_SharpItem` (sceptre) test:

- `GetInTheBoat_Stiletto_Punctures`
- `GetInTheBoat_BloodyAxe_Punctures`

Both failed before the fix (the boat stayed inflated and the player boarded normally — `"You are now in the magic boat."` instead of `"Oops! …"`) and pass after.

## Verification

- `dotnet test ZorkOne.Tests` — **1228 passed, 0 failed** (includes all 34 BoatTests)
- `dotnet test UnitTests` — **844 passed, 0 failed**
- Existing puncture behavior (sceptre/sword/knives) and non-sharp boarding behavior unchanged.

_Verified against `zork1/1actions.zil:2787-2799`._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JuDPrEXvcQs61R7y8LQteg)_