### PR TITLE
Penalize being outside the safety web during the Feinstein explosion

### DIFF
--- a/Planetfall.Tests/ExplosionTests.cs
+++ b/Planetfall.Tests/ExplosionTests.cs
@@ -1,6 +1,8 @@
 using FluentAssertions;
 using GameEngine;
 using Model.AIParsing;
+using Model.Interface;
+using Moq;
 using OpenAI;
 using Planetfall.Item.Feinstein;
 using Planetfall.Location.Feinstein;
@@ -366,5 +368,74 @@ public class ExplosionTests : EngineTestsBase
         // Now try to open the bulkhead from Deck Nine - should say "Too late"
         response = await target.GetResponse("open bulkhead");
         response.Should().Contain("Too late. The pod's launching procedure has already begun.");
+    }
+
+    // When the Feinstein explodes (case 4 of HandleBeingInSpaceAndLanding), the original
+    // penalizes a player who hasn't strapped into the safety web: 20% instant (head-first)
+    // death, otherwise a bruising message. In the web is unharmed. Verified against
+    // planetfall-source/globals.zil I-BLOWUP-FEINSTEIN (BLOWUP-COUNTER 5).
+    [Test]
+    public async Task Explosion_NotInWeb_DeathRoll_KillsPlayer()
+    {
+        var target = GetTarget();
+        var pod = Repository.GetLocation<EscapePod>();
+        target.Context.CurrentLocation = pod;
+        pod.SubLocation = null; // NOT in the web
+        pod.TurnsSinceExplosion = 3; // next Act -> case 4
+        target.Context.RegisterActor(pod);
+
+        var chooser = new Mock<IRandomChooser>();
+        chooser.Setup(c => c.RollDiceSuccess(5)).Returns(true); // force the 20%
+        pod.Chooser = chooser.Object;
+
+        var response = await target.GetResponse("wait");
+
+        response.Should().Contain("head first");
+        response.Should().Contain("You have died");
+    }
+
+    [Test]
+    public async Task Explosion_NotInWeb_Survives_Bruised()
+    {
+        var target = GetTarget();
+        var pod = Repository.GetLocation<EscapePod>();
+        target.Context.CurrentLocation = pod;
+        pod.SubLocation = null; // NOT in the web
+        pod.TurnsSinceExplosion = 3; // next Act -> case 4
+        target.Context.RegisterActor(pod);
+
+        var chooser = new Mock<IRandomChooser>();
+        chooser.Setup(c => c.RollDiceSuccess(5)).Returns(false); // survive the death roll
+        pod.Chooser = chooser.Object;
+
+        var response = await target.GetResponse("wait");
+
+        response.Should().Contain("bruising a few limbs");
+        response.Should().NotContain("You have died");
+        // Still stabilizes / searches for a destination after surviving.
+        response.Should().Contain("autopilot searches for a reasonable destination");
+    }
+
+    [Test]
+    public async Task Explosion_InWeb_Unharmed()
+    {
+        var target = GetTarget();
+        var pod = Repository.GetLocation<EscapePod>();
+        target.Context.CurrentLocation = pod;
+        pod.SubLocation = Repository.GetItem<SafetyWeb>(); // safely in the web
+        pod.TurnsSinceExplosion = 3; // next Act -> case 4
+        target.Context.RegisterActor(pod);
+
+        var chooser = new Mock<IRandomChooser>();
+        chooser.Setup(c => c.RollDiceSuccess(5)).Returns(true); // the web must bypass the roll entirely
+        pod.Chooser = chooser.Object;
+
+        var response = await target.GetResponse("wait");
+
+        response.Should().NotContain("bruising");
+        response.Should().NotContain("head first");
+        response.Should().NotContain("You have died");
+        // The web is unharmed, but the pod still stabilizes and looks for a destination.
+        response.Should().Contain("autopilot searches for a reasonable destination");
     }
 }

--- a/Planetfall/Location/Feinstein/EscapePod.cs
+++ b/Planetfall/Location/Feinstein/EscapePod.cs
@@ -1,5 +1,6 @@
 using GameEngine.Location;
 using Model.AIGeneration;
+using Newtonsoft.Json;
 using Planetfall.Command;
 using Utilities;
 
@@ -58,6 +59,10 @@ internal class SafetyWeb : ItemBase, ISubLocation, ICanBeExamined
 
 internal class EscapePod : LocationBase, ITurnBasedActor
 {
+    // Locations are serialized into save state, so the random source must not be persisted.
+    [UsedImplicitly] [JsonIgnore]
+    public IRandomChooser Chooser { get; set; } = new RandomChooser();
+
     public bool LandedSafely { get; set; }
 
     public byte TurnsSinceExplosion { get; set; }
@@ -237,15 +242,31 @@ internal class EscapePod : LocationBase, ITurnBasedActor
                 break;
 
             case 4:
-                // TODO: If not in web, You are thrown against the bulkhead, bruising a few limbs. The safety webbing might have offered a bit more protection.
-                // TODO: If not in web, chance of: You are thrown against the bulkhead, head first. It seems that getting in the safety webbing would have been a good idea.
-
-                action =
+                // The Feinstein blows apart. If the player never strapped into the safety web,
+                // they're thrown against the bulkhead: a 20% chance of an instant head-first death,
+                // otherwise a survivable bruising. In the web they ride it out unharmed. The death
+                // path must stop early so the stabilization text isn't appended after dying.
+                var explosion =
                     "Through the viewport of the pod you see the Feinstein dwindle as you head away. Bursts of light " +
                     "dot its hull. Suddenly, a huge explosion blows the Feinstein into tiny pieces, sending the " +
-                    "escape pod tumbling away! \n\nAs the escape pod tumbles away from the former location of " +
-                    "the Feinstein, its gyroscopes whine. The pod slowly stops tumbling. Lights on the control " +
-                    "panel blink furiously as the autopilot searches for a reasonable destination. ";
+                    "escape pod tumbling away! ";
+                var inWeb = context.CurrentLocation.SubLocation is SafetyWeb;
+
+                if (!inWeb && Chooser.RollDiceSuccess(5)) // PROB 20 -> head-first death
+                    return Die(explosion + "\n\nYou are thrown against the bulkhead, head first. It seems that " +
+                               "getting in the safety webbing would have been a good idea.", context);
+
+                var bruise = inWeb
+                    ? ""
+                    : "\n\nYou are thrown against the bulkhead, bruising a few limbs. The safety webbing might have " +
+                      "offered a bit more protection. ";
+
+                var stabilize =
+                    "\n\nAs the escape pod tumbles away from the former location of the Feinstein, its gyroscopes " +
+                    "whine. The pod slowly stops tumbling. Lights on the control panel blink furiously as the " +
+                    "autopilot searches for a reasonable destination. ";
+
+                action = explosion + bruise + stabilize;
                 break;
 
             case 5:


### PR DESCRIPTION
Closes #204

## Problem

When the Feinstein explodes and the escape pod tumbles away (`case 4` of `EscapePod.HandleBeingInSpaceAndLanding`), the original game penalizes a player who never strapped into the safety web. The C# port left both consequences as a literal `// TODO`, so standing outside the web during the explosion was completely free.

## Fix

Restore the original behavior at the moment the ship blows apart:

- **Not in the web →** 20% chance of an instant head-first death, otherwise a survivable "bruising a few limbs" message.
- **In the web →** unharmed.

The death path returns early via the existing `Die(...)` helper, so the gyroscope/stabilization/landing-search text is **not** appended after a death. The survival path still shows it.

`EscapePod` gained a mockable `IRandomChooser Chooser` (with `[UsedImplicitly] [JsonIgnore]`, since locations are serialized into save state). `RollDiceSuccess(5)` is exactly the original `PROB 20`.

## Tests (TDD)

Three deterministic tests added to `Planetfall.Tests/ExplosionTests.cs`, driving `case 4` surgically (player in pod, counter primed to 3, mocked chooser, web set/cleared):

- `Explosion_NotInWeb_DeathRoll_KillsPlayer` — forced roll → "head first" + "You have died".
- `Explosion_NotInWeb_Survives_Bruised` — roll fails → "bruising a few limbs", no death, still stabilizes.
- `Explosion_InWeb_Unharmed` — forced roll, but the web bypasses it → no bruise/death, still stabilizes.

The two not-in-web tests failed before the change and pass after it; the in-web test guards that the web bypasses the death roll entirely. Full `Planetfall.Tests` suite green (2247 passed, 1 `[Explicit]` skipped).

## Reference

Verified against `planetfall-source/globals.zil` `I-BLOWUP-FEINSTEIN` (`BLOWUP-COUNTER 5`).

## Affected files

- `Planetfall/Location/Feinstein/EscapePod.cs` — added `Chooser`; implemented the `case 4` not-in-web outcome.
- `Planetfall.Tests/ExplosionTests.cs` — three proving tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KxUmgMJsm4jW4H9Bsogdz3

---
_Generated by [Claude Code](https://claude.ai/code/session_01KxUmgMJsm4jW4H9Bsogdz3)_