### PR TITLE
Add Stream View and Stream rooms off the Reservoir (#210)

### DIFF
--- a/ZorkOne.Tests/Places/StreamTests.cs
+++ b/ZorkOne.Tests/Places/StreamTests.cs
@@ -1,0 +1,147 @@
+using FluentAssertions;
+using GameEngine;
+using Model.Location;
+using ZorkOne.Item;
+using ZorkOne.Location;
+
+namespace ZorkOne.Tests.Places;
+
+[TestFixture]
+public class StreamTests : EngineTestsBase
+{
+    // Issue #210: the optional stream branch off the Reservoir was missing — Stream View and the
+    // water room IN-STREAM (displayed "Stream"), plus the four exits that reach them. Verified against
+    // zork1/1dungeon.zil: STREAM-VIEW :1805, IN-STREAM :1819, RESERVOIR-SOUTH WEST :1775,
+    // RESERVOIR UP/WEST :1788-1789.
+
+    private GameEngine<ZorkI, ZorkIContext> GetLitTargetAt<T>() where T : class, ILocation, new()
+    {
+        var target = GetTarget();
+        target.Context.CurrentLocation = Repository.GetLocation<T>();
+        target.Context.Take(Repository.GetItem<Lantern>());
+        Repository.GetItem<Lantern>().IsOn = true;
+        return target;
+    }
+
+    // Put the reservoir into its drained state — the only state in which the Reservoir room (and so the
+    // stream above it) is reachable in normal play, and the only state in which standing in the
+    // Reservoir is survivable. A full/filling reservoir drowns the player via Reservoir.Act(), which
+    // fires during end-of-turn processing the moment we move into the Reservoir.
+    private static void DrainReservoir()
+    {
+        var south = Repository.GetLocation<ReservoirSouth>();
+        south.IsDrained = true;
+        south.IsFull = false;
+        south.IsFilling = false;
+        south.IsDraining = false;
+    }
+
+    [Test]
+    public async Task ReservoirSouth_West_ReachesStreamView()
+    {
+        // The room's own description promises "a path along the stream to the east or west"; before the
+        // fix, WEST was a dead pointer.
+        var target = GetLitTargetAt<ReservoirSouth>();
+
+        var response = await target.GetResponse("west");
+
+        response.Should().Contain("Stream View");
+        response.Should().Contain("gently flowing stream");
+    }
+
+    [Test]
+    public async Task StreamView_West_TooSmallToEnter()
+    {
+        var target = GetLitTargetAt<StreamView>();
+
+        var response = await target.GetResponse("west");
+
+        response.Should().Contain("too small for you to enter");
+    }
+
+    [Test]
+    public async Task StreamView_East_ReturnsToReservoirSouth()
+    {
+        var target = GetLitTargetAt<StreamView>();
+
+        var response = await target.GetResponse("east");
+
+        response.Should().Contain("Reservoir South");
+    }
+
+    [Test]
+    public async Task Reservoir_Up_ReachesStream_WhenDrained()
+    {
+        DrainReservoir();
+        var target = GetLitTargetAt<Reservoir>();
+
+        var response = await target.GetResponse("up");
+
+        response.Should().Contain("narrow beach");
+    }
+
+    [Test]
+    public async Task Reservoir_West_ReachesStream_WhenDrained()
+    {
+        DrainReservoir();
+        var target = GetLitTargetAt<Reservoir>();
+
+        var response = await target.GetResponse("west");
+
+        response.Should().Contain("narrow beach");
+    }
+
+    [Test]
+    public async Task Stream_Up_ChannelTooNarrow()
+    {
+        var target = GetLitTargetAt<InStream>();
+
+        var response = await target.GetResponse("up");
+
+        response.Should().Contain("channel is too narrow");
+    }
+
+    [Test]
+    public async Task Stream_West_ChannelTooNarrow()
+    {
+        var target = GetLitTargetAt<InStream>();
+
+        var response = await target.GetResponse("west");
+
+        response.Should().Contain("channel is too narrow");
+    }
+
+    [Test]
+    public async Task Stream_Down_ReachesReservoir()
+    {
+        DrainReservoir();
+        var target = GetLitTargetAt<InStream>();
+
+        var response = await target.GetResponse("down");
+
+        response.Should().Contain("mud");
+    }
+
+    [Test]
+    public async Task Stream_East_ReachesReservoir()
+    {
+        DrainReservoir();
+        var target = GetLitTargetAt<InStream>();
+
+        var response = await target.GetResponse("east");
+
+        response.Should().Contain("mud");
+    }
+
+    [Test]
+    public async Task Stream_Land_ReachesStreamView()
+    {
+        // IN-STREAM's LAND exit. Direction has no "Land" member, so InStream handles the original LAND
+        // command (and synonyms) and routes to the beach at Stream View.
+        var target = GetLitTargetAt<InStream>();
+
+        var response = await target.GetResponse("land");
+
+        response.Should().Contain("Stream View");
+    }
+}

--- a/ZorkOne.Tests/Places/StreamTests.cs
+++ b/ZorkOne.Tests/Places/StreamTests.cs
@@ -23,10 +23,10 @@ public class StreamTests : EngineTestsBase
         return target;
     }
 
-    // Put the reservoir into its drained state — the only state in which the Reservoir room (and so the
-    // stream above it) is reachable in normal play, and the only state in which standing in the
-    // Reservoir is survivable. A full/filling reservoir drowns the player via Reservoir.Act(), which
-    // fires during end-of-turn processing the moment we move into the Reservoir.
+    // Put the reservoir into its drained, survivable state. MUST be called AFTER GetLitTargetAt — that
+    // helper runs GetTarget(), which calls Repository.Reset() and rebuilds every location singleton
+    // fresh (ReservoirSouth.Init() sets IsFull = true). Calling it earlier would be silently undone by
+    // that reset, leaving the reservoir full so the player drowns the moment they enter it.
     private static void DrainReservoir()
     {
         var south = Repository.GetLocation<ReservoirSouth>();
@@ -72,8 +72,8 @@ public class StreamTests : EngineTestsBase
     [Test]
     public async Task Reservoir_Up_ReachesStream_WhenDrained()
     {
-        DrainReservoir();
         var target = GetLitTargetAt<Reservoir>();
+        DrainReservoir();
 
         var response = await target.GetResponse("up");
 
@@ -83,8 +83,8 @@ public class StreamTests : EngineTestsBase
     [Test]
     public async Task Reservoir_West_ReachesStream_WhenDrained()
     {
-        DrainReservoir();
         var target = GetLitTargetAt<Reservoir>();
+        DrainReservoir();
 
         var response = await target.GetResponse("west");
 
@@ -114,23 +114,45 @@ public class StreamTests : EngineTestsBase
     [Test]
     public async Task Stream_Down_ReachesReservoir()
     {
-        DrainReservoir();
         var target = GetLitTargetAt<InStream>();
+        DrainReservoir();
 
         var response = await target.GetResponse("down");
 
         response.Should().Contain("mud");
+        response.Should().NotContain("rising river"); // a drained reservoir is survivable — no drowning
     }
 
     [Test]
     public async Task Stream_East_ReachesReservoir()
     {
-        DrainReservoir();
         var target = GetLitTargetAt<InStream>();
+        DrainReservoir();
 
         var response = await target.GetResponse("east");
 
         response.Should().Contain("mud");
+        response.Should().NotContain("rising river"); // a drained reservoir is survivable — no drowning
+    }
+
+    [Test]
+    public async Task Stream_Down_IntoFullReservoir_Drowns()
+    {
+        // InStream's DOWN/EAST exits carry no "you would drown" pre-check (unlike ReservoirSouth's
+        // North). The kill is enforced one layer down by Reservoir.Act() when the reservoir is full, so
+        // re-entering a full reservoir from the stream is fatal. This is the load-bearing safety net
+        // that lets InStream itself carry no drowning logic (issue #210). Set the full state AFTER
+        // GetLitTargetAt so it survives the Reset() inside GetTarget().
+        var target = GetLitTargetAt<InStream>();
+        var south = Repository.GetLocation<ReservoirSouth>();
+        south.IsFull = true;
+        south.IsDrained = false;
+        south.IsFilling = false;
+        south.IsDraining = false;
+
+        var response = await target.GetResponse("down");
+
+        response.Should().Contain("rising river");
     }
 
     [Test]

--- a/ZorkOne/Location/InStream.cs
+++ b/ZorkOne/Location/InStream.cs
@@ -19,7 +19,11 @@ public class InStream : DarkLocation
     {
         return new Dictionary<Direction, MovementParameters>
         {
-            // ZIL IN-STREAM: DOWN and EAST both flow back into the Reservoir.
+            // ZIL IN-STREAM: DOWN and EAST both flow back into the Reservoir. These are deliberately
+            // left unguarded — unlike ReservoirSouth's North exit, which has a "you would drown" check.
+            // The ZIL puts the drown daemon on RESERVOIR alone, and the Stream is only reachable
+            // *through* an already-drained Reservoir (the gate controls live at the Dam, so it can't
+            // refill while the player is up here). Per issue #210: "InStream needs no drowning logic."
             { Direction.Down, new MovementParameters { Location = GetLocation<Reservoir>() } },
             { Direction.E, new MovementParameters { Location = GetLocation<Reservoir>() } },
             {

--- a/ZorkOne/Location/InStream.cs
+++ b/ZorkOne/Location/InStream.cs
@@ -8,6 +8,12 @@ namespace ZorkOne.Location;
 
 public class InStream : DarkLocation
 {
+    // The original LAND verb plus natural synonyms that disembark to the beach at Stream View. Static
+    // so it isn't rebuilt on every command typed in this room.
+    private static readonly string[] LandCommands =
+        ["land", "disembark", "shore", "beach", "ashore", "go to shore", "go ashore"];
+
+
     // The ZIL room IN-STREAM is a NONLANDBIT (water) room reached by boat, but this port already
     // models the adjacent Reservoir as a drained mud flat the player crosses on foot — no boat (see
     // Reservoir.cs / ReservoirSouth.cs). For consistency, and because the port never brings the boat
@@ -20,10 +26,13 @@ public class InStream : DarkLocation
         return new Dictionary<Direction, MovementParameters>
         {
             // ZIL IN-STREAM: DOWN and EAST both flow back into the Reservoir. These are deliberately
-            // left unguarded — unlike ReservoirSouth's North exit, which has a "you would drown" check.
-            // The ZIL puts the drown daemon on RESERVOIR alone, and the Stream is only reachable
-            // *through* an already-drained Reservoir (the gate controls live at the Dam, so it can't
-            // refill while the player is up here). Per issue #210: "InStream needs no drowning logic."
+            // left unguarded — unlike ReservoirSouth's North exit, which pre-checks with "you would
+            // drown." Per issue #210, InStream carries no drowning logic of its own; the drown daemon
+            // lives on RESERVOIR. The refill is timer-driven (the ReservoirSouth actor) and keeps
+            // ticking regardless of the player's location, so the reservoir CAN fill while the player is
+            // up the stream. That's safe because the kill is enforced one layer down: re-entering a full
+            // Reservoir re-registers its actor and Reservoir.Act() drowns the player at end of turn, no
+            // matter which neighbor they came from (see StreamTests.Stream_Down_IntoFullReservoir_Drowns).
             { Direction.Down, new MovementParameters { Location = GetLocation<Reservoir>() } },
             { Direction.E, new MovementParameters { Location = GetLocation<Reservoir>() } },
             {
@@ -57,8 +66,7 @@ public class InStream : DarkLocation
 
         var preppedInput = input.ToLowerInvariant().Trim();
 
-        string[] landCommands = ["land", "disembark", "shore", "beach", "ashore", "go to shore", "go ashore"];
-        if (landCommands.Contains(preppedInput))
+        if (LandCommands.Contains(preppedInput))
             return new PositiveInteractionResult(
                 await MoveEngine.Go(context, client, new MovementParameters { Location = GetLocation<StreamView>() }));
 

--- a/ZorkOne/Location/InStream.cs
+++ b/ZorkOne/Location/InStream.cs
@@ -1,0 +1,67 @@
+using GameEngine.IntentEngine;
+using GameEngine.Location;
+using Model.AIGeneration;
+using Model.Interface;
+using Model.Movement;
+
+namespace ZorkOne.Location;
+
+public class InStream : DarkLocation
+{
+    // The ZIL room IN-STREAM is a NONLANDBIT (water) room reached by boat, but this port already
+    // models the adjacent Reservoir as a drained mud flat the player crosses on foot — no boat (see
+    // Reservoir.cs / ReservoirSouth.cs). For consistency, and because the port never brings the boat
+    // here (a boat-gated room would be unreachable), InStream is a plain walk-in DarkLocation. The
+    // "on the gently flowing stream" text is kept as flavor. Intentional simplification (issue #210).
+    public override string Name => "Stream";
+
+    protected override Dictionary<Direction, MovementParameters> Map(IContext context)
+    {
+        return new Dictionary<Direction, MovementParameters>
+        {
+            // ZIL IN-STREAM: DOWN and EAST both flow back into the Reservoir.
+            { Direction.Down, new MovementParameters { Location = GetLocation<Reservoir>() } },
+            { Direction.E, new MovementParameters { Location = GetLocation<Reservoir>() } },
+            {
+                // ZIL IN-STREAM: UP/WEST are blocked — the channel is too narrow.
+                Direction.Up,
+                new MovementParameters { CanGo = _ => false, CustomFailureMessage = "The channel is too narrow. " }
+            },
+            {
+                Direction.W,
+                new MovementParameters { CanGo = _ => false, CustomFailureMessage = "The channel is too narrow. " }
+            }
+        };
+    }
+
+    protected override string GetContextBasedDescription(IContext context)
+    {
+        return "You are on the gently flowing stream. The upstream route is too narrow to navigate, and the " +
+               "downstream route is invisible due to twisting walls. There is a narrow beach to land on. ";
+    }
+
+    /// <summary>
+    ///     The ZIL gives IN-STREAM a LAND exit to STREAM-VIEW. <see cref="Direction" /> has no "Land"
+    ///     member and the parser maps no word to one, so handle the original LAND command (and natural
+    ///     synonyms) here and route to the beach at Stream View. Issue #210, decision 2(a).
+    /// </summary>
+    public override async Task<InteractionResult> RespondToSpecificLocationInteraction(string? input,
+        IContext context, IGenerationClient client)
+    {
+        if (string.IsNullOrEmpty(input))
+            return await base.RespondToSpecificLocationInteraction(input, context, client);
+
+        var preppedInput = input.ToLowerInvariant().Trim();
+
+        string[] landCommands = ["land", "disembark", "shore", "beach", "ashore", "go to shore", "go ashore"];
+        if (landCommands.Contains(preppedInput))
+            return new PositiveInteractionResult(
+                await MoveEngine.Go(context, client, new MovementParameters { Location = GetLocation<StreamView>() }));
+
+        return await base.RespondToSpecificLocationInteraction(input, context, client);
+    }
+
+    public override void Init()
+    {
+    }
+}

--- a/ZorkOne/Location/Reservoir.cs
+++ b/ZorkOne/Location/Reservoir.cs
@@ -38,7 +38,10 @@ public class Reservoir : DarkLocation, ITurnBasedActor
         return new Dictionary<Direction, MovementParameters>
         {
             { Direction.S, new MovementParameters { Location = GetLocation<ReservoirSouth>() } },
-            { Direction.N, new MovementParameters { Location = GetLocation<ReservoirNorth>() } }
+            { Direction.N, new MovementParameters { Location = GetLocation<ReservoirNorth>() } },
+            // ZIL RESERVOIR: UP and WEST both lead up the stream into the optional Stream branch.
+            { Direction.Up, new MovementParameters { Location = GetLocation<InStream>() } },
+            { Direction.W, new MovementParameters { Location = GetLocation<InStream>() } }
         };
     }
 

--- a/ZorkOne/Location/ReservoirSouth.cs
+++ b/ZorkOne/Location/ReservoirSouth.cs
@@ -67,6 +67,10 @@ public class ReservoirSouth : DarkLocation, ITurnBasedActor
             { Direction.SW, new MovementParameters { Location = GetLocation<Chasm>() } },
             { Direction.SE, new MovementParameters { Location = GetLocation<DeepCanyon>() } },
             { Direction.E, new MovementParameters { Location = GetLocation<Dam>() } },
+            // ZIL RESERVOIR-SOUTH: WEST follows the stream to Stream View (unconditional). This also
+            // makes good on the "path along the stream to the east or west" promised in the room's
+            // own description below, which was previously a dead pointer (issue #210).
+            { Direction.W, new MovementParameters { Location = GetLocation<StreamView>() } },
             {
                 Direction.N,
                 new MovementParameters

--- a/ZorkOne/Location/StreamView.cs
+++ b/ZorkOne/Location/StreamView.cs
@@ -1,0 +1,37 @@
+using GameEngine.Location;
+using Model.Interface;
+using Model.Movement;
+
+namespace ZorkOne.Location;
+
+public class StreamView : DarkLocation
+{
+    public override string Name => "Stream View";
+
+    protected override Dictionary<Direction, MovementParameters> Map(IContext context)
+    {
+        return new Dictionary<Direction, MovementParameters>
+        {
+            { Direction.E, new MovementParameters { Location = GetLocation<ReservoirSouth>() } },
+            {
+                // ZIL STREAM-VIEW: WEST is blocked — the stream emerges from a gap too small to enter.
+                Direction.W,
+                new MovementParameters
+                {
+                    CanGo = _ => false,
+                    CustomFailureMessage = "The stream emerges from a spot too small for you to enter. "
+                }
+            }
+        };
+    }
+
+    protected override string GetContextBasedDescription(IContext context)
+    {
+        return "You are standing on a path beside a gently flowing stream. The path follows the stream, " +
+               "which flows from west to east. ";
+    }
+
+    public override void Init()
+    {
+    }
+}


### PR DESCRIPTION
Closes #210.

The optional stream branch off the Reservoir was missing from the C# port: two rooms and the four exits that reach them didn't exist. Notably, `ReservoirSouth`'s own description **already promised** "a path along the stream to the east **or west**", but there was no `WEST` exit — so this was a *visible* dead-end-pointer bug, not just a hidden gap.

## What changed

- **`ZorkOne/Location/StreamView.cs`** (new, `DarkLocation`) — name "Stream View".
  - `EAST → Reservoir South`
  - `WEST` blocked → *"The stream emerges from a spot too small for you to enter."*
- **`ZorkOne/Location/InStream.cs`** (new, `DarkLocation`) — displayed name **"Stream"** (matching the ZIL `IN-STREAM` DESC).
  - `DOWN → Reservoir`, `EAST → Reservoir`
  - `UP`/`WEST` blocked → *"The channel is too narrow."*
  - The original `LAND` exit → Stream View. `Direction` has no `Land` member and the parser maps no word to one, so the `LAND` command (and natural synonyms: `disembark`, `shore`, `beach`, `ashore`, `go to shore`/`go ashore`) is handled in `RespondToSpecificLocationInteraction` and routed via the existing `MoveEngine.Go` (decision 2(a) in the issue).
- **`Reservoir.cs`** — added `UP → Stream` and `WEST → Stream`.
- **`ReservoirSouth.cs`** — added `WEST → Stream View` (unconditional). Makes good on the description's "east or west" promise.

### Design decisions (per the issue)

1. **No boat.** The ZIL marks `RESERVOIR`/`IN-STREAM` as water rooms, but this port already models the Reservoir as a drained mud flat crossed on foot. `InStream` follows suit as a plain walk-in `DarkLocation`; requiring the boat would diverge from the adjacent Reservoir and make the room unreachable (the port never brings the boat here). Noted in code as an intentional simplification.
2. **`LAND` exit kept**, handled minimally as a location command rather than adding a new `Direction`.

## Tests

New `ZorkOne.Tests/Places/StreamTests.cs` (modeled on `DeepCanyonTests` — lit lantern + set `CurrentLocation`) covering every new/blocked exit and the `LAND` command:

- `Reservoir South` WEST → Stream View; STREAM-VIEW WEST → "too small for you to enter"; STREAM-VIEW EAST → Reservoir South
- drained `Reservoir` UP/WEST → Stream; Stream UP/WEST → "channel is too narrow"; Stream DOWN/EAST → Reservoir; Stream `land` → Stream View

TDD check: the three exit-wiring tests on the existing rooms fail ("You can't go that way") before the change and pass after. `dotnet test ZorkOne.Tests` → **1250 passing**; `dotnet test UnitTests` → **891 passing** (1 pre-existing skip). No regressions in the reservoir/dam/walkthrough tests.

> Room/exit facts verified against `zork1/1dungeon.zil` per issue #210: `STREAM-VIEW` :1805, `IN-STREAM` :1819, `RESERVOIR-SOUTH` WEST :1775, `RESERVOIR` UP/WEST :1788-1789.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017wQY3SJEYwc8mTtigq4CFm

---
_Generated by [Claude Code](https://claude.ai/code/session_017wQY3SJEYwc8mTtigq4CFm)_