### PR TITLE
Fix #286: present-NPC named direct-address without a comma no longer deflects to the narrator

### DIFF
--- a/GameEngine/ConversationHandler.cs
+++ b/GameEngine/ConversationHandler.cs
@@ -394,10 +394,21 @@ public class ConversationHandler(
     }
 
     /// <summary>
-    /// Detects the vocative "Name, ..." direct-address pattern (e.g. "blather, you clean the
-    /// floor") and returns the text that follows the name. This is a strong, deterministic
-    /// signal that the player is speaking to the character, independent of the AI rewriter,
-    /// which only reliably recognizes imperative commands.
+    /// Detects whether the player directly addressed the present character by name and, if so, returns
+    /// the text that follows the name to route to <see cref="ICanBeTalkedTo.OnBeingTalkedTo"/>. This is
+    /// a strong, deterministic signal independent of the AI rewriter, which only reliably recognizes
+    /// imperative commands. Recognizes the name at the start of the utterance — bare ("blather you are
+    /// a fool"), vocative ("blather, ..."), the name alone ("blather"), or behind a casual/article
+    /// opener ("hey blather", "the ambassador ...") — mirroring the absent-NPC check in
+    /// <see cref="IsGenuineDirectAddress"/>.
+    ///
+    /// A comma is deliberately NOT required. Requiring one was the #286 gap: the bare no-comma form had
+    /// no deterministic backstop, so detection fell entirely to the nondeterministic classifier and
+    /// intermittently (~3-5%) deflected to the narrator. Almost nothing legitimately starts a command
+    /// with a character's name, so the leading-name form is genuine address. Names match at a word
+    /// boundary, so a mere mention ("examine blather") is not hijacked (it never starts with the name
+    /// anyway). Imperative lead-ins ("ask blather ...") are left to the classifier, which handles
+    /// commands reliably; only the leading-name form needs the deterministic guard.
     /// </summary>
     private static bool TryStripDirectAddress(string input, ICanBeTalkedTo targetCharacter, out string remainder)
     {
@@ -406,22 +417,17 @@ public class ConversationHandler(
         if (targetCharacter is not IItem item)
             return false;
 
-        var trimmed = input.TrimStart();
+        // Strip one leading casual opener ("hey "/"yo "/...) and/or article ("the ") so "hey blather,
+        // ..." and "the ambassador ..." are recognized, exactly as the absent-NPC path does.
+        var leading = StripLeadingAddressPrefix(input.TrimStart());
 
         // Prefer the longest matching noun so "ensign blather" wins over "blather".
         foreach (var noun in item.NounsForMatching.OrderByDescending(n => n.Length))
         {
-            if (!trimmed.StartsWith(noun, StringComparison.OrdinalIgnoreCase))
+            if (!StartsWithWholeWord(leading, noun))
                 continue;
 
-            var rest = trimmed[noun.Length..];
-
-            // Require the name to be followed by a comma (or to be the whole input) so we
-            // only catch genuine direct address and never hijack a real command.
-            if (!rest.StartsWith(',') && rest.Trim().Length != 0)
-                continue;
-
-            remainder = rest.TrimStart(',', ' ', '.', '!', '?').Trim();
+            remainder = leading[noun.Length..].TrimStart(',', ' ', '.', '!', '?').Trim();
 
             // "blather" / "blather," on its own: pass the whole utterance through.
             if (string.IsNullOrWhiteSpace(remainder))

--- a/UnitTests/Engine/ConversationHandlerTests.cs
+++ b/UnitTests/Engine/ConversationHandlerTests.cs
@@ -142,6 +142,107 @@ public class ConversationHandlerTests
         mockParser.Verify(p => p.ParseAsync("floyd, go north"), Times.Once);
     }
 
+    [TestCase("blather you are a fool", "you are a fool", TestName = "NoComma_Statement")]
+    [TestCase("blather, you are a fool", "you are a fool", TestName = "Comma_Statement")]
+    [TestCase("blather what should i do now", "what should i do now", TestName = "NoComma_Question")]
+    [TestCase("hey blather you fool", "you fool", TestName = "Opener_NoComma")]
+    [TestCase("ensign blather you fool", "you fool", TestName = "MultiWordName_NoComma")]
+    public async Task CheckForConversation_PresentTalker_NamedDirectAddress_RoutesEvenWhenClassifierSaysNo(
+        string input, string expectedRemainder)
+    {
+        // #286: addressing a PRESENT talkable NPC by name must engage them even when the
+        // nondeterministic classifier misfires and reports "not conversational". The deterministic
+        // backstop used to require a comma after the name, so the bare "blather you are a fool" form
+        // had no fallback and ~3-5% of the time deflected to a generic third-person narrator quip. It
+        // now mirrors the absent-NPC path and recognizes the leading-name form (bare, vocative, or
+        // behind a casual opener) without a comma, routing the text after the name to the character.
+        var mockParser = new Mock<IParseConversation>();
+        mockParser.Setup(p => p.ParseAsync(It.IsAny<string>())).ReturnsAsync((false, string.Empty));
+
+        var mockTalker = new Mock<ICanBeTalkedTo>();
+        mockTalker.As<IItem>().Setup(i => i.NounsForMatching).Returns(new[] { "blather", "ensign blather" });
+        mockTalker.Setup(t => t.OnBeingTalkedTo(It.IsAny<string>(), It.IsAny<IContext>(), It.IsAny<IGenerationClient>()))
+                  .ReturnsAsync("Blather sneers.");
+
+        var handler = new ConversationHandler(null, mockParser.Object, Mock.Of<IGenerationClient>());
+        var context = new ZorkIContext();
+        context.Items.Add((IItem)mockTalker.Object);
+
+        // Act
+        var result = await handler.CheckForConversation(input, context);
+
+        // Assert - engaged with the text after the leading name, not dropped to the narrator.
+        result.Should().Be("Blather sneers.");
+        mockTalker.Verify(
+            t => t.OnBeingTalkedTo(expectedRemainder, context, It.IsAny<IGenerationClient>()),
+            Times.Once);
+    }
+
+    [TestCase("robot you are broken", "you are broken", TestName = "Synonym_NoComma")]
+    [TestCase("the robot is broken", "is broken", TestName = "Synonym_WithLeadingArticle")]
+    public async Task CheckForConversation_PresentTalker_AddressedBySynonym_RoutesEvenWhenClassifierSaysNo(
+        string input, string expectedRemainder)
+    {
+        // #286: a present NPC answers to its synonyms too (Floyd IS the "robot", the Ambassador the
+        // "alien"). Leading with a synonym is direct address just like leading with the name, mirroring
+        // the absent path (see CheckForConversation_AbsentKnownTalker_GenericSynonymIsTreatedAsAddress).
+        // This is the one deliberate behavior change: such input used to fall through when the
+        // classifier said "no"; now it deterministically reaches the present NPC.
+        var mockParser = new Mock<IParseConversation>();
+        mockParser.Setup(p => p.ParseAsync(It.IsAny<string>())).ReturnsAsync((false, string.Empty));
+
+        var mockTalker = new Mock<ICanBeTalkedTo>();
+        mockTalker.As<IItem>().Setup(i => i.NounsForMatching).Returns(new[] { "floyd", "robot" });
+        mockTalker.Setup(t => t.OnBeingTalkedTo(It.IsAny<string>(), It.IsAny<IContext>(), It.IsAny<IGenerationClient>()))
+                  .ReturnsAsync("Floyd beeps.");
+
+        var handler = new ConversationHandler(null, mockParser.Object, Mock.Of<IGenerationClient>());
+        var context = new ZorkIContext();
+        context.Items.Add((IItem)mockTalker.Object);
+
+        // Act
+        var result = await handler.CheckForConversation(input, context);
+
+        // Assert
+        result.Should().Be("Floyd beeps.");
+        mockTalker.Verify(
+            t => t.OnBeingTalkedTo(expectedRemainder, context, It.IsAny<IGenerationClient>()),
+            Times.Once);
+    }
+
+    [TestCase("examine blather", TestName = "BareMention")]
+    [TestCase("look at blather", TestName = "LookAtMention")]
+    [TestCase("attack blather with the brush", TestName = "AttackMention")]
+    [TestCase("the lever near blather is stuck", TestName = "NameMidSentence")]
+    public async Task CheckForConversation_PresentTalker_NonAddress_DoesNotHijack(string input)
+    {
+        // #286 guard: the name is merely mentioned, not used to address the NPC. With the comma
+        // requirement relaxed, the leading-name check (after stripping an opener/article) must still
+        // decline these so a real command is not hijacked into the conversation handler. The classifier
+        // is consulted and (unconfigured) also says "not conversational", so the input falls through to
+        // normal parsing and the character is never engaged.
+        var mockParser = new Mock<IParseConversation>();
+        mockParser.Setup(p => p.ParseAsync(It.IsAny<string>())).ReturnsAsync((false, string.Empty));
+
+        var mockTalker = new Mock<ICanBeTalkedTo>();
+        mockTalker.As<IItem>().Setup(i => i.NounsForMatching).Returns(new[] { "blather" });
+        mockTalker.Setup(t => t.OnBeingTalkedTo(It.IsAny<string>(), It.IsAny<IContext>(), It.IsAny<IGenerationClient>()))
+                  .ReturnsAsync("should not be called");
+
+        var handler = new ConversationHandler(null, mockParser.Object, Mock.Of<IGenerationClient>());
+        var context = new ZorkIContext();
+        context.Items.Add((IItem)mockTalker.Object);
+
+        // Act
+        var result = await handler.CheckForConversation(input, context);
+
+        // Assert - not hijacked: the character is never engaged and the input falls through.
+        result.Should().BeNull();
+        mockTalker.Verify(
+            t => t.OnBeingTalkedTo(It.IsAny<string>(), It.IsAny<IContext>(), It.IsAny<IGenerationClient>()),
+            Times.Never);
+    }
+
     [Test]
     public async Task CheckForConversation_ReturnsResponse_WhenConversationDetected()
     {


### PR DESCRIPTION
## What & why

Fixes #286. When a talkable NPC (Floyd / Blather / Ambassador) is **present** and the player addresses them **by name without a comma** — e.g. `blather you are a fool` — the input intermittently (~3–5%) fell through to a generic third-person narrator quip instead of engaging the NPC.

### Root cause

`ConversationHandler.ProcessConversation` backstops the **nondeterministic** conversation classifier (`IParseConversation.ParseAsync`) with `TryStripDirectAddress`. That backstop only fired when the name was followed by a **comma** (or was the entire input):

```csharp
if (!rest.StartsWith(',') && rest.Trim().Length != 0)
    continue;   // bare "blather you are a fool" -> skipped
```

So the bare leading-name form had **no deterministic fallback** and depended entirely on the classifier. The classifier is the Floyd-oriented `RewriteSecondPerson` assistant, which is weakest on non-imperative statements/questions — exactly the form in the bug report — so when it returned "not conversational", the input deflected.

The **absent**-NPC path (#264) already solved this with `IsGenuineDirectAddress`, which recognizes the bare leading-name form without a comma. The present path was simply never brought to parity.

### The fix

`TryStripDirectAddress` now strips an optional opener/article and matches the name at a **word boundary**, reusing the absent path's existing helpers (`StripLeadingAddressPrefix`, `StartsWithWholeWord`) — no duplicated logic. Bare (`blather you are a fool`), vocative (`blather, ...`), name-only, opener (`hey blather`), and `the <name> ...` forms all route deterministically now.

- Imperative lead-ins (`ask blather ...`) are deliberately left to the classifier, which handles commands reliably.
- Whole-word matching means mid-sentence mentions (`examine blather`, `the lever near blather is stuck`) are **not** hijacked.
- One deliberate behavior change: leading **synonyms** (`robot ...` for Floyd, `alien ...` for the Ambassador) and `the <name> ...` now route to a *present* NPC when the classifier says "no" — matching the absent path's long-standing synonym handling.

Production change is ~15 lines (mostly an expanded doc comment explaining the trap).

## Tests (TDD)

Added to `UnitTests/Engine/ConversationHandlerTests.cs` (deterministic — mocked classifier + talker, no AWS):

- **Red first:** the no-comma cases failed with `Expected "Blather sneers.", but found <null>` (the exact deflection); the comma case already passed.
- Routing: no-comma statement/question, comma, opener, and multi-word-name (`ensign blather ...`) forms reach the present NPC even when the classifier says "not conversational".
- Synonym routing: `robot ...` / `the robot ...` reach the NPC.
- No-hijack guard: `examine blather`, `look at blather`, `the lever near blather is stuck` fall through and never engage the NPC.

## Verification

No regressions — each project run separately:

| Suite | Result |
|---|---|
| `ConversationHandlerTests` | 54/54 |
| `Planetfall.Tests` | 2300/2300 |
| `UnitTests` | 902 passed, 1 pre-existing skip |
| `ZorkOne.Tests` | 1251/1251 |

## Related

- #182 (present named-address), #264 (absent named-address) — this completes the named-address trio.
- #284 (nameless conversational forms — bare quoted speech / untargeted `say`) was investigated and is **out of scope** here: it's an orthogonal code path (target never identified) and carries cross-game risk (`say` collides with Zork magic words). Findings posted on that issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
