### PR TITLE
Fix #256: graceful narrator response for multi-command input without periods

### DIFF
--- a/GameEngine/GameEngine.cs
+++ b/GameEngine/GameEngine.cs
@@ -509,6 +509,13 @@ public class GameEngine<TInfocomGame, TContext> : IGameEngine
             
             PromptIntent => (null, parsedResult.Message),
 
+            // #256: the player ran multiple commands together on one line with no periods.
+            // We don't execute them; the narrator asks them to separate commands with periods.
+            MultipleCommandsIntent => (
+                null,
+                await GetGeneratedMultipleCommandsResponse(_currentInput!, GenerationClient, Context)
+            ),
+
             EnterSubLocationIntent subLocationIntent => await new EnterSubLocationEngine().Process(
                 subLocationIntent,
                 Context,
@@ -708,6 +715,20 @@ public class GameEngine<TInfocomGame, TContext> : IGameEngine
         return result + Environment.NewLine;
     }
 
+
+    private static async Task<string> GetGeneratedMultipleCommandsResponse(
+        string input,
+        IGenerationClient generationClient,
+        IContext context
+        )
+    {
+        var request = new MultipleCommandsRequest(
+            context.CurrentLocation.GetDescriptionForGeneration(context),
+            input
+        );
+        var result = await generationClient.GenerateNarration(request, context.SystemPromptAddendum);
+        return result + Environment.NewLine;
+    }
 
     private async Task<string> GetGeneratedNoCommandResponse()
     {

--- a/Model/AIGeneration/Requests/MultipleCommandsRequest.cs
+++ b/Model/AIGeneration/Requests/MultipleCommandsRequest.cs
@@ -1,0 +1,23 @@
+namespace Model.AIGeneration.Requests;
+
+/// <summary>
+/// The player ran several commands together on one line without separating them with periods
+/// (e.g. "look examine bulkhead open bulkhead"). We do not execute these. The narrator, in
+/// character, tells the player they can only do one thing at a time and that multiple commands
+/// must be separated with periods.
+/// </summary>
+public class MultipleCommandsRequest : Request
+{
+    public MultipleCommandsRequest(string location, string? command)
+    {
+        UserMessage =
+            @$"The player is in this location: ""{location}"". They wrote ""{command}"", which is several " +
+            @"separate commands strung together on a single line. In the voice of the game's narrator, briefly " +
+            @"and in-character, tell the player that they can only do one thing at a time, and that if they want " +
+            @"to enter more than one command they should separate them with periods (for example: " +
+            @"""examine bulkhead. open bulkhead.""). Do not attempt to carry out any of the commands, and do not " +
+            "change the state of the game. " + NoInventionGuard;
+
+        Temperature = DeflectionTemperature;
+    }
+}

--- a/Model/Intent/MultipleCommandsIntent.cs
+++ b/Model/Intent/MultipleCommandsIntent.cs
@@ -1,0 +1,10 @@
+namespace Model.Intent;
+
+/// <summary>
+///     The player typed more than one command on a single line without separating them with
+///     periods (e.g. "look examine bulkhead open bulkhead"). The AI parser reveals this by
+///     emitting more than one verb (or intent) tag. We do not try to execute these; instead we
+///     ask the player — in the narrator's voice — to enter one command at a time, or to separate
+///     multiple commands with periods.
+/// </summary>
+public record MultipleCommandsIntent : IntentBase;

--- a/Model/ParsingHelper.cs
+++ b/Model/ParsingHelper.cs
@@ -266,6 +266,20 @@ public static class ParsingHelper
 
     public static IntentBase GetIntent(string input, string? response, ILogger? logger)
     {
+        // #256: More than one <verb> or <intent> tag means the player ran several commands
+        // together on one line without periods (e.g. "look examine bulkhead open bulkhead").
+        // A well-formed single command has exactly one of each (two *nouns* is still fine — that
+        // is a normal multi-noun command like "tie rope to railing"). We do not execute these;
+        // we ask the player to separate them with periods. Detecting it here also keeps us out of
+        // the determiners below, whose .SingleOrDefault() calls throw on duplicate tags — the
+        // original uncaught exception that surfaced as an HTTP 500.
+        var lowered = response?.ToLowerInvariant();
+        if (ExtractElementsByTag(lowered, "verb").Count > 1 || ExtractElementsByTag(lowered, "intent").Count > 1)
+        {
+            logger?.LogDebug("Multiple verbs/intents detected - treating as multiple commands on one line");
+            return new MultipleCommandsIntent { Message = response };
+        }
+
         var takeIntent = DetermineTakeIntent(response?.ToLowerInvariant(), input);
         if (takeIntent != null)
             return takeIntent;

--- a/UnitTests/Models/ParsingHelperTests.cs
+++ b/UnitTests/Models/ParsingHelperTests.cs
@@ -237,6 +237,58 @@ public class ParsingHelperTests
     }
 
     [Test]
+    public void GetIntent_WithMultipleVerbs_ReturnsMultipleCommandsIntent()
+    {
+        // Repro for #256: the player jammed several commands onto one line with no periods
+        // ("look examine bulkhead open bulkhead"). When "bulkhead" is a real in-scope object,
+        // gpt-4o emits more than one <verb> tag. ParsingHelper used .SingleOrDefault(), which
+        // throws InvalidOperationException ("Sequence contains more than one element") on >1
+        // element, surfacing as an HTTP 500 in the Lambda. The parser must instead recognise
+        // this as a multi-command line and degrade gracefully.
+        var input = "look examine bulkhead open bulkhead";
+        var response = @"<intent>act</intent>
+<verb>examine</verb>
+<verb>open</verb>
+<noun>bulkhead</noun>
+<noun>bulkhead</noun>";
+
+        var act = () => ParsingHelper.GetIntent(input, response, _loggerMock?.Object);
+
+        act.Should().NotThrow();
+        ParsingHelper.GetIntent(input, response, _loggerMock?.Object)
+            .Should().BeOfType<MultipleCommandsIntent>();
+    }
+
+    [Test]
+    public void GetIntent_WithMultipleIntents_ReturnsMultipleCommandsIntent()
+    {
+        // Same bug at the other throw site: when the parser duplicates the <intent> tag, the
+        // very first determiner (DetermineTakeIntent) throws on .SingleOrDefault(). Multiple
+        // intents likewise mean multiple commands on one line.
+        var input = "look examine bulkhead open bulkhead";
+        var response = @"<intent>look</intent>
+<intent>act</intent>
+<verb>examine</verb>
+<noun>bulkhead</noun>";
+
+        var act = () => ParsingHelper.GetIntent(input, response, _loggerMock?.Object);
+
+        act.Should().NotThrow();
+        ParsingHelper.GetIntent(input, response, _loggerMock?.Object)
+            .Should().BeOfType<MultipleCommandsIntent>();
+    }
+
+    [Test]
+    public void GetIntent_WithSingleVerb_DoesNotReturnMultipleCommandsIntent()
+    {
+        // Guard against false positives: a normal single command (even one with two nouns and a
+        // preposition, like "tie rope to railing") has exactly one verb and must parse as usual.
+        var result = ParsingHelper.GetIntent("tie the rope to the railing", MultiNounResponse, _loggerMock?.Object);
+
+        result.Should().BeOfType<MultiNounIntent>();
+    }
+
+    [Test]
     public void GetIntent_WithNullResponse_ReturnsNullIntent()
     {
         // This test verifies that a null response produces a NullIntent

--- a/UnitTests/Models/RequestTests.cs
+++ b/UnitTests/Models/RequestTests.cs
@@ -320,6 +320,22 @@ public class RequestTests
     }
 
     [Test]
+    public void MultipleCommandsRequest_AsksToSeparateWithPeriods_AndIsLowTemperature()
+    {
+        // #256: when the player runs several commands together on one line, the narrator should
+        // tell them — in character — to separate commands with periods, at the low deflection
+        // temperature (this is a "stay in room state" deflection, not creative narration).
+        var request = new MultipleCommandsRequest(
+            "Deck Nine. An emergency bulkhead is here.", "look examine bulkhead open bulkhead");
+
+        request.UserMessage.Should().Contain("look examine bulkhead open bulkhead");
+        request.UserMessage.Should().Contain("periods");
+        request.UserMessage.Should().Contain("one thing at a time");
+        request.UserMessage.Should().Contain("Do not invent");
+        request.Temperature.Should().BeLessThan(0.8f);
+    }
+
+    [Test]
     public void CannotGoThatWayRequest_UsesLowDeflectionTemperature()
     {
         // This is the same category of "stay in room state" deflection as the no-effect prompts,


### PR DESCRIPTION
## What & why

Closes #256. Against Planetfall production, the single line `look examine bulkhead open bulkhead` (no periods) returned **HTTP 500 / empty body** from a fresh session.

**Root cause:** the gpt-4o parser emits **more than one `<verb>`/`<intent>` tag** for that multi-command line — but only when the noun resolves to a **real in-scope object** (Deck Nine has the emergency bulkhead; Gangway doesn't), because the parser's system prompt embeds the current room description. `ParsingHelper` read those tags with `.SingleOrDefault()`, which throws `InvalidOperationException: Sequence contains more than one element`. Nothing caught it, so it propagated out of `PlanetfallController` and API Gateway returned a 500. This also explains why `examine bulkhead. open bulkhead` (with a period) was fine: `SentenceSplitter` splits it and each clause parses with a single verb.

## Approach

Detect the multi-command shape **structurally** — not by catching the exception. In `ParsingHelper.GetIntent`, if the parser produced more than one `<verb>` or `<intent>` tag, the player jammed several commands onto one line, so we return a new `MultipleCommandsIntent`. (A normal single command has exactly one verb/intent; two *nouns* is still a valid multi-noun command like `tie rope to railing`, so that path is unaffected.) Detecting up front also keeps us out of the `.SingleOrDefault()` calls that threw.

The engine renders `MultipleCommandsIntent` with a **narrator-generated** `MultipleCommandsRequest` (AI, not a canned string — low deflection temperature + the shared no-invention guard, like the other deflection prompts) telling the player they can only do one thing at a time and to separate multiple commands with periods.

## Scope & the residual third throw site

This fix structurally guards the **two confirmed throw sites**: duplicate `<verb>` (`ParsingHelper.cs:170`/`231`) and duplicate `<intent>` (`ParsingHelper.cs:86`/`103`/`122`/`141`/`157`/`222`/`242`).

There is a **third, narrower `.SingleOrDefault()`** on `preposition` at `ParsingHelper.cs:177`. It is *not* reached by the reproduced bug (a duplicate `<preposition>` can only occur alongside a single inferred verb, which is a hypothetical the production repro never hit), and structurally hardening every remaining site would cut against the deliberately simplified, narrowly-scoped approach here. That residual case — and any other unforeseen engine throw — is exactly what **#271** (the broader "never return a 500; narrator 'oops' on any crash" safety net) is filed to cover. So #271 is the intended backstop for this specific remaining gap, kept out of this PR on purpose.

## Changes

- `Model/ParsingHelper.cs` — detect duplicate `<verb>`/`<intent>` tags → `MultipleCommandsIntent`.
- `Model/Intent/MultipleCommandsIntent.cs` *(new)* — the intent.
- `Model/AIGeneration/Requests/MultipleCommandsRequest.cs` *(new)* — narrator prompt.
- `GameEngine/GameEngine.cs` — route `MultipleCommandsIntent` to a generated response (mirrors `GetGeneratedNoOpResponse`).
- Tests *(new)* in `ParsingHelperTests` and `RequestTests`.

## TDD / verification

Reproduced both throw sites deterministically (no AI/network) in `ParsingHelperTests` — duplicate `<verb>` and duplicate `<intent>` strings. Before the fix they failed with the exact production exception (`Sequence contains more than one element` at `ParsingHelper.cs:170`); after, they return `MultipleCommandsIntent`. A single-verb test guards against false positives, and `RequestTests` checks the narrator prompt.

```
UnitTests:        848 passed, 1 skipped
Planetfall.Tests: 2244 passed
ZorkOne.Tests:    1226 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)