### PR TITLE
God mode: toggle to disable sleep & hunger survival clocks (#277)

### DIFF
--- a/GameEngine/StaticCommand/Implementation/GodModeProcessor.cs
+++ b/GameEngine/StaticCommand/Implementation/GodModeProcessor.cs
@@ -19,7 +19,57 @@ public class GodModeProcessor : IGlobalCommand
         if (input.Contains(" go ")) return Task.FromResult(Go(input, context));
         if (input.Contains(" where ")) return Task.FromResult(Where(input));
 
+        // Issue #277: toggle the survival clocks (sleep/hunger) for deterministic playtesting. Only
+        // games whose context tracks those clocks (Planetfall) implement ISurvivalClockContext.
+        if (context is ISurvivalClockContext survivalContext &&
+            ToggleSurvivalClocks(input, survivalContext) is { } survivalResult)
+            return Task.FromResult(survivalResult);
+
         return Task.FromResult("Invalid use of God mode. Bad adventurer! ");
+    }
+
+    /// <summary>
+    /// Issue #277: recognizes "god mode [no] sleep|hunger|survival" (with optional "on"/"off") and
+    /// flips the corresponding survival-clock flag on the context. "no"/"off" disables a clock;
+    /// anything else re-enables it. "survival" affects both clocks at once. Returns the confirmation
+    /// message, or null if the input names no recognized clock (so the caller falls through to the
+    /// generic god-mode error).
+    /// </summary>
+    private static string? ToggleSurvivalClocks(string input, ISurvivalClockContext context)
+    {
+        var words = input.ToLowerInvariant().Split(' ', StringSplitOptions.RemoveEmptyEntries);
+
+        var affectsSleep = words.Contains("sleep") || words.Contains("survival");
+        var affectsHunger = words.Contains("hunger") || words.Contains("survival");
+
+        // Not a survival-clock command - let the caller emit the generic error.
+        if (!affectsSleep && !affectsHunger)
+            return null;
+
+        // "no" / "off" disables the clock; a bare verb (or explicit "on") re-enables it.
+        var disable = words.Contains("no") || words.Contains("off");
+
+        var affected = new List<string>();
+        var effects = new List<string>();
+        if (affectsSleep)
+        {
+            context.SleepClockDisabled = disable;
+            affected.Add("sleep");
+            effects.Add("tired");
+        }
+
+        if (affectsHunger)
+        {
+            context.HungerClockDisabled = disable;
+            affected.Add("hunger");
+            effects.Add("hungry");
+        }
+
+        var clocks = string.Join(" and ", affected);
+        var noun = affected.Count > 1 ? "clocks" : "clock";
+        return disable
+            ? $"God mode: {clocks} {noun} disabled. You will no longer get {string.Join(" or ", effects)}. "
+            : $"God mode: {clocks} {noun} enabled. ";
     }
 
     private string Where(string input)

--- a/Model/Interface/ISurvivalClockContext.cs
+++ b/Model/Interface/ISurvivalClockContext.cs
@@ -1,0 +1,22 @@
+namespace Model.Interface;
+
+/// <summary>
+///     Marker interface for game contexts that maintain "survival" clocks - the sleep/fatigue and
+///     hunger/thirst timers that advance every turn. Games with these mechanics (Planetfall) implement
+///     this so god mode can switch the clocks off for deterministic playtesting; games without them
+///     (Zork) do not. See issue #277.
+/// </summary>
+public interface ISurvivalClockContext
+{
+    /// <summary>
+    ///     When true, the sleep/fatigue clock is suspended: no tiredness escalation, no sleep warnings,
+    ///     and no forced sleep. Purely a debug/testing affordance.
+    /// </summary>
+    bool SleepClockDisabled { get; set; }
+
+    /// <summary>
+    ///     When true, the hunger/thirst clock is suspended: no hunger escalation, no hunger warnings,
+    ///     and no starvation death. Purely a debug/testing affordance.
+    /// </summary>
+    bool HungerClockDisabled { get; set; }
+}

--- a/Planetfall.Tests/SurvivalClockGodModeTests.cs
+++ b/Planetfall.Tests/SurvivalClockGodModeTests.cs
@@ -1,0 +1,219 @@
+using FluentAssertions;
+using Planetfall.Location.Kalamontee.Dorm;
+using Utilities;
+
+namespace Planetfall.Tests;
+
+/// <summary>
+/// Issue #277: god-mode toggle to disable the sleep and hunger survival clocks, a deterministic
+/// playtesting affordance. Covers the command wiring, the per-turn clock guards, persistence
+/// through save/restore, and that ordinary (non-god-mode) play is unaffected.
+/// </summary>
+public class SurvivalClockGodModeTests : EngineTestsBase
+{
+    #region Command wiring
+
+    [Test]
+    public async Task GodMode_NoSleep_DisablesSleepClockOnly()
+    {
+        var engine = GetTarget();
+        StartHere<DormA>();
+
+        var response = await engine.GetResponse("god mode no sleep");
+
+        engine.Context.SleepClockDisabled.Should().BeTrue();
+        engine.Context.HungerClockDisabled.Should().BeFalse();
+        // Confirmation - and proof the survival branch ran rather than the generic god-mode error.
+        response.Should().Contain("sleep clock disabled");
+    }
+
+    [Test]
+    public async Task GodMode_Sleep_ReEnablesSleepClock()
+    {
+        var engine = GetTarget();
+        StartHere<DormA>();
+        engine.Context.SleepClockDisabled = true;
+
+        await engine.GetResponse("god mode sleep");
+
+        engine.Context.SleepClockDisabled.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task GodMode_NoHunger_DisablesHungerClockOnly()
+    {
+        var engine = GetTarget();
+        StartHere<DormA>();
+
+        await engine.GetResponse("god mode no hunger");
+
+        engine.Context.HungerClockDisabled.Should().BeTrue();
+        engine.Context.SleepClockDisabled.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task GodMode_Hunger_ReEnablesHungerClock()
+    {
+        var engine = GetTarget();
+        StartHere<DormA>();
+        engine.Context.HungerClockDisabled = true;
+
+        await engine.GetResponse("god mode hunger");
+
+        engine.Context.HungerClockDisabled.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task GodMode_NoSurvival_DisablesBothClocks()
+    {
+        var engine = GetTarget();
+        StartHere<DormA>();
+
+        await engine.GetResponse("god mode no survival");
+
+        engine.Context.SleepClockDisabled.Should().BeTrue();
+        engine.Context.HungerClockDisabled.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task GodMode_Survival_ReEnablesBothClocks()
+    {
+        var engine = GetTarget();
+        StartHere<DormA>();
+        engine.Context.SleepClockDisabled = true;
+        engine.Context.HungerClockDisabled = true;
+
+        await engine.GetResponse("god mode survival");
+
+        engine.Context.SleepClockDisabled.Should().BeFalse();
+        engine.Context.HungerClockDisabled.Should().BeFalse();
+    }
+
+    #endregion
+
+    #region Sleep clock guards
+
+    [Test]
+    public void SleepClockDisabled_DoesNotForceSleep_EvenAtMaxTiredness()
+    {
+        var engine = GetTarget();
+        var context = engine.Context;
+        StartHere<DormA>();
+
+        context.SleepClockDisabled = true;
+        context.Tired = TiredLevel.AboutToDrop;
+        // Forced sleep would normally fire this very turn.
+        context.SleepNotifications.NextWarningAt = context.CurrentTime;
+
+        context.ProcessBeginningOfTurn();
+
+        context.Day.Should().Be(1); // no forced sleep, so the day never advanced
+        context.Tired.Should().Be(TiredLevel.WellRested); // an already-tired session is relieved
+        context.CurrentLocation.Should().BeOfType<DormA>(); // never climbed into a bunk
+    }
+
+    [Test]
+    public void SleepClockDisabled_NoTirednessWarnings_OverLongSession()
+    {
+        var engine = GetTarget();
+        var context = engine.Context;
+        StartHere<DormA>();
+
+        context.SleepClockDisabled = true;
+        // Warnings/escalation would otherwise fire repeatedly across the session.
+        context.SleepNotifications.NextWarningAt = context.CurrentTime;
+
+        for (var i = 0; i < 150; i++)
+        {
+            var result = context.ProcessBeginningOfTurn() ?? string.Empty;
+            result.Should().NotContain("weary");
+            result.Should().NotContain("tired");
+            context.ProcessEndOfTurn(); // advances the chronometer
+        }
+
+        context.Tired.Should().Be(TiredLevel.WellRested);
+        context.Day.Should().Be(1);
+    }
+
+    [Test]
+    public void SleepClock_WhenEnabled_StillForcesSleep()
+    {
+        // Control: the toggle is opt-in. Default play must still force sleep at max tiredness.
+        var engine = GetTarget();
+        var context = engine.Context;
+        StartHere<DormA>();
+
+        context.Tired = TiredLevel.AboutToDrop;
+        context.SleepNotifications.NextWarningAt = context.CurrentTime;
+
+        var result = context.ProcessBeginningOfTurn() ?? string.Empty;
+
+        result.Should().Contain("bunk beds"); // forced sleep climbed into a bunk
+        context.Day.Should().Be(2); // and advanced to the next day
+    }
+
+    #endregion
+
+    #region Hunger clock guards
+
+    [Test]
+    public void HungerClockDisabled_NoStarvationDeath_OverLongSession()
+    {
+        var engine = GetTarget();
+        var context = engine.Context;
+        StartHere<DormA>();
+
+        context.HungerClockDisabled = true;
+        context.Hunger = HungerLevel.AboutToPassOut; // one tick from a starvation death
+        context.HungerNotifications.NextWarningAt = context.CurrentTime;
+
+        for (var i = 0; i < 150; i++)
+        {
+            context.ProcessBeginningOfTurn();
+            context.PendingDeath.Should().BeNull();
+            context.ProcessEndOfTurn();
+        }
+
+        context.Hunger.Should().Be(HungerLevel.WellFed); // an already-hungry session is relieved
+    }
+
+    [Test]
+    public void HungerClock_WhenEnabled_StillKillsByStarvation()
+    {
+        // Control: the toggle is opt-in. Default play must still starve the player.
+        var engine = GetTarget();
+        var context = engine.Context;
+        StartHere<DormA>();
+
+        context.Hunger = HungerLevel.AboutToPassOut;
+        context.HungerNotifications.NextWarningAt = context.CurrentTime;
+
+        context.ProcessBeginningOfTurn();
+
+        context.PendingDeath.Should().NotBeNull();
+    }
+
+    #endregion
+
+    #region Persistence
+
+    [Test]
+    public void SurvivalClockFlags_SurviveSaveAndRestore()
+    {
+        var engine = GetTarget();
+        StartHere<DormA>();
+        engine.Context.SleepClockDisabled = true;
+        engine.Context.HungerClockDisabled = true;
+
+        var saved = engine.SaveGame();
+
+        // Restore into a fresh engine/repository to prove the flags round-trip through the save JSON.
+        var freshEngine = GetTarget();
+        var restored = (PlanetfallContext)freshEngine.RestoreGame(saved);
+
+        restored.SleepClockDisabled.Should().BeTrue();
+        restored.HungerClockDisabled.Should().BeTrue();
+    }
+
+    #endregion
+}

--- a/Planetfall/PlanetfallContext.cs
+++ b/Planetfall/PlanetfallContext.cs
@@ -6,10 +6,26 @@ using Utilities;
 
 namespace Planetfall;
 
-public class PlanetfallContext : Context<PlanetfallGame>, ITimeBasedContext
+public class PlanetfallContext : Context<PlanetfallGame>, ITimeBasedContext, ISurvivalClockContext
 {
     [UsedImplicitly]
     public int Day { get; set; } = 1;
+
+    /// <summary>
+    ///     Issue #277: god-mode test affordance. When true, the sleep/fatigue clock is suspended -
+    ///     no tiredness escalation, warnings, or forced sleep - and the player is kept well-rested.
+    ///     Plain auto-property so it round-trips through the save/restore JSON like the rest of context state.
+    /// </summary>
+    [UsedImplicitly]
+    public bool SleepClockDisabled { get; set; }
+
+    /// <summary>
+    ///     Issue #277: god-mode test affordance. When true, the hunger/thirst clock is suspended -
+    ///     no hunger escalation, warnings, or starvation death - and the player is kept well-fed.
+    ///     Plain auto-property so it round-trips through the save/restore JSON like the rest of context state.
+    /// </summary>
+    [UsedImplicitly]
+    public bool HungerClockDisabled { get; set; }
 
     /// <summary>
     ///     Number of times the player has died. Preserved across death restarts.
@@ -101,12 +117,24 @@ public class PlanetfallContext : Context<PlanetfallGame>, ITimeBasedContext
 
         var messages = string.Empty;
 
-        // Check for sleep events (voluntary or forced)
-        var sleepMessage = SleepEngine.CheckForSleep(this);
-        if (!string.IsNullOrEmpty(sleepMessage))
+        // Issue #277: when the sleep clock is disabled (god-mode test affordance) we never check for
+        // voluntary/forced sleep, and we keep the player well-rested so an already-tired session is
+        // immediately relieved. We also cancel any pending fall-asleep so the player can't get stuck
+        // in a bed they entered before flipping the toggle.
+        if (SleepClockDisabled)
         {
-            SleepJustOccurred = true;
-            return sleepMessage + base.ProcessBeginningOfTurn();
+            Tired = TiredLevel.WellRested;
+            SleepNotifications.CancelFallAsleep();
+        }
+        else
+        {
+            // Check for sleep events (voluntary or forced)
+            var sleepMessage = SleepEngine.CheckForSleep(this);
+            if (!string.IsNullOrEmpty(sleepMessage))
+            {
+                SleepJustOccurred = true;
+                return sleepMessage + base.ProcessBeginningOfTurn();
+            }
         }
 
         // Check for sickness notifications
@@ -116,47 +144,60 @@ public class PlanetfallContext : Context<PlanetfallGame>, ITimeBasedContext
             messages += sicknessNotification;
         }
 
-        // Check if sleep level should advance
-        var nextTiredLevel = SleepNotifications.GetNextTiredLevel(CurrentTime, Tired);
-        if (nextTiredLevel.HasValue)
+        // Check if sleep level should advance (skipped entirely when the sleep clock is disabled - issue #277)
+        if (!SleepClockDisabled)
         {
-            // Get notification BEFORE advancing level
-            var sleepNotification = SleepNotifications.GetNotification(CurrentTime, Tired);
-
-            Tired = nextTiredLevel.Value;
-
-            // Add notification message (with newline separator if sickness notification also fired)
-            if (!string.IsNullOrEmpty(sleepNotification))
+            var nextTiredLevel = SleepNotifications.GetNextTiredLevel(CurrentTime, Tired);
+            if (nextTiredLevel.HasValue)
             {
-                if (!string.IsNullOrEmpty(messages))
-                    messages += "\n";
-                messages += sleepNotification;
+                // Get notification BEFORE advancing level
+                var sleepNotification = SleepNotifications.GetNotification(CurrentTime, Tired);
+
+                Tired = nextTiredLevel.Value;
+
+                // Add notification message (with newline separator if sickness notification also fired)
+                if (!string.IsNullOrEmpty(sleepNotification))
+                {
+                    if (!string.IsNullOrEmpty(messages))
+                        messages += "\n";
+                    messages += sleepNotification;
+                }
             }
         }
 
-        // Check if hunger level should advance
-        var nextHungerLevel = HungerNotifications.GetNextHungerLevel(CurrentTime, Hunger);
-        if (nextHungerLevel.HasValue)
+        // Issue #277: when the hunger clock is disabled (god-mode test affordance) we skip all hunger
+        // escalation and the starvation death, and keep the player well-fed so an already-hungry
+        // session is immediately relieved.
+        if (HungerClockDisabled)
         {
-            // Get notification BEFORE advancing level (so it returns notification for the new level)
-            var hungerNotification = HungerNotifications.GetNotification(CurrentTime, Hunger);
-
-            Hunger = nextHungerLevel.Value;
-
-            // Check for death
-            if (Hunger == HungerLevel.Dead)
+            Hunger = HungerLevel.WellFed;
+        }
+        else
+        {
+            // Check if hunger level should advance
+            var nextHungerLevel = HungerNotifications.GetNextHungerLevel(CurrentTime, Hunger);
+            if (nextHungerLevel.HasValue)
             {
-                var deathResult = new DeathProcessor().Process(
-                    "You collapse from extreme thirst and hunger.", this);
-                return messages + "\n" + deathResult.InteractionMessage;
-            }
+                // Get notification BEFORE advancing level (so it returns notification for the new level)
+                var hungerNotification = HungerNotifications.GetNotification(CurrentTime, Hunger);
 
-            // Add notification message (with newline separator if sickness notification also fired)
-            if (!string.IsNullOrEmpty(hungerNotification))
-            {
-                if (!string.IsNullOrEmpty(messages))
-                    messages += "\n";
-                messages += hungerNotification;
+                Hunger = nextHungerLevel.Value;
+
+                // Check for death
+                if (Hunger == HungerLevel.Dead)
+                {
+                    var deathResult = new DeathProcessor().Process(
+                        "You collapse from extreme thirst and hunger.", this);
+                    return messages + "\n" + deathResult.InteractionMessage;
+                }
+
+                // Add notification message (with newline separator if sickness notification also fired)
+                if (!string.IsNullOrEmpty(hungerNotification))
+                {
+                    if (!string.IsNullOrEmpty(messages))
+                        messages += "\n";
+                    messages += hungerNotification;
+                }
             }
         }
 


### PR DESCRIPTION
Closes #277.

Adds a god-mode toggle that switches off the Planetfall **sleep** and **hunger** survival clocks — a debug/testing affordance so the AdventureBreaker harness can deterministically spine-run into the late game without floor-sleeping (which drops all non-worn inventory) or starving mid-session.

## Commands
All under `god mode` (case-insensitive):

| Command | Effect |
|---|---|
| `god mode no sleep` / `god mode sleep` | disable / re-enable the sleep clock |
| `god mode no hunger` / `god mode hunger` | disable / re-enable the hunger clock |
| `god mode no survival` / `god mode survival` | both at once (`off`/`on` also accepted, e.g. `god mode survival off`) |

## Implementation
- **`Model.Interface.ISurvivalClockContext`** (new) exposes two plain `bool` flags. The shared `GodModeProcessor` lives in `GameEngine`, which can't reference `Planetfall`, so it flips the clocks through this interface and gates the whole branch on `context is ISurvivalClockContext` — Zork/EscapeRoom god mode is untouched.
- The flags are **plain auto-properties** on `PlanetfallContext`, so they round-trip through the save/restore JSON and a checkpointed session stays clock-free.
- **`PlanetfallContext.ProcessBeginningOfTurn`** skips forced sleep, tiredness escalation, hunger escalation and the starvation death while the respective clock is disabled, and keeps the player `WellRested`/`WellFed` so an already-tired/hungry session is immediately relieved. It also cancels any pending fall-asleep so the player can't get stuck in a bed entered before the toggle.

## Acceptance criteria
- [x] `god mode no sleep` / `god mode no hunger` (and a combined `survival` toggle) disable the respective clock; the inverse re-enables it.
- [x] While disabled: no tiredness/hunger warnings, no forced sleep, no hunger death — verified over 150-turn sessions.
- [x] The flags survive save/restore.
- [x] No effect on normal (non-god-mode) play.

## Tests
New `SurvivalClockGodModeTests` (12 tests) covers the command wiring, the per-turn guards across 150-turn sessions, save/restore persistence, and opt-in **control** tests proving default play still forces sleep and still starves. Developed test-first (red → green).

Regression: full solution builds clean; `Planetfall.Tests` (2299), `UnitTests` (891), and `ZorkOne.Tests` (1240) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014761zYdDszrsYRHVi3NcZK

---
_Generated by [Claude Code](https://claude.ai/code/session_014761zYdDszrsYRHVi3NcZK)_