### PR TITLE
Route nameless conversational speech to the sole present NPC (#284)

### DIFF
--- a/GameEngine/ConversationHandler.cs
+++ b/GameEngine/ConversationHandler.cs
@@ -31,19 +31,26 @@ public class ConversationHandler(
 
         if (targetCharacter == null)
         {
-            // No talkable NPC is present. If the player nonetheless addressed a KNOWN but absent one,
-            // tell them the character isn't here instead of letting the leftover command fall through
-            // to normal player parsing. Falling through is the #264 bug: it would silently move the
-            // player ("floyd, go up"), drop their items ("floyd, drop diary"), or let the narrator
-            // hallucinate the absent NPC acting. Detection mirrors the present path: a deterministic
-            // fast path catches the common forms (and works offline), and anything else defers to the
-            // same conversation classifier, so any phrasing works. See FindAddressedAbsentCharacter.
+            // No talkable NPC is present BY NAME. If the player nonetheless addressed a KNOWN but
+            // absent one, tell them the character isn't here instead of letting the leftover command
+            // fall through to normal player parsing. Falling through is the #264 bug: it would
+            // silently move the player ("floyd, go up"), drop their items ("floyd, drop diary"), or
+            // let the narrator hallucinate the absent NPC acting. Detection mirrors the present path:
+            // a deterministic fast path catches the common forms (and works offline), and anything
+            // else defers to the same conversation classifier, so any phrasing works. See
+            // FindAddressedAbsentCharacter.
             var absentTarget = await FindAddressedAbsentCharacter(input);
             if (absentTarget != null)
                 return await NarrateAbsence(absentTarget, context);
 
-            logger?.LogDebug("[CONVERSATION DEBUG] No addressed absent talker; returning null");
-            return null;
+            // #284: the player named no one, but if the utterance is plainly conversational speech
+            // (bare quoted "…", or an untargeted "say …"/greeting) and EXACTLY ONE talkable NPC is
+            // present, route it to them — the same outcome "blather, …" already produces. Requiring a
+            // single present talker means we never have to guess WHOM a nameless line addresses;
+            // requiring unambiguous speech (never a real command) means we never hijack puzzle input
+            // like Zork's "say treasure" (Zork has no talkable NPCs, so this branch can't fire there
+            // anyway). See TryRouteNamelessSpeech.
+            return await TryRouteNamelessSpeech(input, present, context);
         }
 
         // A talkable character is present. Routing the player's utterance to them relies on the AI
@@ -56,6 +63,156 @@ public class ConversationHandler(
 
         return await ProcessConversation(input, targetCharacter, context);
     }
+
+    /// <summary>
+    /// Routes plainly-conversational speech that names no one to the sole present talkable NPC
+    /// (#284). Two forms were falling through to the narrator instead of reaching the NPC in the
+    /// room: bare quoted speech (<c>"you are a fool"</c>) and an untargeted speak-aloud verb
+    /// (<c>say hello</c>). Both contain no name, so neither the present-name nor the absent-name
+    /// lookup matches them, and the input used to leak to the third-person narrator.
+    ///
+    /// The guards are deliberately conservative:
+    /// <list type="bullet">
+    /// <item>EXACTLY ONE talker must be present. With no name to disambiguate, a single present
+    /// talker is the only case where we know who is being addressed (Feinstein can hold Blather AND
+    /// the Ambassador at once; that ambiguous case falls through, as the issue allows).</item>
+    /// <item>The input must read as unambiguous speech, never a real command — so puzzle input such
+    /// as Zork's "say treasure" is never hijacked. Zork has no talkable NPCs, so the single-talker
+    /// gate already keeps this branch dormant there; the speech test is a second line of defense.</item>
+    /// <item>Routing relies on the NPC's AI conversation backend, so it honors the generation
+    /// kill-switch exactly like the present-name path, staying deterministic in NoGeneratedResponses
+    /// mode.</item>
+    /// </list>
+    /// Returns the NPC's reply, or null to fall through to normal parsing.
+    /// </summary>
+    private async Task<string?> TryRouteNamelessSpeech(string input, List<ICanBeTalkedTo> present, IContext context)
+    {
+        if (present.Count != 1)
+        {
+            logger?.LogDebug($"[CONVERSATION DEBUG] Nameless speech: {present.Count} present talker(s), not routing");
+            return null;
+        }
+
+        if (!TryExtractNamelessSpeech(input, out var speech))
+        {
+            logger?.LogDebug("[CONVERSATION DEBUG] Input is not nameless conversational speech; returning null");
+            return null;
+        }
+
+        if (generationClient.IsDisabled)
+        {
+            logger?.LogDebug("[CONVERSATION DEBUG] Conversations disabled via NoGeneratedResponses flag");
+            return null;
+        }
+
+        var target = present[0];
+        logger?.LogDebug($"[CONVERSATION DEBUG] Routing nameless speech '{speech}' to the sole present talker");
+        return await target.OnBeingTalkedTo(speech, context, generationClient);
+    }
+
+    /// <summary>
+    /// The "speak aloud" verbs that introduce untargeted speech ("say hello", "shout hi"). Derived
+    /// from the central <see cref="Verbs.SayVerbs" /> list minus "tell", which is a *named*-address
+    /// lead-in ("tell floyd …") handled by the name-based paths rather than untargeted speech.
+    /// </summary>
+    private static readonly string[] NamelessSpeechVerbs =
+        Verbs.SayVerbs.Where(verb => verb != "tell").ToArray();
+
+    /// <summary>
+    /// Casual one-shot greetings that count as conversation when addressed to no one in particular.
+    /// A bare greeting with a single present talker is routed to them ("hi" -> the NPC). Kept tight
+    /// to unambiguous greetings so an ordinary command is never mistaken for one.
+    /// </summary>
+    private static readonly string[] BareGreetings =
+        ["hello", "hi", "hey", "yo", "greetings", "howdy", "hiya", "hey there", "hello there", "hi there"];
+
+    /// <summary>
+    /// Prepositions that, right after a speak-aloud verb, name a *recipient* ("say TO guard …",
+    /// "whisper TO ghost …", "yell AT them", "speak WITH her"). That is directed address to a
+    /// specific (here, unknown or absent) party, not untargeted speech, so it must not be put into
+    /// the present NPC's mouth. When the recipient is the present NPC, the name-based path already
+    /// handled it and we never reach the nameless route.
+    /// </summary>
+    private static readonly string[] DirectedAddressPrepositions = ["to", "at", "with"];
+
+    /// <summary>
+    /// Recognizes the nameless conversational forms and yields the words to hand to the NPC: bare
+    /// quoted speech ("…"), an untargeted speak-aloud verb ("say …"), or a bare greeting ("hi").
+    /// Anything else (a real command) yields false so the input falls through to normal parsing.
+    /// </summary>
+    private static bool TryExtractNamelessSpeech(string input, out string speech)
+    {
+        speech = string.Empty;
+        var trimmed = input.Trim();
+        if (trimmed.Length == 0)
+            return false;
+
+        // 1. Bare quoted speech: "you are a fool" -> you are a fool. The surrounding double quotes
+        //    are a deterministic, collision-free signal — no game command is written inside quotes.
+        if (TryStripQuotedSpeech(trimmed, out var quoted))
+        {
+            speech = quoted;
+            return true;
+        }
+
+        // 2. Untargeted speak-aloud verb: "say hello" -> hello. ("say to floyd …" names a target and
+        //    is handled by the name paths, so by the time we get here no name was found.) Quotes
+        //    around the remainder are stripped too, so 'say "hello"' reaches the NPC as hello.
+        foreach (var verb in NamelessSpeechVerbs)
+        {
+            if (!StartsWithWholeWord(trimmed, verb))
+                continue;
+
+            var rest = trimmed[verb.Length..].Trim();
+
+            // "say to guard …" / "whisper to ghost …" / "yell at X" name a recipient — directed
+            // address to someone else, not untargeted speech — so leave it for normal parsing
+            // instead of routing it to the present NPC.
+            if (DirectedAddressPrepositions.Any(prep => StartsWithWholeWord(rest, prep)))
+                return false;
+
+            if (TryStripQuotedSpeech(rest, out var innerQuoted))
+                rest = innerQuoted;
+
+            if (rest.Length > 0)
+            {
+                speech = rest;
+                return true;
+            }
+        }
+
+        // 3. A bare greeting on its own ("hello", "hey there").
+        if (BareGreetings.Any(greeting => trimmed.Equals(greeting, StringComparison.OrdinalIgnoreCase)))
+        {
+            speech = trimmed;
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// If <paramref name="text" /> begins with a double quote, returns the text inside the quotes (a
+    /// trailing quote is optional, so an unterminated <c>"hello</c> reaches the NPC too). Only double
+    /// quotes — straight or smart — count; an apostrophe is too common in ordinary words to treat as
+    /// the start of speech. Returns false (with an empty result) when there is no opening quote or
+    /// nothing inside.
+    /// </summary>
+    private static bool TryStripQuotedSpeech(string text, out string inner)
+    {
+        inner = string.Empty;
+        if (text.Length == 0 || !IsDoubleQuote(text[0]))
+            return false;
+
+        var body = text[1..];
+        if (body.Length > 0 && IsDoubleQuote(body[^1]))
+            body = body[..^1];
+
+        inner = body.Trim();
+        return inner.Length > 0;
+    }
+
+    private static bool IsDoubleQuote(char c) => c is '"' or '“' or '”';
 
     /// <summary>
     /// Produces the response when the player addressed an absent known character. The narrator tells

--- a/GameEngine/ConversationHandler.cs
+++ b/GameEngine/ConversationHandler.cs
@@ -132,6 +132,11 @@ public class ConversationHandler(
     /// specific (here, unknown or absent) party, not untargeted speech, so it must not be put into
     /// the present NPC's mouth. When the recipient is the present NPC, the name-based path already
     /// handled it and we never reach the nameless route.
+    ///
+    /// Deliberately broad: it also rejects the rare untargeted phrasing that happens to begin with
+    /// one of these words ("say with feeling"). That only costs a harmless fall-through to normal
+    /// parsing, which is the safe failure for an ambiguous line — better than risking a directed
+    /// address being spoken at the wrong NPC.
     /// </summary>
     private static readonly string[] DirectedAddressPrepositions = ["to", "at", "with"];
 
@@ -163,7 +168,10 @@ public class ConversationHandler(
             if (!StartsWithWholeWord(trimmed, verb))
                 continue;
 
-            var rest = trimmed[verb.Length..].Trim();
+            // Strip a leading comma/punctuation after the verb ("say, hello" -> hello), mirroring
+            // TryStripDirectAddress. This also lets the directed-address guard below see the real
+            // first word, so "say, to guard …" is recognized as directed and not routed.
+            var rest = trimmed[verb.Length..].TrimStart(' ', ',', '.', '!', '?').Trim();
 
             // "say to guard …" / "whisper to ghost …" / "yell at X" name a recipient — directed
             // address to someone else, not untargeted speech — so leave it for normal parsing

--- a/Planetfall.Tests/NamelessConversationRoutingTests.cs
+++ b/Planetfall.Tests/NamelessConversationRoutingTests.cs
@@ -57,21 +57,23 @@ public class NamelessConversationRoutingTests : EngineTestsBase
     }
 
     [Test]
-    public async Task RealCommand_WithFloydPresent_IsNotHijacked()
+    public async Task NamelessNonSpeechCommand_WithSolePresentFloyd_IsNotRoutedToHim()
     {
-        // A real command that names no talker and is not speech must still be parsed normally even
-        // with Floyd present — the nameless route must not swallow ordinary play.
+        // A real command that names no talker and is not speech reaches the nameless-speech branch
+        // and must fall through to normal parsing — it must NOT be routed to the present NPC. Any
+        // routed input would surface this sentinel; ordinary parsing of an unrecognized noun won't.
         var target = GetTarget();
         StartHere<RobotShop>();
         var floyd = GetItem<Floyd>();
         floyd.IsOn = true;
-        // If routing fired, AskFloydAsync would be invoked; we never set it up, so any call would be
-        // an obvious mismatch. The assertion below is the real guard.
-        floyd.ChatWithFloyd = new Mock<IChatWithFloyd>(MockBehavior.Strict).Object;
+        var chat = new Mock<IChatWithFloyd>();
+        chat.Setup(s => s.AskFloydAsync(It.IsAny<string>()))
+            .ReturnsAsync(new CompanionResponse("FLOYD-WAS-WRONGLY-ENGAGED", null));
+        floyd.ChatWithFloyd = chat.Object;
 
-        var response = await target.GetResponse("examine floyd");
+        var response = await target.GetResponse("examine the workbench");
 
-        // Examining Floyd describes him; it does not produce a routed conversation reply.
-        response.Should().Contain("robot");
+        response.Should().NotContain("FLOYD-WAS-WRONGLY-ENGAGED");
+        chat.Verify(s => s.AskFloydAsync(It.IsAny<string>()), Times.Never);
     }
 }

--- a/Planetfall.Tests/NamelessConversationRoutingTests.cs
+++ b/Planetfall.Tests/NamelessConversationRoutingTests.cs
@@ -1,0 +1,77 @@
+using ChatLambda;
+using FluentAssertions;
+using Moq;
+using Planetfall.Item.Kalamontee.Mech.FloydPart;
+using Planetfall.Location.Kalamontee.Mech;
+
+namespace Planetfall.Tests;
+
+/// <summary>
+/// Regression tests for #284. When exactly one talkable NPC is present, conversational input that
+/// names no one — bare quoted speech (<c>"you are a fool"</c>) and an untargeted <c>say …</c> — must
+/// route to that NPC in their own voice instead of falling through to the third-person narrator.
+///
+/// Floyd is used as the present talker because his AI backend is injectable (<see cref="IChatWithFloyd"/>),
+/// so the routed call is deterministic. Blather and the Ambassador travel the same
+/// ConversationHandler path; that routing logic is proven game-agnostically in
+/// UnitTests/Engine/ConversationHandlerTests.cs. These tests pin the end-to-end GameEngine wiring.
+/// </summary>
+public class NamelessConversationRoutingTests : EngineTestsBase
+{
+    private static Mock<IChatWithFloyd> FloydAnswering(string expectedPrompt, string reply)
+    {
+        var mock = new Mock<IChatWithFloyd>();
+        mock.Setup(s => s.AskFloydAsync(expectedPrompt))
+            .ReturnsAsync(new CompanionResponse(reply, null));
+        return mock;
+    }
+
+    [Test]
+    public async Task QuotedSpeech_WithSolePresentFloyd_RoutesToFloydInFirstPerson()
+    {
+        var target = GetTarget();
+        StartHere<RobotShop>(); // RobotShop.Init places Floyd here, so he is the sole present talker.
+        var floyd = GetItem<Floyd>();
+        floyd.IsOn = true;
+        floyd.ChatWithFloyd = FloydAnswering("you are a fool", "\"That not nice thing to say!\" Floyd pouts.").Object;
+
+        // The quotes are stripped; the words inside reach Floyd.
+        var response = await target.GetResponse("\"you are a fool\"");
+
+        response.Should().Contain("That not nice thing to say!");
+    }
+
+    [Test]
+    public async Task UntargetedSay_WithSolePresentFloyd_RoutesToFloydInFirstPerson()
+    {
+        var target = GetTarget();
+        StartHere<RobotShop>();
+        var floyd = GetItem<Floyd>();
+        floyd.IsOn = true;
+        floyd.ChatWithFloyd = FloydAnswering("hello", "\"Oh boy! Hello hello hello!\" Floyd burbles.").Object;
+
+        // The "say" verb is stripped; "hello" reaches Floyd.
+        var response = await target.GetResponse("say hello");
+
+        response.Should().Contain("Hello hello hello!");
+    }
+
+    [Test]
+    public async Task RealCommand_WithFloydPresent_IsNotHijacked()
+    {
+        // A real command that names no talker and is not speech must still be parsed normally even
+        // with Floyd present — the nameless route must not swallow ordinary play.
+        var target = GetTarget();
+        StartHere<RobotShop>();
+        var floyd = GetItem<Floyd>();
+        floyd.IsOn = true;
+        // If routing fired, AskFloydAsync would be invoked; we never set it up, so any call would be
+        // an obvious mismatch. The assertion below is the real guard.
+        floyd.ChatWithFloyd = new Mock<IChatWithFloyd>(MockBehavior.Strict).Object;
+
+        var response = await target.GetResponse("examine floyd");
+
+        // Examining Floyd describes him; it does not produce a routed conversation reply.
+        response.Should().Contain("robot");
+    }
+}

--- a/UnitTests/Engine/ConversationHandlerTests.cs
+++ b/UnitTests/Engine/ConversationHandlerTests.cs
@@ -643,4 +643,178 @@ public class ConversationHandlerTests
         result.Should().Be("gizmo talked");
         result.Should().NotContain("isn't here");
     }
+
+    // --- #284: nameless conversational forms route to the SOLE present talker ------------------
+    // Bare quoted speech ("you are a fool") and an untargeted "say …"/greeting name no one, so the
+    // present-name and absent-name lookups both miss them. When exactly one talkable NPC is in the
+    // room they should reach that NPC anyway, the same outcome "blather, …" already produces.
+
+    /// <summary>Builds a handler with a single present mock talker that echoes a sentinel reply.</summary>
+    private static (ConversationHandler handler, ZorkIContext context, Mock<ICanBeTalkedTo> talker)
+        SinglePresentTalker(Mock<IParseConversation> mockParser, IGenerationClient client, string noun = "floyd")
+    {
+        var talker = new Mock<ICanBeTalkedTo>();
+        talker.As<IItem>().Setup(i => i.NounsForMatching).Returns(new[] { noun });
+        talker.Setup(t => t.OnBeingTalkedTo(It.IsAny<string>(), It.IsAny<IContext>(), It.IsAny<IGenerationClient>()))
+              .ReturnsAsync("npc replied");
+
+        var handler = new ConversationHandler(null, mockParser.Object, client);
+        var context = new ZorkIContext();
+        context.Items.Add((IItem)talker.Object);
+        return (handler, context, talker);
+    }
+
+    [TestCase("\"you are a fool\"", "you are a fool", TestName = "QuotedSpeech")]
+    [TestCase("  \"you are a fool\"  ", "you are a fool", TestName = "QuotedSpeechWithSurroundingWhitespace")]
+    [TestCase("“you are a fool”", "you are a fool", TestName = "SmartQuotedSpeech")]
+    [TestCase("\"you are a fool", "you are a fool", TestName = "UnterminatedQuotedSpeech")]
+    [TestCase("say hello", "hello", TestName = "UntargetedSay")]
+    [TestCase("shout get out", "get out", TestName = "UntargetedShout")]
+    [TestCase("say \"hello\"", "hello", TestName = "UntargetedSayQuoted")]
+    [TestCase("hello", "hello", TestName = "BareGreeting")]
+    public async Task CheckForConversation_NamelessSpeech_SinglePresentTalker_Routes(string input, string expectedSpoken)
+    {
+        // Arrange - the classifier is never consulted for the nameless path, so leaving it unset is
+        // deliberate (a call would throw on the strict-by-default mock).
+        var mockParser = new Mock<IParseConversation>();
+        var (handler, context, talker) = SinglePresentTalker(mockParser, Mock.Of<IGenerationClient>());
+
+        // Act
+        var result = await handler.CheckForConversation(input, context);
+
+        // Assert - the words inside the quotes / after the verb are what reaches the NPC.
+        result.Should().Be("npc replied");
+        talker.Verify(t => t.OnBeingTalkedTo(expectedSpoken, context, It.IsAny<IGenerationClient>()), Times.Once);
+        mockParser.Verify(p => p.ParseAsync(It.IsAny<string>()), Times.Never);
+    }
+
+    [Test]
+    public async Task CheckForConversation_NamelessSpeech_NoPresentTalker_ReturnsNull()
+    {
+        // Arrange - quoted speech but nobody is here and the roster is empty: must fall through.
+        var mockParser = new Mock<IParseConversation>();
+        var handler = new ConversationHandler(null, mockParser.Object, Mock.Of<IGenerationClient>());
+        var context = new ZorkIContext();
+
+        // Act
+        var result = await handler.CheckForConversation("\"you are a fool\"", context);
+
+        // Assert
+        result.Should().BeNull();
+        mockParser.Verify(p => p.ParseAsync(It.IsAny<string>()), Times.Never);
+    }
+
+    [Test]
+    public async Task CheckForConversation_NamelessSpeech_MultiplePresentTalkers_DoesNotRoute()
+    {
+        // Arrange - two talkers present and no name in the input: we cannot know who is addressed,
+        // so the ambiguous case falls through rather than guessing (issue allows this).
+        var mockParser = new Mock<IParseConversation>();
+
+        var floyd = new Mock<ICanBeTalkedTo>();
+        floyd.As<IItem>().Setup(i => i.NounsForMatching).Returns(new[] { "floyd" });
+        floyd.Setup(t => t.OnBeingTalkedTo(It.IsAny<string>(), It.IsAny<IContext>(), It.IsAny<IGenerationClient>()))
+             .ReturnsAsync("floyd replied");
+        var captain = new Mock<ICanBeTalkedTo>();
+        captain.As<IItem>().Setup(i => i.NounsForMatching).Returns(new[] { "captain" });
+        captain.Setup(t => t.OnBeingTalkedTo(It.IsAny<string>(), It.IsAny<IContext>(), It.IsAny<IGenerationClient>()))
+               .ReturnsAsync("captain replied");
+
+        var handler = new ConversationHandler(null, mockParser.Object, Mock.Of<IGenerationClient>());
+        var context = new ZorkIContext();
+        context.Items.Add((IItem)floyd.Object);
+        context.Items.Add((IItem)captain.Object);
+
+        // Act
+        var result = await handler.CheckForConversation("\"you are a fool\"", context);
+
+        // Assert - neither was engaged.
+        result.Should().BeNull();
+        floyd.Verify(t => t.OnBeingTalkedTo(It.IsAny<string>(), It.IsAny<IContext>(), It.IsAny<IGenerationClient>()),
+            Times.Never);
+        captain.Verify(t => t.OnBeingTalkedTo(It.IsAny<string>(), It.IsAny<IContext>(), It.IsAny<IGenerationClient>()),
+            Times.Never);
+    }
+
+    [TestCase("say to guard let me pass", TestName = "SayToOtherParty")]
+    [TestCase("whisper to ghost that we should leave", TestName = "WhisperToOtherParty")]
+    [TestCase("yell at the guard to halt", TestName = "YellAtOtherParty")]
+    [TestCase("speak with the wizard", TestName = "SpeakWithOtherParty")]
+    public async Task CheckForConversation_DirectedAtAnotherParty_SinglePresentTalker_DoesNotHijack(string input)
+    {
+        // Arrange - "<speak verb> to/at/with <someone>" names a recipient (here unknown/absent), so
+        // it must not be put in the present NPC's mouth — it falls through to normal parsing.
+        var mockParser = new Mock<IParseConversation>();
+        var (handler, context, talker) = SinglePresentTalker(mockParser, Mock.Of<IGenerationClient>());
+
+        // Act
+        var result = await handler.CheckForConversation(input, context);
+
+        // Assert
+        result.Should().BeNull();
+        talker.Verify(
+            t => t.OnBeingTalkedTo(It.IsAny<string>(), It.IsAny<IContext>(), It.IsAny<IGenerationClient>()),
+            Times.Never);
+    }
+
+    [TestCase("examine the wall", TestName = "Examine")]
+    [TestCase("go north", TestName = "Move")]
+    [TestCase("take the lamp", TestName = "Take")]
+    [TestCase("open door", TestName = "Open")]
+    public async Task CheckForConversation_RealCommand_SinglePresentTalker_DoesNotHijack(string input)
+    {
+        // Arrange - a real command that names no talker and is not speech must NOT be swallowed by
+        // the present NPC; it has to fall through to normal parsing.
+        var mockParser = new Mock<IParseConversation>();
+        var (handler, context, talker) = SinglePresentTalker(mockParser, Mock.Of<IGenerationClient>());
+
+        // Act
+        var result = await handler.CheckForConversation(input, context);
+
+        // Assert
+        result.Should().BeNull();
+        talker.Verify(
+            t => t.OnBeingTalkedTo(It.IsAny<string>(), It.IsAny<IContext>(), It.IsAny<IGenerationClient>()),
+            Times.Never);
+        mockParser.Verify(p => p.ParseAsync(It.IsAny<string>()), Times.Never);
+    }
+
+    [Test]
+    public async Task CheckForConversation_NamelessSpeech_SinglePresentTalker_NotRoutedWhenDisabled()
+    {
+        // Arrange - routing relies on the NPC's AI backend, so the kill-switch must suppress it just
+        // like the present-name path, keeping NoGeneratedResponses mode deterministic.
+        var mockParser = new Mock<IParseConversation>();
+        var mockClient = new Mock<IGenerationClient>();
+        mockClient.Setup(c => c.IsDisabled).Returns(true);
+        var (handler, context, talker) = SinglePresentTalker(mockParser, mockClient.Object);
+
+        // Act
+        var result = await handler.CheckForConversation("\"you are a fool\"", context);
+
+        // Assert
+        result.Should().BeNull();
+        talker.Verify(
+            t => t.OnBeingTalkedTo(It.IsAny<string>(), It.IsAny<IContext>(), It.IsAny<IGenerationClient>()),
+            Times.Never);
+    }
+
+    [Test]
+    public async Task CheckForConversation_NamedAddressToPresentTalker_StillUsesNamedPath()
+    {
+        // Arrange - guard against the nameless branch shadowing the existing named path: when the
+        // talker IS named, the classifier-driven named path runs (and the name is stripped), exactly
+        // as before #284.
+        var mockParser = new Mock<IParseConversation>();
+        mockParser.Setup(p => p.ParseAsync(It.IsAny<string>())).ReturnsAsync((true, "you are a fool"));
+        var (handler, context, talker) = SinglePresentTalker(mockParser, Mock.Of<IGenerationClient>());
+
+        // Act
+        var result = await handler.CheckForConversation("floyd, you are a fool", context);
+
+        // Assert
+        result.Should().Be("npc replied");
+        talker.Verify(t => t.OnBeingTalkedTo("you are a fool", context, It.IsAny<IGenerationClient>()), Times.Once);
+        mockParser.Verify(p => p.ParseAsync("floyd, you are a fool"), Times.Once);
+    }
 }

--- a/UnitTests/Engine/ConversationHandlerTests.cs
+++ b/UnitTests/Engine/ConversationHandlerTests.cs
@@ -669,6 +669,7 @@ public class ConversationHandlerTests
     [TestCase("“you are a fool”", "you are a fool", TestName = "SmartQuotedSpeech")]
     [TestCase("\"you are a fool", "you are a fool", TestName = "UnterminatedQuotedSpeech")]
     [TestCase("say hello", "hello", TestName = "UntargetedSay")]
+    [TestCase("say, hello", "hello", TestName = "UntargetedSayWithComma")]
     [TestCase("shout get out", "get out", TestName = "UntargetedShout")]
     [TestCase("say \"hello\"", "hello", TestName = "UntargetedSayQuoted")]
     [TestCase("hello", "hello", TestName = "BareGreeting")]
@@ -737,6 +738,7 @@ public class ConversationHandlerTests
     }
 
     [TestCase("say to guard let me pass", TestName = "SayToOtherParty")]
+    [TestCase("say, to guard let me pass", TestName = "SayCommaToOtherParty")]
     [TestCase("whisper to ghost that we should leave", TestName = "WhisperToOtherParty")]
     [TestCase("yell at the guard to halt", TestName = "YellAtOtherParty")]
     [TestCase("speak with the wizard", TestName = "SpeakWithOtherParty")]

--- a/ZorkOne.Tests/Places/TempleMagicWordTests.cs
+++ b/ZorkOne.Tests/Places/TempleMagicWordTests.cs
@@ -1,0 +1,40 @@
+using FluentAssertions;
+using GameEngine;
+using ZorkOne.Location;
+using ZorkOne.Location.MazeLocation;
+
+namespace ZorkOne.Tests.Places;
+
+/// <summary>
+/// Regression guard for #284. The fix routes nameless "say …" speech to a present talkable NPC, but
+/// it is presence-gated and Zork has no talkable NPCs, so the engine's "say &lt;magic word&gt;"
+/// teleport puzzles must keep working untouched. These pin the two Temple/Treasure-Room teleports
+/// (the LoudRoom "echo" puzzle is covered by LoudRoomTests).
+/// </summary>
+[TestFixture]
+public class TempleMagicWordTests : EngineTestsBase
+{
+    [Test]
+    public async Task SayTreasure_InTemple_TeleportsToTreasureRoom()
+    {
+        var target = GetTarget();
+        StartHere<Temple>();
+
+        var response = await target.GetResponse("say treasure");
+
+        target.Context.CurrentLocation.Should().BeOfType<TreasureRoom>();
+        response.Should().Contain("Treasure Room");
+    }
+
+    [Test]
+    public async Task SayTemple_InTreasureRoom_TeleportsToTemple()
+    {
+        var target = GetTarget();
+        StartHere<TreasureRoom>();
+
+        var response = await target.GetResponse("say temple");
+
+        target.Context.CurrentLocation.Should().BeOfType<Temple>();
+        response.Should().Contain("Temple");
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #284. When a talkable NPC (Floyd, Blather, or the Ambassador) is **present in the room**, conversational input that **doesn't name them** was falling through to the third-person narrator instead of the NPC responding in their own voice.

`ConversationHandler` finds its target by matching a name/synonym in the input, so the two **nameless** forms had no target and leaked to the narrator:

| Input | Before | After |
|---|---|---|
| `"you are a fool"` | narrator quip about the room | NPC reacts in first person |
| `say hello` | narrator-mediated 3rd-person flavor | NPC responds to the greeting |

This closes the gap left by #182 (present **named**-address) and #264 (absent **named**-address) — both require the NPC's name in the input.

## What changed

In `CheckForConversation`, after the present-name and absent-name lookups both miss, a deterministic **nameless-speech** branch runs (`TryRouteNamelessSpeech`). When **exactly one** talkable NPC is present and the utterance is plainly conversational — bare quoted speech `"…"`, an untargeted speak-aloud verb (`say …`/`shout …`), or a bare greeting — it strips the quotes/verb and routes the words to that NPC via `OnBeingTalkedTo`.

Conservative by construction:
- **Single-present-talker gate** — with no name we can't disambiguate, so the multi-talker case (Feinstein can hold Blather *and* the Ambassador) falls through, as the issue allows.
- **`<verb> to/at/with X`** (`say to guard`, `whisper to ghost`, `yell at X`) names a *recipient* — directed address, not untargeted speech — and is left for normal parsing, never put in the present NPC's mouth.
- **Honors the generation kill-switch**, so `NoGeneratedResponses` mode stays deterministic.
- **Presence-gated**, so Zork's magic-word puzzles (`say treasure` / `say temple` / LoudRoom echo) are untouched — Zork has zero `ICanBeTalkedTo` NPCs, so the branch can never fire there. Proven with tests, not assumed.

## Testing

All three exercising suites pass (`UnitTests` 911, `ZorkOne.Tests` 1253, `Planetfall.Tests` 2303).

- **`UnitTests/Engine/ConversationHandlerTests.cs`** — quoted/say/greeting routing, single vs. multiple present talkers, real-command and directed-address non-hijack, kill-switch suppression, and the named path still winning. (TDD: the 8 routing cases were confirmed red before the fix.)
- **`Planetfall.Tests/NamelessConversationRoutingTests.cs`** — end-to-end GameEngine wiring with Floyd present (mocked `IChatWithFloyd`) for quoted speech and untargeted `say`.
- **`ZorkOne.Tests/Places/TempleMagicWordTests.cs`** — must-not-regress for the `say treasure` / `say temple` teleports.

Found via AdventureBreaker conversation playtesting (AB-026). Refs #182, #264, #286.

🤖 Generated with [Claude Code](https://claude.com/claude-code)