### PR TITLE
Fix "it" losing its antecedent across movement in the production AI path (#275)

### DIFF
--- a/GameEngine/GameEngine.cs
+++ b/GameEngine/GameEngine.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Text.RegularExpressions;
 using ChatLambda;
 using CloudWatch;
 using CloudWatch.Model;
@@ -399,8 +400,15 @@ public class GameEngine<TInfocomGame, TContext> : IGameEngine
         if (returnResponseFromAgainProcessor)
             return PostProcessing(_currentInput);
 
-        // Resolve pronouns from recent player input and game response (BEFORE ItProcessor)
-        if (!string.IsNullOrEmpty(Context.LastInput) || !string.IsNullOrEmpty(Context.LastResponse))
+        // Resolve pronouns from recent player input and game response (BEFORE ItProcessor), UNLESS a
+        // just-completed move left the deterministic engine holding a still-carried antecedent for
+        // this pronoun. After a move, LastInput is the movement command ("north") and LastResponse is
+        // the destination room's description, so the AI resolver would re-bind "it"/"them" to a noun
+        // in the NEW room and lose the carried-item antecedent that MoveEngine deliberately preserved
+        // across the move (issues #248 / #275). In that case we defer to the deterministic ItProcessor
+        // below, which resolves the pronoun from the preserved LastNoun/LastNouns.
+        if (!MoveJustClobberedPronounContext(_currentInput!, Context)
+            && (!string.IsNullOrEmpty(Context.LastInput) || !string.IsNullOrEmpty(Context.LastResponse)))
         {
             var resolved = await _parser.ResolvePronounsAsync(_currentInput!, Context.LastInput, Context.LastResponse);
             if (resolved != null && !resolved.Equals(_currentInput, StringComparison.OrdinalIgnoreCase))
@@ -477,6 +485,39 @@ public class GameEngine<TInfocomGame, TContext> : IGameEngine
 
         // Put it all together for return.
         return await ProcessActorsAndContextEndOfTurn(contextPrepend, complexIntentResult.ResultMessage);
+    }
+
+    /// <summary>
+    ///     True when the immediately preceding command was a movement and the player's current command
+    ///     uses "it"/"them" with a still-carried antecedent that <see cref="MoveEngine" /> preserved
+    ///     across that move (issue #248). When this holds we must NOT run the AI pronoun resolver: right
+    ///     after a move its only context is the movement command (LastInput) and the destination room's
+    ///     description (LastResponse), so it re-binds the pronoun to a noun in the NEW room and the
+    ///     carried-item antecedent is lost (issue #275 — "the invisible gangway"). The deterministic
+    ///     <see cref="ItProcessor" /> downstream resolves the pronoun from LastNoun/LastNouns instead.
+    ///
+    ///     The check is deliberately scoped to the post-move case so the AI resolver keeps its value for
+    ///     every other turn — semantic rewrites like "put it on" -> "wear X", resolving from response
+    ///     narration, the other pronouns (him/her/that/...), and so on.
+    /// </summary>
+    private static bool MoveJustClobberedPronounContext(string input, IContext context)
+    {
+        // "the move is the trigger": only defer to the preserved antecedent when the previous command
+        // (now sitting in LastInput) was itself a movement. Any non-move command refreshes LastInput
+        // with a real noun phrase, which is exactly what the AI resolver needs to work correctly.
+        if (!DirectionParser.IsDirection(context.LastInput, out _))
+            return false;
+
+        // Only "it"/"them" are resolved deterministically from LastNoun/LastNouns; for any other
+        // pronoun (him, her, that, ...) the AI resolver is the only thing that can help, so let it run.
+        if (Regex.IsMatch(input, @"\bit\b", RegexOptions.IgnoreCase))
+            return !string.IsNullOrEmpty(context.LastNoun) &&
+                   context.HasMatchingNoun(context.LastNoun).HasItem;
+
+        if (Regex.IsMatch(input, @"\bthem\b", RegexOptions.IgnoreCase))
+            return context.LastNouns.Any(noun => context.HasMatchingNoun(noun).HasItem);
+
+        return false;
     }
 
     public IContext RestoreGame(string data)

--- a/Planetfall.Tests/PronounResolutionTests.cs
+++ b/Planetfall.Tests/PronounResolutionTests.cs
@@ -1,6 +1,11 @@
+using System.Text.RegularExpressions;
 using FluentAssertions;
+using Planetfall.GlobalCommand;
+using Planetfall.Item.Kalamontee.Mech;
 using Planetfall.Item.Lawanda.LabOffice;
+using Planetfall.Location.Kalamontee.Mech;
 using Planetfall.Location.Lawanda.LabOffice;
+using UnitTests;
 
 namespace Planetfall.Tests;
 
@@ -139,6 +144,80 @@ public class PronounResolutionTests : EngineTestsBase
 
             Context.HasItem<Memo>().Should().BeFalse(
                 because: "Memo should be dropped after 'drop it'");
+        }
+    }
+
+    /// <summary>
+    /// Issue #275: in production, "it" lost its antecedent across movement for an item the player
+    /// was still carrying. The deterministic engine seam (MoveEngine preserves LastNoun, ItProcessor
+    /// resolves it) was already fixed by #248 and its unit test passes — but a production turn ALSO
+    /// runs the AI pronoun resolver first, and after a move that resolver only sees the movement
+    /// command (LastInput) and the destination room's description (LastResponse). It therefore
+    /// re-bound "it" to a noun in the NEW room and the carried-item antecedent was lost.
+    ///
+    /// The stock <see cref="TestParser"/> can't reproduce this (its heuristic returns null for the
+    /// post-move case, so the deterministic path always wins in tests). These tests drive the same
+    /// path prod uses with a resolver that deliberately mimics the production failure mode.
+    /// </summary>
+    [TestFixture]
+    public class ItAcrossMovementWithAiResolver : PronounResolutionTests
+    {
+        /// <summary>
+        /// Models the production gpt-4o-mini pronoun resolver after a move: it re-binds "it" to a
+        /// noun from the new room (here a fixed decoy, echoing the issue's "invisible gangway")
+        /// instead of honoring the carried-item antecedent that #248 preserved. Subclasses the real
+        /// <see cref="TestParser"/> so every non-post-move turn still parses exactly as normal.
+        /// </summary>
+        private sealed class RebindsItToNewRoomAfterMoveParser(string decoyNoun)
+            : TestParser(new PlanetfallGlobalCommandFactory(), "Planetfall")
+        {
+            private static readonly HashSet<string> Directions = new(StringComparer.OrdinalIgnoreCase)
+            {
+                "north", "south", "east", "west", "up", "down", "in", "out",
+                "ne", "nw", "se", "sw", "n", "s", "e", "w", "u", "d",
+                "northeast", "northwest", "southeast", "southwest"
+            };
+
+            public override Task<string?> ResolvePronounsAsync(string input, string? lastInput, string? lastResponse)
+            {
+                // When the previous turn was a bare movement, the real resolver no longer has the
+                // carried item in its context and grabs a noun from the destination room instead.
+                if (Regex.IsMatch(input, @"\bit\b", RegexOptions.IgnoreCase)
+                    && Directions.Contains((lastInput ?? string.Empty).Trim()))
+                {
+                    return Task.FromResult<string?>(
+                        Regex.Replace(input, @"\bit\b", decoyNoun, RegexOptions.IgnoreCase));
+                }
+
+                return base.ResolvePronounsAsync(input, lastInput, lastResponse);
+            }
+        }
+
+        [Test]
+        public async Task DropIt_AfterMovingWithCarriedBar_StillDropsTheCarriedItem()
+        {
+            // Reproduces AB-020: take bar; examine it; <move>; drop it. The bar is carried the whole
+            // time, so "drop it" must still drop it after walking to the next room — even though the
+            // production AI resolver would otherwise re-bind "it" to the destination room.
+            var parser = new RebindsItToNewRoomAfterMoveParser("gangway");
+            var target = GetTarget(parser);
+
+            var toolRoom = StartHere<ToolRoom>();
+            var magnet = GetItem<Magnet>();
+            toolRoom.ItemPlacedHere(magnet);
+
+            await target.GetResponse("take bar");
+            Context.HasItem<Magnet>().Should().BeTrue("the player just picked up the bar");
+
+            await target.GetResponse("examine it"); // sets LastNoun = "bar"
+            await target.GetResponse("east");        // a real parsed move to the Machine Shop
+
+            var response = await target.GetResponse("drop it");
+
+            response.Should().Contain("Dropped",
+                "'it' still refers to the carried bar after a move (issues #248 / #275)");
+            Context.HasItem<Magnet>().Should().BeFalse(
+                "the carried bar should be dropped, not re-bound to a noun in the destination room");
         }
     }
 }


### PR DESCRIPTION
## Problem (issue #275, AB-020)

In production (Planetfall 1.6.2), `it` lost its antecedent **across movement** for an item the player was still carrying — the exact case #248/#253 claimed to fix:

```
take bar
examine it   -> "...the metal bar, curved into a U-shape."   (it = bar ✅)
north
drop it      -> "You don't have that!"   (bar NOT dropped ❌)
```

Without a move it works fine, so **the move is the trigger**.

## Root cause

#248 fixed the **deterministic** engine seam: `MoveEngine` preserves `LastNoun` for a carried item across a move, and `ItProcessor` resolves `it` from it. Its unit test passes on `main`.

But a **production** turn first runs the **AI pronoun resolver** (`PronounResolver`), which only sees `LastInput` and `LastResponse`. Right after a move those become the movement command (`"north"`) and the **destination room's description**, so the resolver re-bound `it`/`them` to a noun in the *new* room (the issue's "invisible gangway") — bypassing the preserved `LastNoun`. The existing unit test can't catch this because it runs the AI-disabled path (no API key → resolver is a no-op), where the deterministic `ItProcessor` always wins.

## Fix

Skip the AI resolver **only** when the immediately preceding command was a movement *and* the pronoun has a still-carried antecedent that `MoveEngine` preserved; defer to the deterministic `ItProcessor` in that case.

The check (`MoveJustClobberedPronounContext`) is deliberately scoped to the post-move case (`DirectionParser.IsDirection(LastInput)`), so the AI resolver keeps its value on every other turn — semantic rewrites like `"put it on"` → `"wear X"`, resolving from response narration, the other pronouns (`him`/`her`/`that`/…), and so on.

## Test (TDD)

Adds a deterministic Planetfall test (`PronounResolutionTests.ItAcrossMovementWithAiResolver`) that drives `take bar` → `examine it` → a real parsed move → `drop it` through the **same path prod uses**, with a stubbed resolver that reproduces the post-move re-binding. It **fails before** the fix (carried bar not dropped; response has no "Dropped") and **passes after**.

## Verification

- New test: red → green.
- Previously-regressing `ChainedPronoun_PutItOn_AfterHavingMask` (semantic `"put it on"`→wear, no movement) stays green — the gate is narrowed to post-move only.
- Full suites, zero failures: **Planetfall.Tests 2272**, **UnitTests 889** (+1 pre-existing skip), **ZorkOne.Tests 1228**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016TwDEa2ZrVSJefwjnbYG7i)_