### PR TITLE
Add #271: engine safety net — never return HTTP 500, narrator "oops" on any unhandled crash

### DIFF
--- a/GameEngine/GameEngine.cs
+++ b/GameEngine/GameEngine.cs
@@ -225,6 +225,12 @@ public class GameEngine<TInfocomGame, TContext> : IGameEngine
         }
         catch (Exception ex)
         {
+            // Intentionally broad — this deliberately includes OperationCanceledException /
+            // TaskCanceledException, which is also how HttpClient timeouts (e.g. the OpenAI
+            // generation call) surface. Those are genuine "something went wrong deep in the engine"
+            // failures that must degrade gracefully. GetResponse has no CancellationToken to tell a
+            // real client-cancel apart from a timeout, so filtering cancellation out here would let
+            // timeouts regress straight back into the HTTP 500s this net exists to prevent.
             return await HandleUnexpectedEngineError(ex);
         }
     }

--- a/GameEngine/GameEngine.cs
+++ b/GameEngine/GameEngine.cs
@@ -55,6 +55,15 @@ public class GameEngine<TInfocomGame, TContext> : IGameEngine
     public TContext Context { get; private set; }
 
     /// <summary>
+    ///     The single guaranteed static fallback sentence for the engine error safety net (issue #271).
+    ///     This is the one acceptable canned string: it is returned only when the AI narrator itself
+    ///     cannot be reached (generation disabled, or it threw while producing the "oops" narration), so
+    ///     that turn processing still returns a graceful, in-character 200 body instead of a hard failure.
+    /// </summary>
+    public const string EngineErrorFallbackMessage =
+        "Something goes wrong, and for a moment the world seems to flicker. Perhaps try that a different way.";
+
+    /// <summary>
     ///     The flat list of held item names, used by the web clients to render the player's hands.
     ///     Derived live from <see cref="Context" />.Items rather than stored, so the projection can
     ///     never drift from the authoritative game state. A stored copy previously went stale on the
@@ -187,24 +196,109 @@ public class GameEngine<TInfocomGame, TContext> : IGameEngine
     /// <returns>The output which we need to display to the adventurer</returns>
     public async Task<string?> GetResponse(string? playerInput)
     {
-        _currentInput = playerInput;
-
-        // Check for multi-sentence input
-        var sentences = SentenceSplitter.Split(playerInput);
-
-        if (sentences.Count == 0)
+        // Engine-wide safety net (issue #271): no matter what throws deep in turn processing, the
+        // player must never see a raw HTTP 500 / empty body. Every turn entry point funnels through
+        // GetResponse — POST, the GET reconnect "look", and restoreGame — so this single wrap covers
+        // them all across Zork, Planetfall, and EscapeRoom. Specific bugs that throw still get their
+        // own root-cause fixes; this only guarantees the *next* unknown crash degrades into a
+        // graceful, logged, in-character "oops" rather than breaking the transport to the client.
+        try
         {
-            // Empty input (like "...") - treat as empty command
-            return await ProcessSingleSentence(null);
+            _currentInput = playerInput;
+
+            // Check for multi-sentence input
+            var sentences = SentenceSplitter.Split(playerInput);
+
+            if (sentences.Count == 0)
+            {
+                // Empty input (like "...") - treat as empty command
+                return await ProcessSingleSentence(null);
+            }
+
+            if (sentences.Count > 1)
+            {
+                return await ProcessMultipleSentences(sentences);
+            }
+
+            // Single sentence processing
+            return await ProcessSingleSentence(playerInput);
+        }
+        catch (Exception ex)
+        {
+            return await HandleUnexpectedEngineError(ex);
+        }
+    }
+
+    /// <summary>
+    ///     Converts an unhandled turn-processing exception into a graceful, in-character narrator
+    ///     "oops" response (issue #271). The exception is logged loudly — via the engine logger and,
+    ///     best-effort, to CloudWatch with the turn correlation id — so the underlying bug is still
+    ///     discoverable; the safety net must never <em>hide</em> a bug. The player gets a normal-shaped
+    ///     200 turn response and can keep playing.
+    /// </summary>
+    private async Task<string> HandleUnexpectedEngineError(Exception ex)
+    {
+        _logger?.LogError(ex,
+            "Unhandled exception during turn processing for input '{Input}'. TurnCorrelationId: {TurnCorrelationId}",
+            _currentInput, _turnCorrelationId);
+
+        // Best-effort structured log with the turn correlation id so the swallowed exception stays
+        // discoverable. Logging must never be allowed to defeat the safety net it supports.
+        try
+        {
+            _turnLogger?.WriteLogEvents(new TurnLog
+            {
+                SessionId = _sessionId,
+                Location = Context.CurrentLocation.Name,
+                Score = Context.Score,
+                Moves = Context.Moves,
+                Input = _currentInput ?? string.Empty,
+                Response = $"ENGINE ERROR ({_turnCorrelationId}): {ex}"
+            });
+        }
+        catch (Exception loggingEx)
+        {
+            _logger?.LogError(loggingEx, "Failed to write engine-error turn log.");
         }
 
-        if (sentences.Count > 1)
+        // Prefer an AI-generated, in-character acknowledgement (consistent with the engine's other
+        // deflection narration). Only fall back to the canned sentence when the narrator itself is
+        // unavailable — i.e. generation is disabled, or the AI client is the very thing that failed.
+        if (!NoGeneratedResponses)
         {
-            return await ProcessMultipleSentences(sentences);
+            try
+            {
+                var narration = await GenerationClient.GenerateNarration(
+                    new EngineErrorRequest(), Context.SystemPromptAddendum);
+
+                if (!string.IsNullOrWhiteSpace(narration))
+                    return SafePostProcess(narration);
+            }
+            catch (Exception generationEx)
+            {
+                _logger?.LogError(generationEx,
+                    "Engine-error narration generation itself failed; using static fallback.");
+            }
         }
 
-        // Single sentence processing
-        return await ProcessSingleSentence(playerInput);
+        return SafePostProcess(EngineErrorFallbackMessage);
+    }
+
+    /// <summary>
+    ///     Runs the normal <see cref="PostProcessing" /> pipeline but, as the safety net's last line of
+    ///     defense, guarantees a non-empty 200 body even if post-processing itself throws.
+    /// </summary>
+    private string SafePostProcess(string message)
+    {
+        try
+        {
+            return PostProcessing(message);
+        }
+        catch (Exception postEx)
+        {
+            _logger?.LogError(postEx, "Post-processing failed inside the engine-error safety net.");
+            return message + Environment.NewLine;
+        }
     }
 
     /// <summary>

--- a/GameEngine/GameEngine.cs
+++ b/GameEngine/GameEngine.cs
@@ -244,6 +244,13 @@ public class GameEngine<TInfocomGame, TContext> : IGameEngine
     /// </summary>
     private async Task<string> HandleUnexpectedEngineError(Exception ex)
     {
+        // Abandon any half-finished stateful interaction (disambiguation, save/quit confirmation,
+        // "it" clarification). A crash can occur *after* _processorInProgress was assigned but before
+        // the turn completed; if we leave it set, the NEXT turn's input is fed into that orphaned
+        // processor instead of being parsed normally — soft-locking the player in a long-lived engine
+        // (e.g. console runtime). Clearing it keeps the "player can keep playing" guarantee (issue #271).
+        _processorInProgress = null;
+
         _logger?.LogError(ex,
             "Unhandled exception during turn processing for input '{Input}'. TurnCorrelationId: {TurnCorrelationId}",
             _currentInput, _turnCorrelationId);

--- a/Model/AIGeneration/Requests/EngineErrorRequest.cs
+++ b/Model/AIGeneration/Requests/EngineErrorRequest.cs
@@ -1,0 +1,24 @@
+namespace Model.AIGeneration.Requests;
+
+/// <summary>
+/// Engine safety-net request (issue #271). Used when an unhandled exception is caught at the
+/// turn-processing chokepoint. The narrator briefly and in-character acknowledges that something
+/// went wrong and the player's action could not be completed — without revealing the error and
+/// without inventing or altering any world state. Follows the existing deflection pattern
+/// (<see cref="CommandHasNoEffectOperationRequest" />): low <see cref="Request.Temperature" /> and
+/// the shared anti-hallucination guard.
+/// </summary>
+public class EngineErrorRequest : Request
+{
+    public EngineErrorRequest()
+    {
+        UserMessage =
+            "Something went wrong inside the game and the player's last action could not be completed. " +
+            "Provide a short, in-character narrator response, in the voice and tone of the story, that " +
+            "acknowledges the action could not be carried out and gently invites the player to try " +
+            "something else. Do not mention errors, bugs, exceptions, code, or anything technical, and " +
+            "do not blame the player. Keep it to one or two sentences. " + NoInventionGuard;
+
+        Temperature = DeflectionTemperature;
+    }
+}

--- a/UnitTests/Engine/GenerationFallbackTests.cs
+++ b/UnitTests/Engine/GenerationFallbackTests.cs
@@ -1,6 +1,7 @@
 using ChatLambda;
 using GameEngine;
 using GameEngine.Item;
+using GameEngine.StaticCommand;
 using Model.AIGeneration;
 using Model.AIParsing;
 using Model.Intent;
@@ -241,5 +242,62 @@ public class GenerationFallbackTests
         client.Verify(
             c => c.GenerateNarration(It.IsAny<Request>(), It.IsAny<string>()),
             Times.Never);
+    }
+
+    // Session-state-not-corrupted criterion (issue #271): a crash that happens AFTER a stateful
+    // processor (disambiguation / save-confirmation / "it" clarification) has been assigned must not
+    // leave it in progress. Otherwise the NEXT turn's input is routed into the orphaned processor
+    // instead of being parsed normally, soft-locking the player in a long-lived engine. We prove the
+    // fix by asserting the stale stateful command is never invoked a second time on the next turn.
+    [Test]
+    public async Task UnhandledException_AfterStatefulProcessorAssigned_ClearsIt_SoNextTurnIsNotSoftLocked()
+    {
+        // A stateful global command that assigns _processorInProgress (Completed == false).
+        var statefulCommand = new Mock<IStatefulProcessor>();
+        statefulCommand
+            .Setup(c => c.Process(It.IsAny<string?>(), It.IsAny<IContext>(),
+                It.IsAny<IGenerationClient>(), It.IsAny<Runtime>()))
+            .ReturnsAsync("A stateful prompt awaiting your answer.");
+        statefulCommand.SetupGet(c => c.Completed).Returns(false);
+        statefulCommand.SetupGet(c => c.ContinueProcessing).Returns(false);
+
+        var parser = new Mock<IIntentParser>();
+        parser.Setup(p => p.DetermineSystemIntentType(It.IsAny<string>())).Returns((IntentBase?)null);
+        // Only the "trigger" command routes to the stateful processor; everything else parses normally.
+        parser.Setup(p => p.DetermineGlobalIntentType("trigger"))
+            .Returns(new GlobalCommandIntent { Command = statefulCommand.Object });
+        parser.Setup(p => p.ResolvePronounsAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<string?>()))
+            .ReturnsAsync((string?)null);
+        parser.Setup(p => p.DetermineComplexIntentType(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(new NullIntent());
+
+        var client = new Mock<IGenerationClient>();
+        client.SetupAllProperties();
+        client.Object.LastFiveInputOutputs = new List<(string, string, bool)>();
+        client.Setup(c => c.GenerateNarration(It.IsAny<Request>(), It.IsAny<string>())).ReturnsAsync("oops");
+
+        var engine = BuildEngine(client, parser.Object);
+
+        // An actor that throws, so the turn crashes AFTER the stateful processor has been assigned.
+        var throwingActor = new Mock<ITurnBasedActor>();
+        throwingActor.Setup(a => a.Act(It.IsAny<IContext>(), It.IsAny<IGenerationClient>()))
+            .ThrowsAsync(new InvalidOperationException("actor boom"));
+        engine.Context.Actors.Add(throwingActor.Object);
+
+        // Turn 1: assigns the stateful processor, then the actor throws -> safety net catches it.
+        string? turn1 = null;
+        var act1 = async () => turn1 = await engine.GetResponse("trigger");
+        await act1.Should().NotThrowAsync();
+        turn1.Should().NotBeNullOrEmpty();
+
+        // Turn 2: a normal command. If the orphaned processor were still in progress,
+        // RunProcessorInProgress would feed this input into it (a 2nd Process call).
+        var act2 = async () => await engine.GetResponse("look");
+        await act2.Should().NotThrowAsync();
+
+        statefulCommand.Verify(
+            c => c.Process(It.IsAny<string?>(), It.IsAny<IContext>(),
+                It.IsAny<IGenerationClient>(), It.IsAny<Runtime>()),
+            Times.Once);
     }
 }

--- a/UnitTests/Engine/GenerationFallbackTests.cs
+++ b/UnitTests/Engine/GenerationFallbackTests.cs
@@ -14,7 +14,8 @@ public class GenerationFallbackTests
 {
     private static GameEngine<ZorkI, ZorkIContext> BuildEngine(
         Mock<IGenerationClient> client,
-        IIntentParser parser)
+        IIntentParser parser,
+        CloudWatch.ICloudWatchLogger<CloudWatch.Model.TurnLog>? turnLogger = null)
     {
         var takeAndDropParser = new Mock<IAITakeAndAndDropParser>();
         takeAndDropParser
@@ -40,7 +41,7 @@ public class GenerationFallbackTests
             parser,
             client.Object,
             secrets,
-            Mock.Of<CloudWatch.ICloudWatchLogger<CloudWatch.Model.TurnLog>>(), 
+            turnLogger ?? Mock.Of<CloudWatch.ICloudWatchLogger<CloudWatch.Model.TurnLog>>(),
             Mock.Of<IParseConversation>()
         );
 
@@ -172,5 +173,73 @@ public class GenerationFallbackTests
         // Assert: still a graceful 200 body, this time the guaranteed canned sentence.
         result.Should().NotBeNullOrEmpty();
         result.Should().Contain(GameEngine<ZorkI, ZorkIContext>.EngineErrorFallbackMessage);
+    }
+
+    // The "exception stays discoverable" acceptance criterion: a failed turn must leave a CloudWatch
+    // TurnLog carrying the raw exception and the turn correlation id, so the swallowed bug can still
+    // be found. Verify the diagnostic TurnLog content directly, not just that generation happened.
+    [Test]
+    public async Task UnhandledException_WritesDiagnosticTurnLog_WithEngineErrorAndCorrelationId()
+    {
+        // Arrange: capture every TurnLog the engine writes during the failed turn.
+        var parser = new Mock<IIntentParser>();
+        parser.Setup(p => p.DetermineSystemIntentType(It.IsAny<string>()))
+            .Throws(new InvalidOperationException("boom — simulated deep engine crash"));
+
+        var loggedTurns = new List<CloudWatch.Model.TurnLog>();
+        var turnLogger = new Mock<CloudWatch.ICloudWatchLogger<CloudWatch.Model.TurnLog>>();
+        turnLogger.Setup(l => l.WriteLogEvents(It.IsAny<CloudWatch.Model.TurnLog>()))
+            .Callback<CloudWatch.Model.TurnLog>(loggedTurns.Add)
+            .Returns(Task.CompletedTask);
+
+        var client = new Mock<IGenerationClient>();
+        client.SetupAllProperties();
+        client.Object.LastFiveInputOutputs = new List<(string, string, bool)>();
+        client
+            .Setup(c => c.GenerateNarration(It.IsAny<Request>(), It.IsAny<string>()))
+            .ReturnsAsync("The world flickers for a moment.");
+
+        var engine = BuildEngine(client, parser.Object, turnLogger.Object);
+
+        // Act
+        await engine.GetResponse("do something that explodes");
+
+        // Assert: a diagnostic row exists carrying the raw exception and a correlation-id GUID.
+        loggedTurns.Should().Contain(t =>
+            t.Response.Contains("ENGINE ERROR") && t.Response.Contains("boom"));
+        loggedTurns.Should().Contain(t =>
+            System.Text.RegularExpressions.Regex.IsMatch(
+                t.Response, @"ENGINE ERROR \([0-9a-fA-F-]{36}\)"));
+    }
+
+    // The third branch of HandleUnexpectedEngineError: when generation is disabled
+    // (NoGeneratedResponses), the net must skip the AI call entirely and return the guaranteed
+    // static fallback. Covered only implicitly by the "generation throws" test otherwise.
+    [Test]
+    public async Task UnhandledException_WhenGenerationDisabled_ReturnsStaticFallback_WithoutCallingGeneration()
+    {
+        // Arrange
+        var parser = new Mock<IIntentParser>();
+        parser.Setup(p => p.DetermineSystemIntentType(It.IsAny<string>()))
+            .Throws(new InvalidOperationException("boom — simulated deep engine crash"));
+
+        var client = new Mock<IGenerationClient>();
+        client.SetupAllProperties();
+        client.Object.LastFiveInputOutputs = new List<(string, string, bool)>();
+
+        var engine = BuildEngine(client, parser.Object);
+        engine.NoGeneratedResponses = true;
+
+        // Act
+        string? result = null;
+        var act = async () => result = await engine.GetResponse("do something that explodes");
+        await act.Should().NotThrowAsync();
+
+        // Assert: static fallback returned, and no AI generation was attempted on the error path.
+        result.Should().NotBeNullOrEmpty();
+        result.Should().Contain(GameEngine<ZorkI, ZorkIContext>.EngineErrorFallbackMessage);
+        client.Verify(
+            c => c.GenerateNarration(It.IsAny<Request>(), It.IsAny<string>()),
+            Times.Never);
     }
 }

--- a/UnitTests/Engine/GenerationFallbackTests.cs
+++ b/UnitTests/Engine/GenerationFallbackTests.cs
@@ -110,4 +110,67 @@ public class GenerationFallbackTests
         // In DI constructor path, OnGenerate hook is not wired; flag may be false. Assert presence only.
         last.Item2.Should().NotBeNullOrEmpty();
     }
+
+    // Engine safety net (issue #271): an unhandled exception thrown anywhere during turn processing
+    // must never reach the player as an HTTP 500 / empty body. It is caught at the GetResponse
+    // chokepoint, logged, and converted into a graceful, AI-generated, in-character narrator "oops"
+    // returned with the normal turn shape (a non-empty 200 body).
+    [Test]
+    public async Task UnhandledException_DuringTurn_ReturnsGeneratedNarration_WithoutThrowing()
+    {
+        // Arrange: the parser seam throws while determining the intent for this input.
+        var parser = new Mock<IIntentParser>();
+        parser.Setup(p => p.DetermineSystemIntentType(It.IsAny<string>()))
+            .Throws(new InvalidOperationException("boom — simulated deep engine crash"));
+
+        var client = new Mock<IGenerationClient>();
+        client.SetupAllProperties();
+        client.Object.LastFiveInputOutputs = new List<(string, string, bool)>();
+        client
+            .Setup(c => c.GenerateNarration(It.IsAny<Request>(), It.IsAny<string>()))
+            .ReturnsAsync("The world flickers for a moment.");
+
+        var engine = BuildEngine(client, parser.Object);
+
+        // Act
+        string? result = null;
+        var act = async () => result = await engine.GetResponse("do something that explodes");
+        await act.Should().NotThrowAsync();
+
+        // Assert: graceful, non-empty 200-style response, generated via an EngineErrorRequest.
+        result.Should().NotBeNullOrEmpty();
+        result.Should().Contain("The world flickers for a moment.");
+        client.Verify(
+            c => c.GenerateNarration(It.IsAny<EngineErrorRequest>(), It.IsAny<string>()),
+            Times.Once);
+    }
+
+    // If the narrator itself is the thing that failed (generation throws), the net must still return
+    // the single guaranteed static fallback sentence rather than rethrowing.
+    [Test]
+    public async Task UnhandledException_WhenGenerationAlsoThrows_ReturnsStaticFallback()
+    {
+        // Arrange: turn processing throws, AND the error-narration generation throws too.
+        var parser = new Mock<IIntentParser>();
+        parser.Setup(p => p.DetermineSystemIntentType(It.IsAny<string>()))
+            .Throws(new InvalidOperationException("boom — simulated deep engine crash"));
+
+        var client = new Mock<IGenerationClient>();
+        client.SetupAllProperties();
+        client.Object.LastFiveInputOutputs = new List<(string, string, bool)>();
+        client
+            .Setup(c => c.GenerateNarration(It.IsAny<Request>(), It.IsAny<string>()))
+            .ThrowsAsync(new HttpRequestException("AI service unavailable"));
+
+        var engine = BuildEngine(client, parser.Object);
+
+        // Act
+        string? result = null;
+        var act = async () => result = await engine.GetResponse("do something that explodes");
+        await act.Should().NotThrowAsync();
+
+        // Assert: still a graceful 200 body, this time the guaranteed canned sentence.
+        result.Should().NotBeNullOrEmpty();
+        result.Should().Contain(GameEngine<ZorkI, ZorkIContext>.EngineErrorFallbackMessage);
+    }
 }

--- a/UnitTests/Models/RequestTests.cs
+++ b/UnitTests/Models/RequestTests.cs
@@ -328,4 +328,21 @@ public class RequestTests
 
         request.Temperature.Should().BeLessThan(0.8f);
     }
+
+    // The engine safety net (issue #271) turns any unhandled turn-processing crash into an
+    // in-character "oops" narration via this request. It must read as a deflection (low temperature,
+    // anti-hallucination guard) and must never tell the player a technical error occurred.
+    [Test]
+    public void EngineErrorRequest_HasNonEmptyMessage_AndUsesDeflectionTemperature()
+    {
+        // Act
+        var request = new EngineErrorRequest();
+
+        // Assert
+        request.UserMessage.Should().NotBeNullOrEmpty();
+        request.UserMessage.Should().Contain("could not be completed");
+        request.UserMessage.Should().Contain("Do not mention errors");
+        request.UserMessage.Should().Contain("not already explicitly present");
+        request.Temperature.Should().BeLessThan(0.8f);
+    }
 }


### PR DESCRIPTION
Closes #271.

## What

A single, well-placed catch-all so that **no unhandled exception during turn processing can ever reach the player as a raw HTTP 500 / empty body**. Any crash deep in the engine is now caught, logged, and converted into a graceful, in-character narrator **"oops"** returned with the normal `GameResponse` shape (a non-empty 200 body).

This is **defense-in-depth**, complementary to — not a replacement for — fixing the specific bugs that throw (e.g. #256). The net deliberately logs *loudly* so the underlying bug stays discoverable.

## How

**Primary chokepoint — `GameEngine.GetResponse`.** The body is wrapped in a single `try/catch`. Because every turn entry point (`POST /`, the `GET /` reconnect "look", and the `restoreGame` "look") funnels through `GetResponse`, this one wrap covers **Zork, Planetfall, and EscapeRoom**.

On an unhandled exception, `HandleUnexpectedEngineError`:
1. Logs the exception via the engine logger **and**, best-effort, writes a structured CloudWatch `TurnLog` carrying the **turn correlation id** — so the swallowed exception is still findable.
2. Generates a short, in-character acknowledgement from a new **`EngineErrorRequest`** and returns it through the normal `PostProcessing` pipeline, so it renders like any other turn.
3. Falls back to a **single guaranteed static sentence** only when the narrator itself is unavailable (`NoGeneratedResponses` set, or generation itself throws). `SafePostProcess` guarantees a non-empty 200 body even if post-processing itself throws.

**New request type — `Model/AIGeneration/Requests/EngineErrorRequest.cs`.** Follows the existing deflection pattern (`CommandHasNoEffectOperationRequest`): low `DeflectionTemperature`, includes `NoInventionGuard`, asks the narrator to acknowledge — briefly and in-character — that the action couldn't be completed, **without** inventing world state and **without** revealing the error.

## Testing (deterministic — no AI, no network)

- `GenerationFallbackTests.UnhandledException_DuringTurn_ReturnsGeneratedNarration_WithoutThrowing` — a parser seam that throws yields a non-empty, non-throwing response, and `IGenerationClient.GenerateNarration` is invoked with an `EngineErrorRequest`.
- `GenerationFallbackTests.UnhandledException_WhenGenerationAlsoThrows_ReturnsStaticFallback` — when error-narration generation *also* throws, the guaranteed static fallback is returned and nothing rethrows.
- `RequestTests.EngineErrorRequest_HasNonEmptyMessage_AndUsesDeflectionTemperature` — message is non-empty and runs at the low deflection temperature.

Confirmed red first (temporarily neutralised the catch with an always-false exception filter → both engine tests failed on `NotThrowAsync` because the exception propagated), then green with the fix.

Full suites pass with no regressions: UnitTests (880), ZorkOne.Tests (1228), Planetfall.Tests (2267), EscapeRoom.Tests (7).

## Acceptance criteria

- [x] An exception thrown anywhere during turn processing yields a 200 narrator "oops" response, never a 500.
- [x] The narrator message is AI-generated (with a guaranteed static fallback only when generation is itself unavailable).
- [x] The exception is logged with the turn correlation id.
- [x] Behavior verified by deterministic unit tests.
- [x] Applies to Zork, Planetfall, and EscapeRoom (shared engine path).

## Out of scope

The issue's **optional secondary chokepoint** (ASP.NET exception middleware for the save/restore/session endpoints that don't go through `GetResponse`) is intentionally left as a follow-up. It's explicitly lower priority, touches the shared hosting layer, and the turn-level net already satisfies every acceptance criterion above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S4DxLeBTKeEbeszUPzdrU4)_