### PR TITLE
Fix #218: force-open the egg with any weapon or tool, add throw

### DIFF
--- a/Model/Item/IAmATool.cs
+++ b/Model/Item/IAmATool.cs
@@ -1,0 +1,8 @@
+namespace Model.Item;
+
+/// <summary>
+///     Marker interface for items that count as a "tool" — the analog of the original Zork I
+///     <c>TOOLBIT</c> flag. Used (alongside <see cref="IWeapon" />, the <c>WEAPONBIT</c> analog) to
+///     decide what can force the jewel-encrusted egg open, clumsily damaging it.
+/// </summary>
+public interface IAmATool;

--- a/UnitTests/IntentMappings/base-mappings.json
+++ b/UnitTests/IntentMappings/base-mappings.json
@@ -124,6 +124,10 @@
     { "inputs": ["open the egg with the screwdriver"], "verb": "open", "nounOne": "egg", "nounTwo": "screwdriver", "preposition": "with", "originalInput": "open the egg with the screwdriver" },
     { "inputs": ["open the egg with the knife"], "verb": "open", "nounOne": "egg", "nounTwo": "knife", "preposition": "with", "originalInput": "open the egg with the knife" },
     { "inputs": ["open the egg with the sword"], "verb": "open", "nounOne": "egg", "nounTwo": "sword", "preposition": "with", "originalInput": "open the egg with the sword" },
+    { "inputs": ["open the egg with the stiletto"], "verb": "open", "nounOne": "egg", "nounTwo": "stiletto", "preposition": "with", "originalInput": "open the egg with the stiletto" },
+    { "inputs": ["open the egg with the wrench"], "verb": "open", "nounOne": "egg", "nounTwo": "wrench", "preposition": "with", "originalInput": "open the egg with the wrench" },
+    { "inputs": ["open the egg with the lamp"], "verb": "open", "nounOne": "egg", "nounTwo": "lamp", "preposition": "with", "originalInput": "open the egg with the lamp" },
+    { "inputs": ["open the egg with the sceptre"], "verb": "open", "nounOne": "egg", "nounTwo": "sceptre", "preposition": "with", "originalInput": "open the egg with the sceptre" },
 
     { "inputs": ["light candles with match"], "verb": "light", "nounOne": "candles", "nounTwo": "match", "preposition": "with", "originalInput": "light candles with match" },
     { "inputs": ["put magnet on crevice"], "verb": "put", "nounOne": "magnet", "nounTwo": "crevice", "preposition": "on", "originalInput": "put magnet on crevice" },

--- a/ZorkOne.Tests/Things/EggAndCanaryTests.cs
+++ b/ZorkOne.Tests/Things/EggAndCanaryTests.cs
@@ -623,4 +623,25 @@ public class EggAndCanaryTests : EngineTestsBase
         Repository.GetItem<Egg>().IsDestroyed.Should().BeFalse();
         Repository.GetItem<Canary>().IsDestroyed.Should().BeFalse();
     }
+
+    [Test]
+    public async Task ThrowEgg_NotHeld_DoesNothing()
+    {
+        // You can only throw what you're holding. The simple-interaction dispatch offers the verb to
+        // room-resident items too, so the throw handler must verify possession before breaking the
+        // egg — otherwise "throw egg" wrecks an egg sitting untouched in the room.
+        var target = GetTarget();
+        target.Context.CurrentLocation = Repository.GetLocation<ForestPath>();
+        Repository.GetLocation<ForestPath>().ItemPlacedHere(Repository.GetItem<Egg>()); // in the room, NOT inventory
+
+        var response = await target.GetResponse("throw egg");
+        Console.WriteLine(response);
+
+        response.Should().NotContain("succeeded in opening it");
+        response.Should().Contain("don't have");
+        Repository.GetItem<Egg>().IsDestroyed.Should().BeFalse();
+        Repository.GetItem<Egg>().IsOpen.Should().BeFalse();
+        Repository.GetItem<Canary>().IsDestroyed.Should().BeFalse();
+        Repository.GetItem<Egg>().CurrentLocation.Should().BeOfType<ForestPath>();
+    }
 }

--- a/ZorkOne.Tests/Things/EggAndCanaryTests.cs
+++ b/ZorkOne.Tests/Things/EggAndCanaryTests.cs
@@ -601,4 +601,26 @@ public class EggAndCanaryTests : EngineTestsBase
         Repository.GetItem<Canary>().IsDestroyed.Should().BeTrue();
         Repository.GetItem<Egg>().CurrentLocation.Should().BeOfType<ForestPath>();
     }
+
+    [Test]
+    public async Task ForceOpenAlreadyOpenEgg_DoesNotDamageTheIntactCanary()
+    {
+        // The thief opens the egg cleanly (IsOpen, canary intact). The original short-circuits any
+        // further open/force attempt with "already open" BEFORE the WEAPONBIT/TOOLBIT branch
+        // (zork1/1actions.zil:2920-2922: <COND (<FSET? ,PRSO ,OPENBIT> <TELL "The egg is already
+        // open.">) ...>), protecting the intact canary. Force-opening it must NOT wreck the canary.
+        var target = GetTarget();
+        target.Context.CurrentLocation = Repository.GetLocation<ForestPath>();
+        Repository.GetItem<Egg>().IsOpen = true; // thief already opened it, undamaged
+        target.Context.ItemPlacedHere(Repository.GetItem<Egg>());
+        target.Context.ItemPlacedHere(Repository.GetItem<Sword>());
+
+        var response = await target.GetResponse("open the egg with the sword");
+        Console.WriteLine(response);
+
+        response.Should().Contain("already open");
+        response.Should().NotContain("seriously compromised");
+        Repository.GetItem<Egg>().IsDestroyed.Should().BeFalse();
+        Repository.GetItem<Canary>().IsDestroyed.Should().BeFalse();
+    }
 }

--- a/ZorkOne.Tests/Things/EggAndCanaryTests.cs
+++ b/ZorkOne.Tests/Things/EggAndCanaryTests.cs
@@ -492,4 +492,113 @@ public class EggAndCanaryTests : EngineTestsBase
 
         response.Should().Contain("It seems to have recently had a bad");
     }
+
+    [Test]
+    public async Task OpenEggWithStiletto()
+    {
+        // The stiletto is a WEAPONBIT item in the original (zork1/1dungeon.zil:895) and so should
+        // force the egg open, but the old code only accepted a hard-coded Sword/NastyKnife/Screwdriver trio.
+        var target = GetTarget();
+        target.Context.CurrentLocation = Repository.GetLocation<ForestPath>();
+        target.Context.ItemPlacedHere(Repository.GetItem<Egg>());
+        target.Context.ItemPlacedHere(Repository.GetItem<Stiletto>());
+
+        var response = await target.GetResponse("open the egg with the stiletto");
+        Console.WriteLine(response);
+
+        response
+            .Should()
+            .Contain(
+                "The egg is now open, but the clumsiness of your attempt has seriously compromised"
+            );
+        Repository.GetItem<Canary>().IsDestroyed.Should().BeTrue();
+        Repository.GetItem<Egg>().IsDestroyed.Should().BeTrue();
+        Repository.GetItem<Egg>().IsOpen.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task OpenEggWithWrench()
+    {
+        // The wrench is a TOOLBIT item in the original (zork1/1dungeon.zil:1135) and so should
+        // force the egg open. It is neither a weapon nor a previously-whitelisted tool, so this
+        // exercises the new IAmATool generalization.
+        var target = GetTarget();
+        target.Context.CurrentLocation = Repository.GetLocation<ForestPath>();
+        target.Context.ItemPlacedHere(Repository.GetItem<Egg>());
+        target.Context.ItemPlacedHere(Repository.GetItem<Wrench>());
+
+        var response = await target.GetResponse("open the egg with the wrench");
+        Console.WriteLine(response);
+
+        response
+            .Should()
+            .Contain(
+                "The egg is now open, but the clumsiness of your attempt has seriously compromised"
+            );
+        Repository.GetItem<Canary>().IsDestroyed.Should().BeTrue();
+        Repository.GetItem<Egg>().IsDestroyed.Should().BeTrue();
+        Repository.GetItem<Egg>().IsOpen.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task OpenEggWithLamp_DoesNotForceItOpen()
+    {
+        // The brass lantern has neither WEAPONBIT nor TOOLBIT in the original
+        // (zork1/1dungeon.zil LAMP: TAKEBIT LIGHTBIT only), so it must NOT force the egg open.
+        // Guards against the generalization becoming "any held item opens the egg".
+        var target = GetTarget();
+        target.Context.CurrentLocation = Repository.GetLocation<ForestPath>();
+        target.Context.ItemPlacedHere(Repository.GetItem<Egg>());
+        target.Context.ItemPlacedHere(Repository.GetItem<Lantern>());
+
+        var response = await target.GetResponse("open the egg with the lamp");
+        Console.WriteLine(response);
+
+        response.Should().NotContain("seriously compromised");
+        Repository.GetItem<Egg>().IsDestroyed.Should().BeFalse();
+        Repository.GetItem<Egg>().IsOpen.Should().BeFalse();
+        Repository.GetItem<Canary>().IsDestroyed.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task OpenEggWithSceptre()
+    {
+        // The sceptre is a WEAPONBIT item in the original (zork1/1dungeon.zil:244), so it should
+        // force the egg open like any other weapon.
+        var target = GetTarget();
+        target.Context.CurrentLocation = Repository.GetLocation<ForestPath>();
+        target.Context.ItemPlacedHere(Repository.GetItem<Egg>());
+        target.Context.ItemPlacedHere(Repository.GetItem<Sceptre>());
+
+        var response = await target.GetResponse("open the egg with the sceptre");
+        Console.WriteLine(response);
+
+        response
+            .Should()
+            .Contain(
+                "The egg is now open, but the clumsiness of your attempt has seriously compromised"
+            );
+        Repository.GetItem<Canary>().IsDestroyed.Should().BeTrue();
+        Repository.GetItem<Egg>().IsDestroyed.Should().BeTrue();
+        Repository.GetItem<Egg>().IsOpen.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task ThrowEgg()
+    {
+        // The original THROW branch (zork1/1actions.zil:2950) opens the egg with damage and drops
+        // it into the room: "...succeeded in opening it." + BAD-EGG.
+        var target = GetTarget();
+        target.Context.CurrentLocation = Repository.GetLocation<ForestPath>();
+        target.Context.ItemPlacedHere(Repository.GetItem<Egg>());
+
+        var response = await target.GetResponse("throw egg");
+        Console.WriteLine(response);
+
+        response.Should().Contain("succeeded in opening it");
+        Repository.GetItem<Egg>().IsDestroyed.Should().BeTrue();
+        Repository.GetItem<Egg>().IsOpen.Should().BeTrue();
+        Repository.GetItem<Canary>().IsDestroyed.Should().BeTrue();
+        Repository.GetItem<Egg>().CurrentLocation.Should().BeOfType<ForestPath>();
+    }
 }

--- a/ZorkOne/Item/AirPump.cs
+++ b/ZorkOne/Item/AirPump.cs
@@ -2,7 +2,7 @@ using GameEngine.Item;
 
 namespace ZorkOne.Item;
 
-public class AirPump : ItemBase, ICanBeTakenAndDropped
+public class AirPump : ItemBase, ICanBeTakenAndDropped, IAmATool
 {
     public override string[] NounsForMatching => ["pump", "air pump", "hand-held air pump"];
 

--- a/ZorkOne/Item/Egg.cs
+++ b/ZorkOne/Item/Egg.cs
@@ -1,5 +1,6 @@
 using GameEngine;
 using GameEngine.Item;
+using Model.AIGeneration;
 using Model.Intent;
 using Model.Interface;
 
@@ -76,6 +77,25 @@ public class Egg
         return "You have neither the tools nor the expertise. ";
     }
 
+    public override async Task<InteractionResult?> RespondToSimpleInteraction(SimpleIntent action,
+        IContext context, IGenerationClient client, IItemProcessorFactory itemProcessorFactory)
+    {
+        // Throwing the egg opens it — but clumsily. It lands on the floor of the room, damaged
+        // (zork1/1actions.zil:2950: <VERB? THROW> -> <MOVE ,PRSO ,HERE> then BAD-EGG).
+        if (!action.Match(Verbs.ThrowVerbs, NounsForMatching))
+            return await base.RespondToSimpleInteraction(action, context, client, itemProcessorFactory);
+
+        BreakEggAndCanary();
+
+        // <MOVE ,PRSO ,HERE> — the thrown egg comes to rest in the current room.
+        context.Drop(this);
+
+        return new PositiveInteractionResult(
+            "Your rather indelicate handling of the egg has caused it some damage, although you "
+            + "have succeeded in opening it. "
+        );
+    }
+
     public override async Task<InteractionResult?> RespondToMultiNounInteraction(
         MultiNounIntent action,
         IContext context
@@ -91,33 +111,36 @@ public class Egg
         )
             return await base.RespondToMultiNounInteraction(action, context);
 
-        if (action.MatchNounTwo<Sword>())
-            return PryOpen<Sword>(context);
+        // The original force-opens the egg with ANY weapon or tool: it tests the WEAPONBIT/TOOLBIT
+        // flags, not a fixed item list (zork1/1actions.zil:2932:
+        //   <OR <FSET? ,PRSI ,WEAPONBIT> <FSET? ,PRSI ,TOOLBIT> ...>).
+        // IWeapon is our WEAPONBIT analog; IAmATool is our TOOLBIT analog. Resolving the second
+        // noun to its item (rather than matching fixed types) keeps this faithful as items grow.
+        var tool = action.ItemTwo ?? Repository.GetItem(action.NounTwo);
+        if (tool is not (IWeapon or IAmATool))
+            return await base.RespondToMultiNounInteraction(action, context);
 
-        if (action.MatchNounTwo<NastyKnife>())
-            return PryOpen<NastyKnife>(context);
-
-        if (action.MatchNounTwo<Screwdriver>())
-            return PryOpen<Screwdriver>(context);
-
-        return await base.RespondToMultiNounInteraction(action, context);
-    }
-
-    private InteractionResult PryOpen<T>(IContext context)
-        where T : IItem, new()
-    {
-        if (!context.HasItem<T>())
+        if (!context.Items.Contains(tool))
             return new PositiveInteractionResult("You don't have that! ");
 
-        IsDestroyed = true;
-        IsOpen = true;
-        Repository.GetItem<Canary>().IsDestroyed = true;
+        BreakEggAndCanary();
 
         return new PositiveInteractionResult(
             "The egg is now open, but the clumsiness of your attempt has seriously compromised "
             + "its esthetic appeal. There is a golden clockwork canary nestled in the egg. "
             + Canary.DestroyedMessage
         );
+    }
+
+    /// <summary>
+    ///     The shared BAD-EGG effect (zork1/1actions.zil:2960): the egg is forced open but ruined,
+    ///     and the clockwork canary nestled inside is wrecked along with it.
+    /// </summary>
+    private void BreakEggAndCanary()
+    {
+        IsDestroyed = true;
+        IsOpen = true;
+        Repository.GetItem<Canary>().IsDestroyed = true;
     }
 
     public override string ItemListDescription(string name, ILocation? location)

--- a/ZorkOne/Item/Egg.cs
+++ b/ZorkOne/Item/Egg.cs
@@ -85,6 +85,12 @@ public class Egg
         if (!action.Match(Verbs.ThrowVerbs, NounsForMatching))
             return await base.RespondToSimpleInteraction(action, context, client, itemProcessorFactory);
 
+        // You can only throw what you're holding. The dispatch offers this verb to room-resident
+        // items too (ContainerBase walks the room's items), so guard on possession — otherwise
+        // "throw egg" would wreck an egg sitting untouched in the room.
+        if (!context.Items.Contains(this))
+            return new PositiveInteractionResult("You don't have that! ");
+
         BreakEggAndCanary();
 
         // <MOVE ,PRSO ,HERE> — the thrown egg comes to rest in the current room.

--- a/ZorkOne/Item/Egg.cs
+++ b/ZorkOne/Item/Egg.cs
@@ -111,6 +111,13 @@ public class Egg
         )
             return await base.RespondToMultiNounInteraction(action, context);
 
+        // Already open (e.g. the thief opened it cleanly, canary intact)? The original short-circuits
+        // here — before any tool check — so a second force attempt can't wreck the intact canary
+        // (zork1/1actions.zil:2920-2922: <COND (<FSET? ,PRSO ,OPENBIT> <TELL "The egg is already
+        // open.">) ...>). Note the THROW branch deliberately has no such guard (it re-breaks).
+        if (IsOpen)
+            return new PositiveInteractionResult(AlreadyOpen);
+
         // The original force-opens the egg with ANY weapon or tool: it tests the WEAPONBIT/TOOLBIT
         // flags, not a fixed item list (zork1/1actions.zil:2932:
         //   <OR <FSET? ,PRSI ,WEAPONBIT> <FSET? ,PRSI ,TOOLBIT> ...>).

--- a/ZorkOne/Item/Sceptre.cs
+++ b/ZorkOne/Item/Sceptre.cs
@@ -6,7 +6,7 @@ using Model.Interface;
 namespace ZorkOne.Item;
 
 public class Sceptre : ItemBase, ICanBeTakenAndDropped, IGivePointsWhenPlacedInTrophyCase,
-    IGivePointsWhenFirstPickedUp, IAmPointyAndPunctureThings
+    IGivePointsWhenFirstPickedUp, IAmPointyAndPunctureThings, IWeapon
 {
     // The original Zork I source accepts both spellings: (SYNONYM SCEPTRE SCEPTER TREASURE).
     // Keep the American "scepter" so players can refer to the item either way.

--- a/ZorkOne/Item/Screwdriver.cs
+++ b/ZorkOne/Item/Screwdriver.cs
@@ -2,7 +2,7 @@
 
 namespace ZorkOne.Item;
 
-public class Screwdriver : ItemBase, ICanBeTakenAndDropped
+public class Screwdriver : ItemBase, ICanBeTakenAndDropped, IAmATool
 {
     public override string[] NounsForMatching => ["screwdriver"];
 

--- a/ZorkOne/Item/Shovel.cs
+++ b/ZorkOne/Item/Shovel.cs
@@ -2,7 +2,7 @@ using GameEngine.Item;
 
 namespace ZorkOne.Item;
 
-public class Shovel : ItemBase, ICanBeTakenAndDropped
+public class Shovel : ItemBase, ICanBeTakenAndDropped, IAmATool
 {
     public override string[] NounsForMatching => ["shovel"];
 

--- a/ZorkOne/Item/SkeletonKey.cs
+++ b/ZorkOne/Item/SkeletonKey.cs
@@ -2,7 +2,7 @@ using GameEngine.Item;
 
 namespace ZorkOne.Item;
 
-public class SkeletonKey : ItemBase, ICanBeTakenAndDropped
+public class SkeletonKey : ItemBase, ICanBeTakenAndDropped, IAmATool
 {
     public override string[] NounsForMatching => ["key", "skeleton", "skeleton key"];
 

--- a/ZorkOne/Item/ViscousMaterial.cs
+++ b/ZorkOne/Item/ViscousMaterial.cs
@@ -2,7 +2,7 @@ using GameEngine.Item;
 
 namespace ZorkOne.Item;
 
-public class ViscousMaterial : ItemBase, ICanBeTakenAndDropped
+public class ViscousMaterial : ItemBase, ICanBeTakenAndDropped, IAmATool
 {
     public override string[] NounsForMatching => ["viscous material", "viscous", "material", "gunk"];
 

--- a/ZorkOne/Item/Wrench.cs
+++ b/ZorkOne/Item/Wrench.cs
@@ -2,7 +2,7 @@ using GameEngine.Item;
 
 namespace ZorkOne.Item;
 
-public class Wrench : ItemBase, ICanBeTakenAndDropped
+public class Wrench : ItemBase, ICanBeTakenAndDropped, IAmATool
 {
     public override string[] NounsForMatching => ["wrench"];
 


### PR DESCRIPTION
Closes #218.

## Problem

Force-opening the jewel-encrusted egg (the clumsy, damaging open — distinct from the thief's clean open) only accepted a hard-coded `Sword` / `NastyKnife` / `Screwdriver` trio and had **no `throw` handling**. The original Zork I tests a *flag*, not a whitelist:

```
(<OR <FSET? ,PRSI ,WEAPONBIT> <FSET? ,PRSI ,TOOLBIT> <VERB? MUNG>> ...)   ; zork1/1actions.zil:2932
```

So ~11 qualifying items force the egg open in the original, but only 3 did here. A player reaching for the stiletto, wrench, shovel, etc. got nothing.

## What changed

1. **Generalized the force-open** ([Egg.cs](../blob/claude/musing-perlman-6c7dca/ZorkOne/Item/Egg.cs)) — `RespondToMultiNounInteraction` now resolves the second noun to its item and force-opens for any `IWeapon` (our `WEAPONBIT` analog) **or** `IAmATool` (the new `TOOLBIT` analog), instead of matching three fixed types. Resolution is `action.ItemTwo ?? Repository.GetItem(action.NounTwo)`, gated by an inventory check, preserving the old "must be holding it" semantics.

2. **New `IAmATool` marker** ([Model/Item/IAmATool.cs](../blob/claude/musing-perlman-6c7dca/Model/Item/IAmATool.cs)) applied to the six ZIL `TOOLBIT` items: `Screwdriver`, `Wrench`, `Shovel`, `SkeletonKey`, `AirPump` (Pump), `ViscousMaterial` (Putty). It has no consumers outside the egg, so tagging these items has zero blast radius. `RustyKnife` is already `IWeapon`, so it's covered.

3. **`throw egg`** — new `RespondToSimpleInteraction` override: opens it damaged (*"…succeeded in opening it."*) and drops it in the room (`zork1/1actions.zil:2950` → `<MOVE ,PRSO ,HERE>` + `BAD-EGG`).

4. **Shared `BreakEggAndCanary()` helper** replaces the triple-duplicated state mutation (the `BAD-EGG` effect).

5. **Already-open guard** — the force-open path now short-circuits with the egg's `AlreadyOpen` message when the egg is already open (e.g. the thief opened it cleanly, canary intact), instead of re-running `BAD-EGG` and destroying the intact canary. Matches the original, which checks `OPENBIT` before the `WEAPONBIT`/`TOOLBIT` branch (`zork1/1actions.zil:2920-2922`). The `throw` branch deliberately keeps **no** such guard — the original's separate `THROW` clause (`:2950`) re-breaks regardless of state.

6. **`Sceptre` now implements `IWeapon`** for full `WEAPONBIT` parity (`zork1/1dungeon.zil:244`) — it was the one missing `WEAPONBIT` item. **Reviewer note:** this is a deliberate change beyond the egg — the sceptre now participates in combat weapon selection (`GetWeapon` / weapon-count disambiguation). Verified regression-free; the only newly-affected path is holding *only* the sceptre and typing bare "kill X", which now fights with it instead of bare-knuckle (strictly more faithful).

Clean (undamaged) opening stays **thief-only** and is unchanged.

### Intentionally out of scope
The `MUNG`/bare-destroy no-tool branch, `open egg with hands`, and the `FIGHTBIT` joke responses are noted in the issue as lower-priority flavor and are not included here.

## Ground truth verified
- Generic `WEAPONBIT`/`TOOLBIT` acceptance + `THROW` branch + the `OPENBIT` already-open guard: `zork1/1actions.zil:2919-2958`; `BAD-EGG` at `:2960`.
- Flag membership: `WEAPONBIT` → Axe, Sceptre, Knife, Rusty-knife, Stiletto, Sword; `TOOLBIT` → Pump, Rusty-knife, Screwdriver, Keys, Shovel, Putty, Wrench (`zork1/1dungeon.zil`, `zork1/gglobals.zil`).

## Tests (TDD, failing-first)
Added to `EggAndCanaryTests`, each confirmed red-for-the-right-reason before green:
- `OpenEggWithStiletto` — a `WEAPONBIT` item the old code rejected
- `OpenEggWithWrench` — a `TOOLBIT` item (exercises `IAmATool`)
- `OpenEggWithSceptre` — `WEAPONBIT` parity
- `ThrowEgg` — opens damaged + lands in the room
- `OpenEggWithLamp_DoesNotForceItOpen` — negative boundary (the lamp is `TAKEBIT LIGHTBIT` only, so it must **not** open the egg)
- `ForceOpenAlreadyOpenEgg_DoesNotDamageTheIntactCanary` — the already-open guard protects a thief-opened canary

Plus the matching test-parser intent mappings.

**Verification:** `ZorkOne.Tests` 1257, `UnitTests` 891, `Planetfall.Tests` 2300 — all passing, no regressions. Solution builds with 0 warnings, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)