### PR TITLE
Follow-up to #264: address absent-NPC review nits (attribution, matching, contract test)

### DIFF
--- a/GameEngine/ConversationHandler.cs
+++ b/GameEngine/ConversationHandler.cs
@@ -114,7 +114,16 @@ public class ConversationHandler(
 
         var parseResult = await parseConversation.ParseAsync(input);
         logger?.LogDebug($"[CONVERSATION DEBUG] Absent-talker classifier isConversational: {parseResult.isConversational}");
-        return parseResult.isConversational ? referenced[0] : null;
+        if (!parseResult.isConversational)
+            return null;
+
+        // The classifier confirms the input is address but not WHOM it addresses. When more than one
+        // absent talker is named, attribute to the one whose name appears earliest in the input (the
+        // addressed party in "tell floyd that blather left" phrasings) rather than arbitrary roster
+        // order.
+        return referenced
+            .OrderBy(talker => FirstMentionIndex(input, (IItem)talker))
+            .First();
     }
 
     /// <summary>
@@ -124,7 +133,31 @@ public class ConversationHandler(
     private static bool Mentions(string input, IItem item) =>
         item.NounsForMatching.Any(noun => ContainsWholeWord(input, noun));
 
-    private static bool ContainsWholeWord(string text, string word)
+    /// <summary>
+    /// The index of the earliest whole-word mention of any of the item's nouns in the input, or
+    /// <see cref="int.MaxValue"/> if none — used to attribute an ambiguous classifier-detected
+    /// address to the talker named first.
+    /// </summary>
+    private static int FirstMentionIndex(string input, IItem item)
+    {
+        var earliest = int.MaxValue;
+        foreach (var noun in item.NounsForMatching)
+        {
+            var index = WholeWordIndex(input, noun);
+            if (index >= 0 && index < earliest)
+                earliest = index;
+        }
+
+        return earliest;
+    }
+
+    private static bool ContainsWholeWord(string text, string word) => WholeWordIndex(text, word) >= 0;
+
+    /// <summary>
+    /// The index of the first whole-word occurrence of <paramref name="word"/> in
+    /// <paramref name="text"/> (case-insensitive), or -1 if not present.
+    /// </summary>
+    private static int WholeWordIndex(string text, string word)
     {
         var index = 0;
         while ((index = text.IndexOf(word, index, StringComparison.OrdinalIgnoreCase)) >= 0)
@@ -133,11 +166,11 @@ public class ConversationHandler(
             var end = index + word.Length;
             var endOk = end == text.Length || !char.IsLetterOrDigit(text[end]);
             if (startOk && endOk)
-                return true;
+                return index;
             index = end;
         }
 
-        return false;
+        return -1;
     }
 
     /// <summary>
@@ -303,22 +336,16 @@ public class ConversationHandler(
     }
 
     /// <summary>
-    /// Finds the target character for conversation based on noun matching in the input.
+    /// Finds the target character for conversation based on noun matching in the input. Matches on a
+    /// whole-word boundary (consistent with the absent-NPC path) so a present NPC is not matched by a
+    /// partial-word hit (e.g. "robot" inside "robotics").
     /// </summary>
     private ICanBeTalkedTo? FindTargetCharacter(string input, List<ICanBeTalkedTo> talkers)
     {
-        var inputLower = input.ToLowerInvariant();
-        logger?.LogDebug($"[CONVERSATION DEBUG] Input lowercased: '{inputLower}'");
-
         var targetCharacter = talkers
             .OfType<IItem>()
-            .FirstOrDefault(item => item.NounsForMatching
-                .Any(noun => {
-                    var nounLower = noun.ToLowerInvariant();
-                    var contains = inputLower.Contains(nounLower);
-                    logger?.LogDebug($"[CONVERSATION DEBUG] Checking noun '{nounLower}' in '{inputLower}': {contains}");
-                    return contains;
-                })) as ICanBeTalkedTo;
+            .FirstOrDefault(item => item.NounsForMatching.Any(noun => ContainsWholeWord(input, noun)))
+            as ICanBeTalkedTo;
 
         if (targetCharacter != null)
         {

--- a/Planetfall.Tests/AbsentTalkableNpcTests.cs
+++ b/Planetfall.Tests/AbsentTalkableNpcTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using Moq;
 using Planetfall.Item.Feinstein;
+using Planetfall.Item.Kalamontee.Mech.FloydPart;
 using Planetfall.Location.Feinstein;
 
 namespace Planetfall.Tests;
@@ -274,5 +275,28 @@ public class AbsentTalkableNpcTests : EngineTestsBase
         var response = await target.GetResponse("attack floyd");
 
         response.Should().NotContain("isn't here");
+    }
+
+    // The absent-NPC guard force-instantiates the whole declared roster early (see
+    // ConversationHandler.CollectAllKnownTalkers). This pins the contract that doing so has no
+    // observable side effects: instantiating an NPC must not place it in a location or register it
+    // as an actor. If a future talkable NPC's Init() does either, this test fails loudly.
+    [Test]
+    public void InstantiatingTheTalkableRoster_DoesNotPlaceOrRegisterAnyNpc()
+    {
+        GetTarget();
+        StartHere<DeckNine>();
+
+        var floyd = GetItem<Floyd>();
+        var blather = GetItem<Blather>();
+        var ambassador = GetItem<Ambassador>();
+
+        floyd.CurrentLocation.Should().BeNull();
+        blather.CurrentLocation.Should().BeNull();
+        ambassador.CurrentLocation.Should().BeNull();
+
+        Context.Actors.Should().NotContain(floyd);
+        Context.Actors.Should().NotContain(blather);
+        Context.Actors.Should().NotContain(ambassador);
     }
 }

--- a/UnitTests/Engine/ConversationHandlerTests.cs
+++ b/UnitTests/Engine/ConversationHandlerTests.cs
@@ -484,6 +484,53 @@ public class ConversationHandlerTests
     }
 
     [Test]
+    public async Task CheckForConversation_TwoAbsentTalkers_ClassifierFallback_AttributesToEarliestNamed()
+    {
+        // Arrange - deterministic check misses for both; the classifier says it's address but not
+        // whom. Attribution must go to the talker NAMED first ("captain"), not roster order (Gizmo).
+        var mockParser = new Mock<IParseConversation>();
+        mockParser.Setup(p => p.ParseAsync(It.IsAny<string>())).ReturnsAsync((true, ""));
+        var handler = new ConversationHandler(null, mockParser.Object, Mock.Of<IGenerationClient>(),
+            new[] { typeof(GizmoTalker), typeof(CaptainTalker) });
+        var context = new ZorkIContext();
+
+        // Act - "captain" appears before "gizmo", and neither is an explicit (deterministic) address.
+        var result = await handler.CheckForConversation(
+            "could you let captain know that gizmo wandered off", context);
+
+        // Assert
+        result.Should().Be("The captain isn't here. ");
+    }
+
+    [Test]
+    public async Task CheckForConversation_PresentTalker_NotMatchedByPartialWord()
+    {
+        // Arrange - a present NPC named "bob" must not be engaged by a partial-word hit inside
+        // "bobbin"; the present path now uses the same whole-word matching as the absent path.
+        var mockParser = new Mock<IParseConversation>();
+        mockParser.Setup(p => p.ParseAsync(It.IsAny<string>())).ReturnsAsync((true, "hello"));
+
+        var mockTalker = new Mock<ICanBeTalkedTo>();
+        mockTalker.As<IItem>().Setup(i => i.NounsForMatching).Returns(new[] { "bob" });
+        mockTalker.Setup(t => t.OnBeingTalkedTo(It.IsAny<string>(), It.IsAny<IContext>(), It.IsAny<IGenerationClient>()))
+                  .ReturnsAsync("engaged");
+
+        var handler = new ConversationHandler(null, mockParser.Object, Mock.Of<IGenerationClient>());
+        var context = new ZorkIContext();
+        context.Items.Add((IItem)mockTalker.Object);
+
+        // Act
+        var result = await handler.CheckForConversation("examine the bobbin", context);
+
+        // Assert
+        result.Should().BeNull();
+        mockTalker.Verify(
+            t => t.OnBeingTalkedTo(It.IsAny<string>(), It.IsAny<IContext>(), It.IsAny<IGenerationClient>()),
+            Times.Never);
+        mockParser.Verify(p => p.ParseAsync(It.IsAny<string>()), Times.Never);
+    }
+
+    [Test]
     public async Task CheckForConversation_AbsentKnownTalker_RunsEvenWhenGenerationDisabled()
     {
         // Arrange - the absent-NPC guard is deterministic, so it must fire in NoGeneratedResponses mode.


### PR DESCRIPTION
Follow-up to the merged #264 fix (#267), addressing the substantive points from that PR's reviews. No behavior change to the #264 fix itself; these tighten correctness/robustness and add coverage.

## Changes

1. **Classifier-fallback attribution (correctness).** In the LLM-backed absent path, the classifier confirms an input is *address* but not *whom* it addresses. When the deterministic check misses and more than one absent talker is named, the code previously fell back to `referenced[0]` (roster order) — which could name the wrong character. It now attributes to the talker named **earliest in the input**.
   - Test: `CheckForConversation_TwoAbsentTalkers_ClassifierFallback_AttributesToEarliestNamed`.

2. **Align matching precision.** The present-NPC path (`FindTargetCharacter`) used a raw case-insensitive substring `Contains`, while the absent path uses whole-word matching. The present path now uses the same whole-word matching, so a present NPC isn't matched by a partial-word hit (e.g. "bob" inside "bobbin").
   - Test: `CheckForConversation_PresentTalker_NotMatchedByPartialWord`.

3. **Pin the eager-instantiation contract.** The guard force-instantiates the whole declared roster early; a reviewer flagged that "roster `Init()` must have no side effects" lived only in a doc-comment. A Planetfall test now asserts that instantiating Floyd/Blather/Ambassador places no NPC and registers no actor — so a future NPC with a stateful `Init()` fails loudly instead of silently breaking the invariant.
   - Test: `InstantiatingTheTalkableRoster_DoesNotPlaceOrRegisterAnyNpc`.

Refactors the word-boundary helper to expose an index (`WholeWordIndex`), reused by `ContainsWholeWord` and the new `FirstMentionIndex`.

## Not changed (and why)
- **`GetItem(null)` overload footgun** — already handled in #264 (the one call site was disambiguated; the compiler catches any future case).
- **`"alien"` synonym is generic** — the ambassador *is* an alien, so the synonym stays; noted for whoever adds new Planetfall content.

## Verification
All suites green locally: UnitTests 879, Planetfall.Tests 2268, ZorkOne.Tests 1228, EscapeRoom.Tests 7; solution builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HzzV8FfuhzoBya2uf3MYrC)_