### PR TITLE
Add Floyd SHOW reactions: printout/computer gate, cards, LLM default (#203)

### DIFF
--- a/Model/Verbs.cs
+++ b/Model/Verbs.cs
@@ -39,6 +39,13 @@ public static class Verbs
     public static readonly string[] OpenVerbs = ["open", "lift", "pry", "unbar", "raise", "uncover", "unlatch", "unseal"];
     public static readonly string[] GiveVerbs =
         ["give", "offer", "transfer", "present", "provide", "hand", "donate", "deliver", "pass", "feed"];
+
+    /// <summary>
+    ///     The "show it to someone" family. Distinct from <see cref="GiveVerbs" /> — showing keeps the
+    ///     object in your hand (the ZIL syntax is <c>SHOW OBJECT (HAVE) TO OBJECT</c>), whereas giving
+    ///     transfers it. Deliberately excludes "present" (a give synonym) so the two verbs don't collide.
+    /// </summary>
+    public static readonly string[] ShowVerbs = ["show", "display"];
     public static readonly string[] ThrowVerbs =
         ["throw", "toss", "launch", "hurl", "fling", "heave", "chuck", "lob", "pitch", "cast", "sling"];
 

--- a/Planetfall.Tests/FloydTests.cs
+++ b/Planetfall.Tests/FloydTests.cs
@@ -1914,6 +1914,20 @@ public class FloydTests : EngineTestsBase
     }
 
     [Test]
+    public void ShownAnObjectPrompt_WithBracesInNoun_SurvivesDownstreamStringFormat()
+    {
+        // GenerateCompanionSpeech runs the prompt through string.Format; a shown noun with literal
+        // braces must not throw there (would be a FormatException at runtime) and must survive intact.
+        var prompt = FloydPrompts.ShownAnObject("gizmo {with} braces");
+
+        Action format = () => string.Format(prompt, "Room Name", "room description", "last outputs");
+
+        format.Should().NotThrow();
+        string.Format(prompt, "Room Name", "room description", "last outputs")
+            .Should().Contain("gizmo {with} braces");
+    }
+
+    [Test]
     public void Show_LowerCard_RevealedFlag_StopsTheDaemonReReveal()
     {
         // Coordination with #222: once the lower card is revealed (here, as if shown to Floyd), the

--- a/Planetfall.Tests/FloydTests.cs
+++ b/Planetfall.Tests/FloydTests.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using FluentAssertions;
 using Model.AIGeneration.Requests;
+using Model.Intent;
 using Model.Interface;
 using Model.Item;
 using Moq;
@@ -1789,20 +1790,26 @@ public class FloydTests : EngineTestsBase
     }
 
     [Test]
-    public async Task Show_Printout_ToFloyd_WhenAlreadyConcerned_FallsToDefault()
+    public async Task Show_Printout_ToFloyd_WhenAlreadyConcerned_FallsToLlmDefault()
     {
+        // Already concerned (e.g. Floyd already visited the Computer Room): the one-shot guard
+        // (<NOT ,COMPUTER-FLAG>) means showing the printout again no longer re-fires the concern.
+        // In real play Floyd is a registered turn actor, so the default goes through the LLM path.
         var target = GetTarget();
         StartHere<RobotShop>();
-        // Already concerned (e.g. Floyd already visited the Computer Room): the one-shot guard
-        // (<NOT ,COMPUTER-FLAG>) means showing the printout again hits the default branch. Set the flag
-        // before Take<ComputerOutput>() — instantiating the Computer Room homes the printout there.
+        // Set the flag before Take<ComputerOutput>() — instantiating the Computer Room homes the printout there.
         GetLocation<ComputerRoom>().FloydHasExpressedConcern = true;
         Take<ComputerOutput>();
-        GetItem<Floyd>().IsOn = true;
+        var floyd = GetItem<Floyd>();
+        floyd.IsOn = true;
+        target.Context.RegisterActor(floyd);
+        Mock.Get(target.GenerationClient)
+            .Setup(c => c.GenerateCompanionSpeech(It.IsAny<CompanionRequest>()))
+            .ReturnsAsync("Floyd looks it over. \"What're all the squiggles?\"");
 
         var response = await target.GetResponse("show printout to floyd");
 
-        response.Should().Contain("Can you play any games with it");
+        response.Should().Contain("What're all the squiggles"); // LLM default, not the concern line
         response.Should().NotContain("Computer is broken");
     }
 
@@ -1836,6 +1843,72 @@ public class FloydTests : EngineTestsBase
     }
 
     [Test]
+    public async Task Show_ShuttleCard_ToFloyd_AsksIfTheyAreUsuallyBlue()
+    {
+        var target = GetTarget();
+        StartHere<RobotShop>();
+        Take<ShuttleAccessCard>();
+        GetItem<Floyd>().IsOn = true;
+
+        var response = await target.GetResponse("show shuttle card to floyd");
+
+        response.Should().Contain("usually blue");
+    }
+
+    [Test]
+    public async Task Show_UpperElevatorCard_ToFloyd_AsksIfTheyAreUsuallyBlue()
+    {
+        var target = GetTarget();
+        StartHere<RobotShop>();
+        Take<UpperElevatorAccessCard>();
+        GetItem<Floyd>().IsOn = true;
+
+        var response = await target.GetResponse("show upper elevator card to floyd");
+
+        response.Should().Contain("usually blue");
+    }
+
+    [Test]
+    public async Task Show_FloydTheCard_ReverseNounOrder_StillReacts()
+    {
+        // RespondToShow accepts Floyd as either noun ("show x to floyd" / "show floyd the x"). The forward
+        // order is covered by the other tests; this locks in the reverse branch (Floyd as NounOne).
+        var target = GetTarget();
+        StartHere<RobotShop>();
+        Take<IdCard>();
+        var floyd = GetItem<Floyd>();
+        floyd.IsOn = true;
+
+        var intent = new MultiNounIntent
+        {
+            Verb = "show",
+            NounOne = "floyd",
+            NounTwo = "id card",
+            Preposition = "",
+            OriginalInput = "show floyd the id card"
+        };
+        var result = await floyd.RespondToMultiNounInteraction(intent, target.Context);
+
+        result.Should().NotBeNull();
+        result!.InteractionMessage.Should().Contain("usually blue");
+    }
+
+    [Test]
+    public async Task Show_ObjectNotHeld_ToFloyd_SaysYouDontHaveIt()
+    {
+        // SHOW requires the item be held (syntax.zil:450 SHOW OBJECT (HAVE) ...). With the object only on
+        // the ground (resolvable but not in inventory), Floyd reports you don't have it — mirroring GIVE.
+        var target = GetTarget();
+        var robotShop = StartHere<RobotShop>();
+        robotShop.ItemPlacedHere(GetItem<Diary>()); // in the room, not the player's inventory
+        GetItem<Floyd>().IsOn = true;
+
+        var response = await target.GetResponse("show diary to floyd");
+
+        response.Should().Contain("You don't have the");
+    }
+
+    [Test]
     public async Task Show_LowerElevatorCard_ToFloyd_RecognizesItAndMarksRevealed()
     {
         var target = GetTarget();
@@ -1854,17 +1927,24 @@ public class FloydTests : EngineTestsBase
     }
 
     [Test]
-    public async Task Show_LowerElevatorCard_ToFloyd_WhenAlreadyRevealed_FallsToDefault()
+    public async Task Show_LowerElevatorCard_ToFloyd_WhenAlreadyRevealed_FallsToLlmDefault()
     {
+        // Already revealed: the one-shot guard means a second show no longer gets the recognition line.
+        // In real play Floyd is a registered turn actor, so the default goes through the LLM path.
         var target = GetTarget();
         StartHere<RobotShop>();
         Take<LowerElevatorAccessCard>();
-        GetItem<Floyd>().IsOn = true;
-        GetItem<Floyd>().HasRevealedLowerElevatorCard = true;
+        var floyd = GetItem<Floyd>();
+        floyd.IsOn = true;
+        floyd.HasRevealedLowerElevatorCard = true;
+        target.Context.RegisterActor(floyd);
+        Mock.Get(target.GenerationClient)
+            .Setup(c => c.GenerateCompanionSpeech(It.IsAny<CompanionRequest>()))
+            .ReturnsAsync("Floyd peers at it. \"Ooo, shiny card!\"");
 
         var response = await target.GetResponse("show lower elevator card to floyd");
 
-        response.Should().Contain("Can you play any games with it");
+        response.Should().Contain("Ooo, shiny card"); // LLM default, not the recognition line
         response.Should().NotContain("just like that");
     }
 

--- a/Planetfall.Tests/FloydTests.cs
+++ b/Planetfall.Tests/FloydTests.cs
@@ -1763,4 +1763,195 @@ public class FloydTests : EngineTestsBase
     }
 
     #endregion
+
+    #region Show (issue #203 — Floyd's SHOW reactions, ZIL FLOYD-F compone.zil:2022-2047)
+
+    [Test]
+    public async Task Show_Printout_ToFloyd_TriggersComputerConcern()
+    {
+        var target = GetTarget();
+        StartHere<RobotShop>();
+        // Instantiate the Computer Room first: its Init() homes the printout there, so we must do this
+        // before Take<ComputerOutput>() or the Take would be undone (printout re-homed out of inventory).
+        GetLocation<ComputerRoom>().FloydHasExpressedConcern = false;
+        Take<ComputerOutput>();
+        GetItem<Floyd>().IsOn = true;
+
+        var response = await target.GetResponse("show printout to floyd");
+
+        // The "computer is broken" concern, in the printout-variant wording — NOT the Computer-Room
+        // "glowing light" wording (COMPUTER-ACTION branches its text on location, comptwo.zil:1514-1524).
+        response.Should().Contain("Computer is broken");
+        response.Should().Contain("computer printout");
+        response.Should().NotContain("glowing light");
+        // Sets the SAME flag the Computer-Room visit sets — this is what gates the bio-lab card foray.
+        GetLocation<ComputerRoom>().FloydHasExpressedConcern.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task Show_Printout_ToFloyd_WhenAlreadyConcerned_FallsToDefault()
+    {
+        var target = GetTarget();
+        StartHere<RobotShop>();
+        // Already concerned (e.g. Floyd already visited the Computer Room): the one-shot guard
+        // (<NOT ,COMPUTER-FLAG>) means showing the printout again hits the default branch. Set the flag
+        // before Take<ComputerOutput>() — instantiating the Computer Room homes the printout there.
+        GetLocation<ComputerRoom>().FloydHasExpressedConcern = true;
+        Take<ComputerOutput>();
+        GetItem<Floyd>().IsOn = true;
+
+        var response = await target.GetResponse("show printout to floyd");
+
+        response.Should().Contain("Can you play any games with it");
+        response.Should().NotContain("Computer is broken");
+    }
+
+    [Test]
+    public async Task Show_IdCard_ToFloyd_AsksIfTheyAreUsuallyBlue()
+    {
+        // IdCard extends ItemBase directly (NOT AccessCard) — proves the four "blue" cards must be
+        // enumerated explicitly rather than matched via `is AccessCard`.
+        var target = GetTarget();
+        StartHere<RobotShop>();
+        Take<IdCard>();
+        GetItem<Floyd>().IsOn = true;
+
+        var response = await target.GetResponse("show id card to floyd");
+
+        response.Should().Contain("usually blue");
+    }
+
+    [Test]
+    public async Task Show_KitchenCard_ToFloyd_AsksIfTheyAreUsuallyBlue()
+    {
+        // KitchenAccessCard IS an AccessCard — proves the enumeration spans both type hierarchies.
+        var target = GetTarget();
+        StartHere<RobotShop>();
+        Take<KitchenAccessCard>();
+        GetItem<Floyd>().IsOn = true;
+
+        var response = await target.GetResponse("show kitchen card to floyd");
+
+        response.Should().Contain("usually blue");
+    }
+
+    [Test]
+    public async Task Show_LowerElevatorCard_ToFloyd_RecognizesItAndMarksRevealed()
+    {
+        var target = GetTarget();
+        StartHere<RobotShop>();
+        Take<LowerElevatorAccessCard>();
+        GetItem<Floyd>().IsOn = true;
+        GetItem<Floyd>().HasRevealedLowerElevatorCard = false;
+
+        var response = await target.GetResponse("show lower elevator card to floyd");
+
+        response.Should().Contain("just like that");
+        // The lower card IS an AccessCard but must NOT get the "blue" line — guards the enumeration trap.
+        response.Should().NotContain("usually blue");
+        // Shares the revealed flag with the #222 reveal daemon.
+        GetItem<Floyd>().HasRevealedLowerElevatorCard.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task Show_LowerElevatorCard_ToFloyd_WhenAlreadyRevealed_FallsToDefault()
+    {
+        var target = GetTarget();
+        StartHere<RobotShop>();
+        Take<LowerElevatorAccessCard>();
+        GetItem<Floyd>().IsOn = true;
+        GetItem<Floyd>().HasRevealedLowerElevatorCard = true;
+
+        var response = await target.GetResponse("show lower elevator card to floyd");
+
+        response.Should().Contain("Can you play any games with it");
+        response.Should().NotContain("just like that");
+    }
+
+    [Test]
+    public async Task Show_OrdinaryObject_ToFloyd_GeneratesLlmReaction()
+    {
+        // Option #6 default is an LLM reaction, not the canned line. Floyd has no IGenerationClient in
+        // RespondToMultiNounInteraction, so the reaction is queued via CommentOnAction and rendered by
+        // Floyd's Act() this turn — which requires Floyd to be a registered turn actor (as he is in real
+        // play once activated; setting IsOn directly in a test does not register him).
+        var target = GetTarget();
+        StartHere<RobotShop>();
+        Take<Diary>();
+        var floyd = GetItem<Floyd>();
+        floyd.IsOn = true;
+        target.Context.RegisterActor(floyd);
+        Mock.Get(target.GenerationClient)
+            .Setup(c => c.GenerateCompanionSpeech(It.IsAny<CompanionRequest>()))
+            .ReturnsAsync("Floyd looks it over. \"Ooo, what's this thing do?\"");
+
+        var response = await target.GetResponse("show diary to floyd");
+
+        response.Should().Contain("what's this thing do");
+        response.Should().NotContain("Can you play any games with it"); // no longer the canned line
+    }
+
+    [Test]
+    public async Task Show_OrdinaryObject_ToFloyd_RepeatShow_FallsBackToCannedLine()
+    {
+        // The LLM reaction is queued through CommentOnAction, which fires once per distinct prompt. Showing
+        // Floyd the same object again can't queue a fresh comment, so we fall back to the canned line rather
+        // than returning a blank response.
+        var target = GetTarget();
+        StartHere<RobotShop>();
+        Take<Diary>();
+        var floyd = GetItem<Floyd>();
+        floyd.IsOn = true;
+        target.Context.RegisterActor(floyd);
+        Mock.Get(target.GenerationClient)
+            .Setup(c => c.GenerateCompanionSpeech(It.IsAny<CompanionRequest>()))
+            .ReturnsAsync("Floyd looks it over. \"Ooo, what's this thing do?\"");
+
+        await target.GetResponse("show diary to floyd");              // first time: LLM reaction
+        var response = await target.GetResponse("show diary to floyd"); // repeat: canned fallback
+
+        response.Should().Contain("Can you play any games with it");
+    }
+
+    [Test]
+    public void Show_LowerCard_RevealedFlag_StopsTheDaemonReReveal()
+    {
+        // Coordination with #222: once the lower card is revealed (here, as if shown to Floyd), the
+        // spontaneous reveal daemon must NOT fire again, even when its roll would otherwise succeed.
+        var target = GetTarget();
+        StartHere<RobotShop>();
+        var floyd = GetItem<Floyd>();
+        floyd.IsOn = true;
+
+        var mockChooser = new Mock<IRandomChooser>();
+        mockChooser.Setup(r => r.RollDiceSuccess(3)).Returns(true); // would reveal
+        floyd.Chooser = mockChooser.Object;
+
+        floyd.HasRevealedLowerElevatorCard = true;
+
+        floyd.OffersLowerElevatorCard(target.Context).Should().BeNull();
+    }
+
+    [Test]
+    public void Daemon_Reveal_SetsTheSharedRevealedFlag()
+    {
+        // The reveal daemon sets the same shared flag, so a later `show lower card to floyd` won't
+        // re-trigger the recognition line.
+        var target = GetTarget();
+        StartHere<RobotShop>();
+        var floyd = GetItem<Floyd>();
+        floyd.IsOn = true;
+        floyd.HasRevealedLowerElevatorCard = false;
+
+        var mockChooser = new Mock<IRandomChooser>();
+        mockChooser.Setup(r => r.RollDiceSuccess(3)).Returns(true);
+        floyd.Chooser = mockChooser.Object;
+
+        var reveal = floyd.OffersLowerElevatorCard(target.Context);
+
+        reveal.Should().NotBeNull();
+        floyd.HasRevealedLowerElevatorCard.Should().BeTrue();
+    }
+
+    #endregion
 }

--- a/Planetfall.Tests/FloydTests.cs
+++ b/Planetfall.Tests/FloydTests.cs
@@ -1843,6 +1843,22 @@ public class FloydTests : EngineTestsBase
     }
 
     [Test]
+    public async Task Show_ToFloyd_WhenOff_ProducesNoShowReaction()
+    {
+        // The SHOW branches sit behind RespondToMultiNounInteraction's `!IsOn` guard, so showing Floyd
+        // something while he's switched off must not trigger any reaction. (When Floyd isn't in the room
+        // at all, the multi-noun engine never invokes his handler, so that case is covered by routing.)
+        var target = GetTarget();
+        StartHere<RobotShop>();
+        Take<IdCard>();
+        GetItem<Floyd>().IsOn = false;
+
+        var response = await target.GetResponse("show id card to floyd");
+
+        response.Should().NotContain("usually blue");
+    }
+
+    [Test]
     public async Task Show_ShuttleCard_ToFloyd_AsksIfTheyAreUsuallyBlue()
     {
         var target = GetTarget();

--- a/Planetfall.Tests/FloydTests.cs
+++ b/Planetfall.Tests/FloydTests.cs
@@ -326,7 +326,7 @@ public class FloydTests : EngineTestsBase
         Take<KitchenAccessCard>();
         GetItem<Floyd>().IsOn = true;
         GetItem<Floyd>().CurrentLocation = GetLocation<MessHall>();
-        GetItem<Floyd>().Chooser = Mock.Of<IRandomChooser>(r => r.RollDiceSuccess(3) == true);
+        GetItem<Floyd>().Chooser = Mock.Of<IRandomChooser>(r => r.RollDice(100) == 1); // within Day 1's window -> reveals
 
         var response = await target.GetResponse("slide kitchen access card through slot");
 
@@ -342,7 +342,7 @@ public class FloydTests : EngineTestsBase
         Take<KitchenAccessCard>();
         GetItem<Floyd>().IsOn = true;
         GetItem<Floyd>().CurrentLocation = GetLocation<Library>();
-        GetItem<Floyd>().Chooser = Mock.Of<IRandomChooser>(r => r.RollDiceSuccess(3) == true);
+        GetItem<Floyd>().Chooser = Mock.Of<IRandomChooser>(r => r.RollDice(100) == 1); // within Day 1's window -> reveals
 
         var response = await target.GetResponse("slide kitchen access card through slot");
 
@@ -357,7 +357,7 @@ public class FloydTests : EngineTestsBase
         Take<KitchenAccessCard>();
         GetItem<Floyd>().IsOn = true;
         GetItem<Floyd>().CurrentLocation = GetLocation<MessHall>();
-        GetItem<Floyd>().Chooser = Mock.Of<IRandomChooser>(r => r.RollDiceSuccess(3) == false);
+        GetItem<Floyd>().Chooser = Mock.Of<IRandomChooser>(r => r.RollDice(100) == 100); // above Day 1's window -> no reveal
 
         var response = await target.GetResponse("slide kitchen access card through slot");
 
@@ -371,7 +371,7 @@ public class FloydTests : EngineTestsBase
         StartHere<MessHall>();
         Take<KitchenAccessCard>();
         GetItem<Floyd>().CurrentLocation = GetLocation<MessHall>();
-        GetItem<Floyd>().Chooser = Mock.Of<IRandomChooser>(r => r.RollDiceSuccess(3) == true);
+        GetItem<Floyd>().Chooser = Mock.Of<IRandomChooser>(r => r.RollDice(100) == 1); // within Day 1's window -> reveals
 
         var response = await target.GetResponse("slide kitchen access card through slot");
 
@@ -387,7 +387,7 @@ public class FloydTests : EngineTestsBase
         GetItem<Floyd>().IsOn = true;
         GetItem<Floyd>().Items.Clear();
         GetItem<Floyd>().CurrentLocation = GetLocation<MessHall>();
-        GetItem<Floyd>().Chooser = Mock.Of<IRandomChooser>(r => r.RollDiceSuccess(3) == true);
+        GetItem<Floyd>().Chooser = Mock.Of<IRandomChooser>(r => r.RollDice(100) == 1); // within Day 1's window -> reveals
 
         var response = await target.GetResponse("slide kitchen access card through slot");
 
@@ -2011,16 +2011,12 @@ public class FloydTests : EngineTestsBase
     public void Show_LowerCard_RevealedFlag_StopsTheDaemonReReveal()
     {
         // Coordination with #222: once the lower card is revealed (here, as if shown to Floyd), the
-        // spontaneous reveal daemon must NOT fire again, even when its roll would otherwise succeed.
+        // spontaneous reveal daemon must NOT fire again, even on Day 4 where the chance is otherwise 100%.
         var target = GetTarget();
         StartHere<RobotShop>();
         var floyd = GetItem<Floyd>();
         floyd.IsOn = true;
-
-        var mockChooser = new Mock<IRandomChooser>();
-        mockChooser.Setup(r => r.RollDiceSuccess(3)).Returns(true); // would reveal
-        floyd.Chooser = mockChooser.Object;
-
+        target.Context.Day = 4; // guaranteed reveal window — so the flag is what stops it
         floyd.HasRevealedLowerElevatorCard = true;
 
         floyd.OffersLowerElevatorCard(target.Context).Should().BeNull();
@@ -2036,15 +2032,102 @@ public class FloydTests : EngineTestsBase
         var floyd = GetItem<Floyd>();
         floyd.IsOn = true;
         floyd.HasRevealedLowerElevatorCard = false;
-
-        var mockChooser = new Mock<IRandomChooser>();
-        mockChooser.Setup(r => r.RollDiceSuccess(3)).Returns(true);
-        floyd.Chooser = mockChooser.Object;
+        target.Context.Day = 4; // Day > 3 => guaranteed reveal
 
         var reveal = floyd.OffersLowerElevatorCard(target.Context);
 
         reveal.Should().NotBeNull();
         floyd.HasRevealedLowerElevatorCard.Should().BeTrue();
+    }
+
+    // --- #222: lower-card reveal uses a day-keyed escalating chance, not a flat per-turn roll
+    // (based on FLOYD-REVEAL-CARD-F, globals.zil:1440-1455). Day 1 keeps a small non-zero chance (a
+    // deliberate divergence from the original's strict 0%) so the card stays obtainable on Day 1;
+    // the chance escalates on Days 2-3 and is guaranteed after Day 3. Windows: Day 1 = 5%, Day 2 = 10%,
+    // Day 3 = 30%, Day > 3 = 100%. ---
+
+    [Test]
+    public void Daemon_Day1_Reveals_OnLowRoll()
+    {
+        // Day 1 is intentionally still gettable (small chance) — a sufficiently low roll reveals.
+        var target = GetTarget();
+        StartHere<RobotShop>();
+        var floyd = GetItem<Floyd>();
+        floyd.IsOn = true;
+        target.Context.Day = 1;
+
+        var mockChooser = new Mock<IRandomChooser>();
+        mockChooser.Setup(r => r.RollDice(100)).Returns(1); // inside Day 1's small window
+        floyd.Chooser = mockChooser.Object;
+
+        floyd.OffersLowerElevatorCard(target.Context).Should().NotBeNull();
+    }
+
+    [Test]
+    public void Daemon_Day1_DoesNotReveal_OnRollAboveItsWindow()
+    {
+        var target = GetTarget();
+        StartHere<RobotShop>();
+        var floyd = GetItem<Floyd>();
+        floyd.IsOn = true;
+        target.Context.Day = 1;
+
+        var mockChooser = new Mock<IRandomChooser>();
+        mockChooser.Setup(r => r.RollDice(100)).Returns(8); // above Day 1's window
+        floyd.Chooser = mockChooser.Object;
+
+        floyd.OffersLowerElevatorCard(target.Context).Should().BeNull();
+    }
+
+    [Test]
+    public void Daemon_Day2_Reveals_OnRollThatWouldMissDay1()
+    {
+        // Same roll (8) that misses on Day 1 lands inside Day 2's larger window — the chance escalates.
+        var target = GetTarget();
+        StartHere<RobotShop>();
+        var floyd = GetItem<Floyd>();
+        floyd.IsOn = true;
+        target.Context.Day = 2;
+
+        var mockChooser = new Mock<IRandomChooser>();
+        mockChooser.Setup(r => r.RollDice(100)).Returns(8); // misses Day 1, within Day 2
+        floyd.Chooser = mockChooser.Object;
+
+        floyd.OffersLowerElevatorCard(target.Context).Should().NotBeNull();
+    }
+
+    [Test]
+    public void Daemon_Day3_Reveals_OnRollThatWouldMissDay2()
+    {
+        // A roll (20) above Day 2's window lands inside Day 3's — escalation continues.
+        var target = GetTarget();
+        StartHere<RobotShop>();
+        var floyd = GetItem<Floyd>();
+        floyd.IsOn = true;
+        target.Context.Day = 3;
+
+        var mockChooser = new Mock<IRandomChooser>();
+        mockChooser.Setup(r => r.RollDice(100)).Returns(20); // above Day 2's window, within Day 3's
+        floyd.Chooser = mockChooser.Object;
+
+        floyd.OffersLowerElevatorCard(target.Context).Should().NotBeNull();
+    }
+
+    [Test]
+    public void Daemon_Day4_AlwaysReveals_EvenOnWorstRoll()
+    {
+        // Day > 3 is guaranteed; even the worst possible roll reveals.
+        var target = GetTarget();
+        StartHere<RobotShop>();
+        var floyd = GetItem<Floyd>();
+        floyd.IsOn = true;
+        target.Context.Day = 4;
+
+        var mockChooser = new Mock<IRandomChooser>();
+        mockChooser.Setup(r => r.RollDice(100)).Returns(100); // would miss every sub-100% window
+        floyd.Chooser = mockChooser.Object;
+
+        floyd.OffersLowerElevatorCard(target.Context).Should().NotBeNull();
     }
 
     #endregion

--- a/Planetfall.Tests/Walkthrough/WalkthroughTestBase.cs
+++ b/Planetfall.Tests/Walkthrough/WalkthroughTestBase.cs
@@ -33,7 +33,9 @@ public abstract class WalkthroughTestBase : EngineTestsBase
             .ReturnsAsync((true, "go north")); // (true, "go north") means it IS conversational, rewritten to "go north"
 
         _floydChooser = new Mock<IRandomChooser>();
-        _floydChooser.Setup(s => s.RollDiceSuccess(3)).Returns(true);
+        // Force Floyd's lower-elevator-card reveal: the daemon now rolls RollDice(100) against a day-keyed
+        // chance (#222), so a roll of 1 lands inside every day's window (including Day 1's small chance).
+        _floydChooser.Setup(s => s.RollDice(100)).Returns(1);
 
         // Prevent Floyd from wandering during walkthrough tests
         _floydChooser.Setup(s => s.RollDiceSuccess(5)).Returns(false);  // Don't stop following when player moves

--- a/Planetfall/Item/Kalamontee/Mech/FloydPart/Floyd.cs
+++ b/Planetfall/Item/Kalamontee/Mech/FloydPart/Floyd.cs
@@ -81,26 +81,30 @@ public class Floyd : QuirkyCompanion, IAmANamedPerson, ICanHoldItems, ICanBeGive
     /// </summary>
     /// <param name="prompt">The AI prompt describing what Floyd should say</param>
     /// <param name="context">Current game context</param>
-    public void CommentOnAction(string prompt, IContext context)
+    /// <returns>True if the comment was queued; false if it was a no-op (Floyd absent/off, already
+    /// commenting this turn, or this prompt was already used). Callers that need to know whether the
+    /// queue took — e.g. to decide between an empty response and a fallback line — can branch on this.</returns>
+    public bool CommentOnAction(string prompt, IContext context)
     {
         // Must be on and in the same location as player
         if (!IsHereAndIsOn(context))
-            return;
+            return false;
 
         if (context is not PlanetfallContext planetfallContext)
-            return;
+            return false;
 
         // Only one action comment per turn
         if (planetfallContext.PendingFloydActionCommentPrompt != null)
-            return;
+            return false;
 
         // Don't repeat prompts that have already been used
         if (planetfallContext.UsedFloydActionCommentPrompts.Contains(prompt))
-            return;
+            return false;
 
         // Store the prompt for Act() to process and mark as used
         planetfallContext.PendingFloydActionCommentPrompt = prompt;
         planetfallContext.UsedFloydActionCommentPrompts.Add(prompt);
+        return true;
     }
 
     /// <summary>
@@ -388,13 +392,12 @@ public class Floyd : QuirkyCompanion, IAmANamedPerson, ICanHoldItems, ICanBeGive
         //    return an empty body. If the comment can't be queued — Floyd already reacted to this object,
         //    already spoke this turn, or isn't a turn actor right now — fall back to the canned line so
         //    the player never gets a blank response.
-        if (context is PlanetfallContext pfc && context.Actors.Contains(this))
-        {
-            var reactionPrompt = FloydPrompts.ShownAnObject(shown.NounsForMatching[0]);
-            CommentOnAction(reactionPrompt, context);
-            if (pfc.PendingFloydActionCommentPrompt == reactionPrompt)
-                return new PositiveInteractionResult("");
-        }
+        // Only queue when Floyd will actually act this turn (he renders the comment in Act()); the bool
+        // result tells us the queue took (vs. one of CommentOnAction's silent no-ops), so we know whether
+        // to return the empty body or fall back to the canned line.
+        if (context.Actors.Contains(this)
+            && CommentOnAction(FloydPrompts.ShownAnObject(shown.NounsForMatching[0]), context))
+            return new PositiveInteractionResult("");
 
         return new PositiveInteractionResult(string.Format(FloydConstants.ShowDefaultFormat,
             shown.NounsForMatching[0]));

--- a/Planetfall/Item/Kalamontee/Mech/FloydPart/Floyd.cs
+++ b/Planetfall/Item/Kalamontee/Mech/FloydPart/Floyd.cs
@@ -5,6 +5,7 @@ using Newtonsoft.Json;
 using Planetfall.Item.Kalamontee.Admin;
 using Planetfall.Item.Lawanda;
 using Planetfall.Location;
+using Planetfall.Location.Lawanda;
 
 namespace Planetfall.Item.Kalamontee.Mech.FloydPart;
 
@@ -52,6 +53,12 @@ public class Floyd : QuirkyCompanion, IAmANamedPerson, ICanHoldItems, ICanBeGive
     [UsedImplicitly] public bool HasEverGoneThroughTheLittleDoor { get; set; }
 
     [UsedImplicitly] public bool HasGottenTheFromitzBoard { get; set; }
+
+    // CARD-REVEALED in the original (compone.zil:2039, comptwo/globals). One-time flag, set by EITHER
+    // path: the player showing Floyd a lower-elevator card ("I've got one just like that!", the SHOW
+    // branch) or Floyd spontaneously revealing his own (FloydInventoryManager.OfferLowerElevatorCard,
+    // #222). Shared so the two paths never double-reveal.
+    [UsedImplicitly] public bool HasRevealedLowerElevatorCard { get; set; }
 
     // When you initially turn on Floyd, nothing happens for 3 turns. This delay never happens
     // again if you turn him on/off another time.
@@ -303,12 +310,91 @@ public class Floyd : QuirkyCompanion, IAmANamedPerson, ICanHoldItems, ICanBeGive
         if (!IsOn || HasDied)
             return await base.RespondToMultiNounInteraction(action, context);
 
+        // SHOW is handled before GIVE: in the original, "show <x> to floyd" drives several reactions
+        // (FLOYD-F SHOW branch, compone.zil:2022-2047) that GIVE does not — the printout/computer-concern
+        // gate chief among them. SHOW keeps the object in your hand; GIVE transfers it.
+        var showResult = RespondToShow(action, context);
+        if (showResult is not null)
+            return showResult;
+
         var result = _giveHimSomethingEngine.AreWeGivingSomethingToSomeone(action, this, context);
 
         if (result is not null)
             return result;
 
         return await base.RespondToMultiNounInteraction(action, context);
+    }
+
+    /// <summary>
+    ///     Handles "show &lt;x&gt; to floyd". Ports the reactions from the original FLOYD-F SHOW branch
+    ///     (<c>compone.zil:2022-2047</c>) whose objects exist in this port, in the ZIL's evaluation order.
+    ///     Returns null when this isn't a show-to-Floyd intent (or the item can't be resolved) so the
+    ///     caller falls through to the give engine / base.
+    /// </summary>
+    private InteractionResult? RespondToShow(MultiNounIntent action, IContext context)
+    {
+        if (!action.MatchVerb(Verbs.ShowVerbs))
+            return null;
+
+        // Floyd can be either noun: "show x to floyd" or "show floyd the x".
+        string shownNoun;
+        if (action.MatchNounOne(NounsForMatching))
+            shownNoun = action.NounTwo;
+        else if (action.MatchNounTwo(NounsForMatching))
+            shownNoun = action.NounOne;
+        else
+            return null;
+
+        var shown = Repository.GetItemInScope(shownNoun, context);
+        if (shown is null)
+            return null;
+
+        // ZIL syntax is SHOW OBJECT (HAVE) ... (syntax.zil:450) — the shown item must be held.
+        if (!context.Items.Contains(shown))
+            return new PositiveInteractionResult($"You don't have the {shown.NounsForMatching[0]}! ");
+
+        // Branch order mirrors the ZIL exactly; the printout and lower-card branches are one-shot.
+
+        // 1. Printout, first time -> Floyd's "computer is broken" concern. Sets the SAME flag the
+        //    Computer-Room visit sets (COMPUTER-FLAG / ComputerRoom.FloydHasExpressedConcern), which
+        //    gates the bio-lab card foray. Once concerned, the printout falls through to the default.
+        var computerRoom = Repository.GetLocation<ComputerRoom>();
+        if (shown is ComputerOutput && !computerRoom.FloydHasExpressedConcern)
+        {
+            computerRoom.FloydHasExpressedConcern = true;
+            return new PositiveInteractionResult(FloydConstants.ComputerBrokenFromPrintout);
+        }
+
+        // 2. The four "blue" cards. Enumerate explicitly: IdCard isn't an AccessCard at all, and the
+        //    teleport/mini/lower AccessCards must NOT match here — so `is AccessCard` would be wrong.
+        if (shown is IdCard or ShuttleAccessCard or KitchenAccessCard or UpperElevatorAccessCard)
+            return new PositiveInteractionResult(FloydConstants.CardsUsuallyBlue);
+
+        // 3. Lower-elevator card, first time -> recognition. Shares the revealed flag with the reveal
+        //    daemon (FloydInventoryManager.OfferLowerElevatorCard, #222) so the paths don't double-reveal.
+        if (shown is LowerElevatorAccessCard && !HasRevealedLowerElevatorCard)
+        {
+            HasRevealedLowerElevatorCard = true;
+            return new PositiveInteractionResult(FloydConstants.LowerCardJustLikeThat);
+        }
+
+        // 4. Default — anything else (and the printout/lower-card once their one-shot flags are set).
+        //    The original's fixed "Can you play any games with it?" is replaced by an in-character LLM
+        //    reaction. RespondToMultiNounInteraction has no IGenerationClient to generate inline, so we
+        //    queue it via the standard CommentOnAction path (Floyd's Act() renders it this turn) and
+        //    return an empty body. If the comment can't be queued — Floyd already reacted to this object,
+        //    already spoke this turn, or isn't a turn actor right now — fall back to the canned line so
+        //    the player never gets a blank response.
+        if (context is PlanetfallContext pfc && context.Actors.Contains(this))
+        {
+            var reactionPrompt = FloydPrompts.ShownAnObject(shown.NounsForMatching[0]);
+            CommentOnAction(reactionPrompt, context);
+            if (pfc.PendingFloydActionCommentPrompt == reactionPrompt)
+                return new PositiveInteractionResult("");
+        }
+
+        return new PositiveInteractionResult(string.Format(FloydConstants.ShowDefaultFormat,
+            shown.NounsForMatching[0]));
     }
 
     /// <summary>

--- a/Planetfall/Item/Kalamontee/Mech/FloydPart/Floyd.cs
+++ b/Planetfall/Item/Kalamontee/Mech/FloydPart/Floyd.cs
@@ -358,11 +358,14 @@ public class Floyd : QuirkyCompanion, IAmANamedPerson, ICanHoldItems, ICanBeGive
         // 1. Printout, first time -> Floyd's "computer is broken" concern. Sets the SAME flag the
         //    Computer-Room visit sets (COMPUTER-FLAG / ComputerRoom.FloydHasExpressedConcern), which
         //    gates the bio-lab card foray. Once concerned, the printout falls through to the default.
-        var computerRoom = Repository.GetLocation<ComputerRoom>();
-        if (shown is ComputerOutput && !computerRoom.FloydHasExpressedConcern)
+        if (shown is ComputerOutput)
         {
-            computerRoom.FloydHasExpressedConcern = true;
-            return new PositiveInteractionResult(FloydConstants.ComputerBrokenFromPrintout);
+            var computerRoom = Repository.GetLocation<ComputerRoom>();
+            if (!computerRoom.FloydHasExpressedConcern)
+            {
+                computerRoom.FloydHasExpressedConcern = true;
+                return new PositiveInteractionResult(FloydConstants.ComputerBrokenFromPrintout);
+            }
         }
 
         // 2. The four "blue" cards. Enumerate explicitly: IdCard isn't an AccessCard at all, and the

--- a/Planetfall/Item/Kalamontee/Mech/FloydPart/FloydConstants.cs
+++ b/Planetfall/Item/Kalamontee/Mech/FloydPart/FloydConstants.cs
@@ -82,6 +82,25 @@ public static class FloydConstants
     internal const string ComputerBroken =
         "Floyd examines the glowing light. With a concerned frown, he says, \"Uh oh. Computer is broken. A Doctor-person once told Floyd that Computer is the most important part of the Project.\"";
 
+    // The same concern as ComputerBroken, but the SHOW-printout variant. COMPUTER-ACTION
+    // (comptwo.zil:1514-1524) branches its wording on location: "glowing light" in the Computer Room
+    // (ComputerBroken, used by the room trigger) vs "computer printout" everywhere else — which is where
+    // "show printout to floyd" fires. Reusing ComputerBroken would have Floyd "examine the glowing light"
+    // while you hold a printout in another room, a divergence from the original.
+    internal const string ComputerBrokenFromPrintout =
+        "Floyd examines the computer printout. With a concerned frown, he says, \"Uh oh. Computer is broken. A Doctor-person once told Floyd that Computer is the most important part of the Project.\"";
+
+    internal const string CardsUsuallyBlue =
+        "Floyd scratches his head. \"Aren't those things usually blue?\"";
+
+    internal const string LowerCardJustLikeThat =
+        "\"I've got one just like that!\" says Floyd. He looks through several of his compartments, then glances at you suspiciously.";
+
+    // Default SHOW reaction (FLOYD-F, compone.zil:2044-2047): "Floyd looks over the <x>...". {0} is the
+    // shown item's primary noun, mirroring the give engine's "You don't have the {noun}!" convention.
+    internal const string ShowDefaultFormat =
+        "Floyd looks over the {0}. \"Can you play any games with it?\" he asks.";
+
     internal const string NeedToGetCard =
         """Floyd stands on his tiptoes and peers in the window. "Looks dangerous in there," says Floyd. "I don't think you should go inside." He peers in again. "We'll need card there to fix computer. Hmmm... I know! Floyd will get card. Robots are tough. Nothing can hurt robots. You open the door, then Floyd will rush in. Then you close door. When Floyd knocks, open door again. Okay? Go!" Floyd's voice trembles slightly as he waits for you to open the door.""";
 

--- a/Planetfall/Item/Kalamontee/Mech/FloydPart/FloydInventoryManager.cs
+++ b/Planetfall/Item/Kalamontee/Mech/FloydPart/FloydInventoryManager.cs
@@ -41,7 +41,7 @@ public class FloydInventoryManager(Floyd floyd)
             !floyd.IsOn ||
             !floyd.Items.Any() ||
             floyd.HasRevealedLowerElevatorCard ||
-            !chooser.RollDiceSuccess(3))
+            !RevealChanceSucceeds(context, chooser))
             return null;
 
         // Shared one-time flag (CARD-REVEALED): also set when the player shows Floyd a lower-elevator
@@ -68,5 +68,29 @@ public class FloydInventoryManager(Floyd floyd)
     private bool IsFloydInRoom(IContext context)
     {
         return floyd.CurrentLocation == context.CurrentLocation;
+    }
+
+    // Based on FLOYD-REVEAL-CARD-F (globals.zil:1440-1455): the chance Floyd reveals his lower-elevator
+    // card escalates by day and is guaranteed after Day 3 (the divergence #222 fixes — the old code used a
+    // flat ~33% every turn). The original gives Day 1 a 0% chance and splits Days 2-3 by an absolute
+    // INTERNAL-MOVES boundary (5%/10% on Day 2, 20%/40% on Day 3); that move counter has no clean C# analog
+    // (the chronometer resets to a morning base each day with no fixed day length), so we use one
+    // representative chance per day. We deliberately keep a small NON-ZERO Day-1 chance rather than the
+    // original's strict 0%, so the card stays obtainable on Day 1 to match the engine's existing early-game
+    // flow. The day escalation and the post-Day-3 guarantee are the load-bearing behavior.
+    private static bool RevealChanceSucceeds(IContext context, IRandomChooser chooser)
+    {
+        var day = (context as PlanetfallContext)?.Day ?? 1;
+        var percent = day switch
+        {
+            <= 1 => 5,   // Day 1: small but non-zero (pragmatic divergence from the original's 0%)
+            2 => 10,     // Day 2: ~5-10% in the original
+            3 => 30,     // Day 3: ~20-40% in the original
+            _ => 100     // Day > 3: guaranteed
+        };
+
+        // RollDice(100) returns 1-100; succeed when the roll lands in the percent window. Short-circuit the
+        // guaranteed (>=100%) case so the roll is only consulted when it actually matters.
+        return percent >= 100 || chooser.RollDice(100) <= percent;
     }
 }

--- a/Planetfall/Item/Kalamontee/Mech/FloydPart/FloydInventoryManager.cs
+++ b/Planetfall/Item/Kalamontee/Mech/FloydPart/FloydInventoryManager.cs
@@ -40,8 +40,13 @@ public class FloydInventoryManager(Floyd floyd)
         if (!IsFloydInRoom(context) ||
             !floyd.IsOn ||
             !floyd.Items.Any() ||
+            floyd.HasRevealedLowerElevatorCard ||
             !chooser.RollDiceSuccess(3))
             return null;
+
+        // Shared one-time flag (CARD-REVEALED): also set when the player shows Floyd a lower-elevator
+        // card (Floyd.RespondToShow, #203), so that path and this daemon never both reveal the card.
+        floyd.HasRevealedLowerElevatorCard = true;
 
         // Remove it from inside, put it in his hand.
         floyd.Items.Clear();

--- a/Planetfall/Item/Kalamontee/Mech/FloydPart/FloydPrompts.cs
+++ b/Planetfall/Item/Kalamontee/Mech/FloydPart/FloydPrompts.cs
@@ -278,6 +278,17 @@ internal static class FloydPrompts
         "Preface it with 'Floyd takes a step back' or 'Floyd eyes the laser nervously' or something similar, " +
         "and put his comment in quotes. ";
 
+    // Floyd's reaction when the player shows him an ordinary object (the default SHOW branch, replacing
+    // the original's fixed "Can you play any games with it?"). The object name is baked in as plain text;
+    // keep it brace-free so GenerateCompanionSpeech's own string.Format pass is a no-op.
+    public static string ShownAnObject(string objectName) =>
+        $"The player holds up a {objectName} and shows it to you. Give Floyd something short and curious " +
+        "to say about it, in his eager childlike way - he might wonder aloud what it is or what it does, " +
+        "ask whether you can play a game with it, or make an innocent observation. Keep it brief and light, " +
+        "with no effect on the game. " +
+        "Preface it with 'Floyd looks it over' or 'Floyd peers at it' or something similar, " +
+        "and put his comment in quotes. ";
+
     public static string LibraryComputerFirstUse =>
         "Give Floyd something short and curious to say as you start typing on a library computer terminal. " +
         "Floyd is fascinated by the computer and watches intently as you navigate the menus. " +

--- a/Planetfall/Item/Kalamontee/Mech/FloydPart/FloydPrompts.cs
+++ b/Planetfall/Item/Kalamontee/Mech/FloydPart/FloydPrompts.cs
@@ -281,13 +281,19 @@ internal static class FloydPrompts
     // Floyd's reaction when the player shows him an ordinary object (the default SHOW branch, replacing
     // the original's fixed "Can you play any games with it?"). The object name is baked in as plain text;
     // keep it brace-free so GenerateCompanionSpeech's own string.Format pass is a no-op.
-    public static string ShownAnObject(string objectName) =>
-        $"The player holds up a {objectName} and shows it to you. Give Floyd something short and curious " +
-        "to say about it, in his eager childlike way - he might wonder aloud what it is or what it does, " +
-        "ask whether you can play a game with it, or make an innocent observation. Keep it brief and light, " +
-        "with no effect on the game. " +
-        "Preface it with 'Floyd looks it over' or 'Floyd peers at it' or something similar, " +
-        "and put his comment in quotes. ";
+    public static string ShownAnObject(string objectName)
+    {
+        // GenerateCompanionSpeech runs every prompt through string.Format, so literal braces in the
+        // (runtime) object noun must be doubled or that pass throws FormatException. Every current item
+        // noun is brace-free, but escaping keeps that from being a silent invariant a future noun breaks.
+        var safeName = objectName.Replace("{", "{{").Replace("}", "}}");
+        return $"The player holds up a {safeName} and shows it to you. Give Floyd something short and curious " +
+               "to say about it, in his eager childlike way - he might wonder aloud what it is or what it does, " +
+               "ask whether you can play a game with it, or make an innocent observation. Keep it brief and light, " +
+               "with no effect on the game. " +
+               "Preface it with 'Floyd looks it over' or 'Floyd peers at it' or something similar, " +
+               "and put his comment in quotes. ";
+    }
 
     public static string LibraryComputerFirstUse =>
         "Give Floyd something short and curious to say as you start typing on a library computer terminal. " +

--- a/UnitTests/IntentMappings/base-mappings.json
+++ b/UnitTests/IntentMappings/base-mappings.json
@@ -176,6 +176,11 @@
     { "inputs": ["give the key to floyd"], "verb": "give", "nounOne": "key", "nounTwo": "floyd", "preposition": "to", "originalInput": "give the key to floyd" },
     { "inputs": ["give the plate to floyd", "give plate to floyd"], "verb": "give", "nounOne": "plate", "nounTwo": "floyd", "preposition": "to", "originalInput": "give the plate to floyd" },
     { "inputs": ["give the breastplate to floyd", "give breastplate to floyd"], "verb": "give", "nounOne": "breastplate", "nounTwo": "floyd", "preposition": "to", "originalInput": "give the breastplate to floyd" },
+    { "inputs": ["show printout to floyd", "show the printout to floyd"], "verb": "show", "nounOne": "printout", "nounTwo": "floyd", "preposition": "to", "originalInput": "show printout to floyd" },
+    { "inputs": ["show id card to floyd", "show the id card to floyd"], "verb": "show", "nounOne": "id card", "nounTwo": "floyd", "preposition": "to", "originalInput": "show id card to floyd" },
+    { "inputs": ["show kitchen card to floyd"], "verb": "show", "nounOne": "kitchen card", "nounTwo": "floyd", "preposition": "to", "originalInput": "show kitchen card to floyd" },
+    { "inputs": ["show lower elevator card to floyd", "show lower card to floyd"], "verb": "show", "nounOne": "lower elevator card", "nounTwo": "floyd", "preposition": "to", "originalInput": "show lower elevator card to floyd" },
+    { "inputs": ["show diary to floyd"], "verb": "show", "nounOne": "diary", "nounTwo": "floyd", "preposition": "to", "originalInput": "show diary to floyd" },
 
     { "inputs": ["kill thief with sword"], "verb": "kill", "nounOne": "thief", "nounTwo": "sword", "preposition": "with", "originalInput": "kill thief with sword" },
     { "inputs": ["kill thief with knife"], "verb": "kill", "nounOne": "thief", "nounTwo": "knife", "preposition": "with", "originalInput": "kill thief with knife" },

--- a/UnitTests/IntentMappings/base-mappings.json
+++ b/UnitTests/IntentMappings/base-mappings.json
@@ -179,6 +179,8 @@
     { "inputs": ["show printout to floyd", "show the printout to floyd"], "verb": "show", "nounOne": "printout", "nounTwo": "floyd", "preposition": "to", "originalInput": "show printout to floyd" },
     { "inputs": ["show id card to floyd", "show the id card to floyd"], "verb": "show", "nounOne": "id card", "nounTwo": "floyd", "preposition": "to", "originalInput": "show id card to floyd" },
     { "inputs": ["show kitchen card to floyd"], "verb": "show", "nounOne": "kitchen card", "nounTwo": "floyd", "preposition": "to", "originalInput": "show kitchen card to floyd" },
+    { "inputs": ["show shuttle card to floyd"], "verb": "show", "nounOne": "shuttle card", "nounTwo": "floyd", "preposition": "to", "originalInput": "show shuttle card to floyd" },
+    { "inputs": ["show upper elevator card to floyd"], "verb": "show", "nounOne": "upper elevator card", "nounTwo": "floyd", "preposition": "to", "originalInput": "show upper elevator card to floyd" },
     { "inputs": ["show lower elevator card to floyd", "show lower card to floyd"], "verb": "show", "nounOne": "lower elevator card", "nounTwo": "floyd", "preposition": "to", "originalInput": "show lower elevator card to floyd" },
     { "inputs": ["show diary to floyd"], "verb": "show", "nounOne": "diary", "nounTwo": "floyd", "preposition": "to", "originalInput": "show diary to floyd" },
 


### PR DESCRIPTION
## What & why

Floyd never reacted to `show <x> to floyd` — only GIVE was handled, so the entire `FLOYD-F` SHOW branch (`compone.zil:2022-2047`) was missing. This ports it, in the ZIL's evaluation order. Closes #203, and folds in / closes #280 and #222.

## Reactions

| Shown to Floyd | Reaction |
|---|---|
| **Printout** (first time) | Sets `ComputerRoom.FloydHasExpressedConcern` (the `COMPUTER-FLAG` analog) and emits a "computer is broken" message — **unlocking the bio-lab card foray**. This is the #280 fix: showing the printout is the second, previously-missing trigger for that gate (the Computer-Room visit was the only one). |
| **The four "blue" cards** (id / shuttle / kitchen / upper-elevator) | "Aren't those usually blue?" |
| **Lower-elevator card** (first time) | "I've got one just like that!" + marks it revealed |
| **Anything else** | An **LLM-generated, in-character reaction** (see below) |

## Also folds in #222 — lower-card reveal escalation

The same lower-card daemon (`FloydInventoryManager.OfferLowerElevatorCard`) used a flat ~33% roll every qualifying turn. Based on `FLOYD-REVEAL-CARD-F` (`globals.zil:1440-1455`), the chance now escalates by day and is guaranteed after Day 3 — **Day 1 = 5%, Day 2 = 10%, Day 3 = 30%, Day > 3 = 100%** (via `RollDice(100)`).

- **Deliberate divergence:** the ZIL gives Day 1 a strict **0%**. Per a decision on this PR, we keep a small **non-zero** Day-1 chance so the card stays obtainable on Day 1 — the existing Day-1 walkthroughs (and early-game flow) get the card from Floyd before any sleep, which a hard 0% would break. The day-escalation and post-Day-3 guarantee (the substance of #222) are preserved.
- The original's `INTERNAL-MOVES`-based mid-day split has no clean C# analog (the chronometer resets to a morning base each day with no fixed day length), so each day uses one representative chance.
- The shared `HasRevealedLowerElevatorCard` flag (the #203 coordination) is unchanged.

## Notes for reviewers

- **`COMPUTER-ACTION` wording varies by location** (`comptwo.zil:1514-1524`): "glowing light" in the Computer Room vs "computer printout" elsewhere. The show-printout path fires elsewhere, so it uses a dedicated printout-variant string rather than reusing the existing "glowing light" `ComputerBroken` constant (which would have been a divergence).
- **Blue cards are enumerated explicitly**, *not* `is AccessCard` — `IdCard` isn't an `AccessCard` at all, while the teleport/mini/lower cards *are* but must not get the blue line.
- **Two shared one-shot flags**:
  - `ComputerRoom.FloydHasExpressedConcern` is now set by *both* the Computer-Room visit and the show-printout path (the bio-lock state machine already consumes it).
  - New `Floyd.HasRevealedLowerElevatorCard` (the `CARD-REVEALED` analog) is set/checked by *both* the lower-card SHOW and the spontaneous reveal daemon, so they never double-reveal (coordinates with #222).
- **LLM default (deliberate divergence from the canned ZIL line).** `RespondToMultiNounInteraction` has no `IGenerationClient`, so the default reaction is queued via the existing `CommentOnAction` path (rendered by Floyd's `Act()` that turn) using an object-aware prompt. The canned "Can you play any games with it?" line is retained **only as a fallback** for when a comment can't be queued (Floyd already reacted to that object, already spoke this turn, or isn't a turn actor) — so the player never gets a blank response.
- **SHOW requires the item to be held** (`syntax.zil:450` — `SHOW OBJECT (HAVE) …`), mirroring the give engine's possession guard.

## Tests (TDD per CLAUDE.md)

Deterministic tests in `Planetfall.Tests/FloydTests.cs`, confirmed red-before / green-after, covering each SHOW branch, both one-shot guards, the LLM default + its repeat-show fallback, the daemon-coordination flag (both directions), and the #222 day-escalation (Day-1 gettable, escalation across days, post-Day-3 guarantee — verified red against the old flat roll). The two Day-1 walkthroughs and the `DoesFloydOfferCard_*` integration tests were updated to force the reveal via the new `RollDice(100)` mechanism.

- **Planetfall.Tests**: 2320/2320
- **UnitTests**: 891/891 (1 pre-existing skip)
- **ZorkOne.Tests**: 1251/1251

`Model/Verbs.cs` (`ShowVerbs`) and `UnitTests/IntentMappings/base-mappings.json` are shared across games; the latter two suites are run as regression guards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

