### PR TITLE
Planetfall: add EMPTY and SHAKE handlers to the survival kit (#219)

### DIFF
--- a/Planetfall.Tests/HungerSystemTests.cs
+++ b/Planetfall.Tests/HungerSystemTests.cs
@@ -545,6 +545,67 @@ public class HungerSystemTests : EngineTestsBase
 
     #endregion
 
+    #region Survival Kit SHAKE Tests
+
+    [Test]
+    public async Task ShakeKit_WhenOpenWithGoo_FlingsAndDestroysAllGoo()
+    {
+        var target = GetTarget();
+        StartHere<Kitchen>();
+
+        PreventHungerAdvancement(target.Context);
+
+        var kit = GetItem<SurvivalKit>();
+        kit.IsOpen = true;
+        target.Context.ItemPlacedHere(kit);
+
+        var response = await target.GetResponse("shake kit");
+        response.Should().Contain("Colored goo flies all over everything. Yechh!");
+
+        // All three goo blobs are destroyed - the player's only food source is gone.
+        kit.Items.Should().NotContain(item => item is RedGoo);
+        kit.Items.Should().NotContain(item => item is BrownGoo);
+        kit.Items.Should().NotContain(item => item is GreenGoo);
+    }
+
+    [Test]
+    public async Task ShakeKit_WhenClosedWithGoo_StillDestroysAllGoo()
+    {
+        var target = GetTarget();
+        StartHere<Kitchen>();
+
+        PreventHungerAdvancement(target.Context);
+
+        // The original V-SHAKE only checks whether the goo is IN the kit, not OPENBIT,
+        // so shaking a closed kit destroys the goo just the same.
+        var kit = GetItem<SurvivalKit>();
+        kit.IsOpen = false;
+        target.Context.ItemPlacedHere(kit);
+
+        var response = await target.GetResponse("shake kit");
+        response.Should().Contain("Colored goo flies all over everything. Yechh!");
+        kit.Items.OfType<GooBase>().Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task ShakeKit_WhenAlreadyEmpty_DoesNotShowGooMessage()
+    {
+        var target = GetTarget();
+        StartHere<Kitchen>();
+
+        PreventHungerAdvancement(target.Context);
+
+        var kit = GetItem<SurvivalKit>();
+        kit.IsOpen = true;
+        kit.Items.Clear(); // No goo left to fling
+        target.Context.ItemPlacedHere(kit);
+
+        var response = await target.GetResponse("shake kit");
+        response.Should().NotContain("Colored goo flies all over everything");
+    }
+
+    #endregion
+
     #region Integration Tests
 
     [Test]

--- a/Planetfall.Tests/HungerSystemTests.cs
+++ b/Planetfall.Tests/HungerSystemTests.cs
@@ -604,6 +604,27 @@ public class HungerSystemTests : EngineTestsBase
         response.Should().NotContain("Colored goo flies all over everything");
     }
 
+    [Test]
+    public async Task SurvivalKit_OpenAndClose_StillWorkThroughOverrideFallback()
+    {
+        var target = GetTarget();
+        StartHere<Kitchen>();
+
+        PreventHungerAdvancement(target.Context);
+
+        var kit = GetItem<SurvivalKit>();
+        kit.IsOpen = false;
+        target.Context.ItemPlacedHere(kit);
+
+        // The EMPTY/SHAKE override must not swallow unrelated verbs - open and close
+        // still fall through to OpenAndCloseContainerBase.
+        await target.GetResponse("open kit");
+        kit.IsOpen.Should().BeTrue();
+
+        await target.GetResponse("close kit");
+        kit.IsOpen.Should().BeFalse();
+    }
+
     #endregion
 
     #region Integration Tests

--- a/Planetfall.Tests/HungerSystemTests.cs
+++ b/Planetfall.Tests/HungerSystemTests.cs
@@ -486,6 +486,65 @@ public class HungerSystemTests : EngineTestsBase
 
     #endregion
 
+    #region Survival Kit EMPTY Tests
+
+    [Test]
+    public async Task EmptyKit_WhenClosed_SaysKitIsClosed()
+    {
+        var target = GetTarget();
+        StartHere<Kitchen>();
+
+        PreventHungerAdvancement(target.Context);
+
+        var kit = GetItem<SurvivalKit>();
+        kit.IsOpen = false;
+        target.Context.ItemPlacedHere(kit);
+
+        var response = await target.GetResponse("empty kit");
+        response.Should().Contain("The kit is closed!");
+    }
+
+    [Test]
+    public async Task EmptyKit_WhenOpenWithGoo_SaysGooSticksAndKeepsGoo()
+    {
+        var target = GetTarget();
+        StartHere<Kitchen>();
+
+        PreventHungerAdvancement(target.Context);
+
+        var kit = GetItem<SurvivalKit>();
+        kit.IsOpen = true;
+        target.Context.ItemPlacedHere(kit);
+
+        var response = await target.GetResponse("empty kit");
+        response.Should().Contain("sticks to the inside of the kit");
+
+        // EMPTY is a misdirect - it never removes the goo.
+        kit.Items.Should().HaveCount(3);
+        kit.Items.Should().Contain(item => item is RedGoo);
+        kit.Items.Should().Contain(item => item is BrownGoo);
+        kit.Items.Should().Contain(item => item is GreenGoo);
+    }
+
+    [Test]
+    public async Task EmptyKit_WhenOpenAndEmpty_SaysNothingInIt()
+    {
+        var target = GetTarget();
+        StartHere<Kitchen>();
+
+        PreventHungerAdvancement(target.Context);
+
+        var kit = GetItem<SurvivalKit>();
+        kit.IsOpen = true;
+        kit.Items.Clear(); // No goo left in the kit
+        target.Context.ItemPlacedHere(kit);
+
+        var response = await target.GetResponse("empty kit");
+        response.Should().Contain("There's nothing in the survival kit");
+    }
+
+    #endregion
+
     #region Integration Tests
 
     [Test]

--- a/Planetfall/Item/Feinstein/SurvivalKit.cs
+++ b/Planetfall/Item/Feinstein/SurvivalKit.cs
@@ -1,3 +1,4 @@
+using Model.AIGeneration;
 using Utilities;
 
 namespace Planetfall.Item.Feinstein;
@@ -39,5 +40,26 @@ public class SurvivalKit : OpenAndCloseContainerBase, ICanBeTakenAndDropped, ICa
     public override string GenericDescription(ILocation? currentLocation)
     {
         return !IsOpen ? "A survival kit" : $"A survival kit\n{ItemListDescription("survival kit", null)}";
+    }
+
+    public override async Task<InteractionResult?> RespondToSimpleInteraction(SimpleIntent action, IContext context,
+        IGenerationClient client, IItemProcessorFactory itemProcessorFactory)
+    {
+        // The original FOOD-KIT-F routine gives state-specific flavor for EMPTY, and it is a
+        // pure misdirect - EMPTY never removes the goo. Closed -> "The kit is closed!"; open with
+        // goo -> the goo-sticks message; open and empty -> the default V-EMPTY message.
+        // See planetfall-source/globals.zil:1022-1029 and verbs.zil:1718.
+        if (action.Match(["empty"], NounsForMatching))
+        {
+            if (!IsOpen)
+                return new PositiveInteractionResult("The kit is closed! ");
+
+            return new PositiveInteractionResult(Items.Any()
+                ? "The goo, being gooey, sticks to the inside of the kit. You would probably " +
+                  "have to shake the kit to get the goo out. "
+                : "There's nothing in the survival kit. ");
+        }
+
+        return await base.RespondToSimpleInteraction(action, context, client, itemProcessorFactory);
     }
 }

--- a/Planetfall/Item/Feinstein/SurvivalKit.cs
+++ b/Planetfall/Item/Feinstein/SurvivalKit.cs
@@ -60,6 +60,23 @@ public class SurvivalKit : OpenAndCloseContainerBase, ICanBeTakenAndDropped, ICa
                 : "There's nothing in the survival kit. ");
         }
 
+        // V-SHAKE special-cases the food kit: if any goo is inside, shaking flings it out and
+        // destroys whatever goo it holds - the player's only food source. The original checks only
+        // whether the goo is IN the kit (not OPENBIT), so a closed kit is emptied just the same.
+        // With no goo left, fall through to the default shake handling. See
+        // planetfall-source/verbs.zil:1167.
+        if (action.Match(["shake"], NounsForMatching))
+        {
+            var goo = Items.OfType<GooBase>().ToList();
+            if (goo.Count > 0)
+            {
+                foreach (var blob in goo)
+                    RemoveItem(blob);
+
+                return new PositiveInteractionResult("Colored goo flies all over everything. Yechh! ");
+            }
+        }
+
         return await base.RespondToSimpleInteraction(action, context, client, itemProcessorFactory);
     }
 }

--- a/UnitTests/TestParser.cs
+++ b/UnitTests/TestParser.cs
@@ -27,7 +27,7 @@ public class TestParser : IntentParser
             "deactivate", "type", "key", "punch", "push", "pull", "burn", "set", "search", "empty", "wear",
             "drink", "use", "count", "touch", "read", "turn", "wave", "move", "ring", "activate", "search",
             "smell", "turn on", "turn off", "throw", "light", "rub", "kiss", "wind", "kick", "deflate",
-            "lower", "raise", "get", "inflate", "leave", "unlock", "lock", "climb", "extend", "lift"
+            "lower", "raise", "get", "inflate", "leave", "unlock", "lock", "climb", "extend", "lift", "shake"
         ];
 
         _allNouns = Repository.GetNouns(gameName);


### PR DESCRIPTION
## Summary

Fixes #219 by restoring the two missing food-kit (`FOOD-KIT`) verbs from the original Planetfall — `EMPTY` and `SHAKE`. Both were special-cased in the ZIL but absent from the C# port, so each fell through to the generic fallback.

## EMPTY (state-dependent flavor — removes nothing)

`empty kit` now mirrors the original three-state behavior (`SurvivalKit.RespondToSimpleInteraction`):

| `empty kit` state | Response |
|---|---|
| closed | `The kit is closed!` |
| open, contains goo | `The goo, being gooey, sticks to the inside of the kit. You would probably have to shake the kit to get the goo out.` |
| open, empty | `There's nothing in the survival kit.` |

`EMPTY` is pure flavor — the middle message is a misdirect and **nothing is ever removed**. Matches `FOOD-KIT-F` (`planetfall-source/globals.zil:1022-1029`) and the default `V-EMPTY` message (`verbs.zil:1718`).

## SHAKE (has gameplay consequences — destroys the goo)

`shake kit` now mirrors `V-SHAKE`:

- **Kit contains goo** → all the goo blobs (`RedGoo`, `BrownGoo`, `GreenGoo`) are destroyed and it prints `Colored goo flies all over everything. Yechh!` — permanently removing the player's only food source.
- **Kit already empty** → falls through to default shake handling.

Faithfulness note: the original `V-SHAKE` checks only whether the goo is `IN?` the kit — *not* `OPENBIT` — so shaking a **closed** kit destroys the goo just the same (there's a test pinning this down). This doesn't contradict `EMPTY`, which refuses on a closed kit because `FOOD-KIT-F` checks `OPENBIT`; each verb mirrors its own original routine. Ground truth: `planetfall-source/verbs.zil:1167`.

`shake` was added to the test parser's verb list (it's already a recognized verb in production, e.g. ZorkOne's `EntranceToHades`); no production parser change was needed.

## TDD

Six deterministic tests added to `Planetfall.Tests/HungerSystemTests.cs` (new `Survival Kit EMPTY Tests` and `Survival Kit SHAKE Tests` regions) — one per EMPTY state and one per SHAKE state. Each behavior-changing test was confirmed to fail before its fix and pass after.

- ✅ `Planetfall.Tests`: 2333 passed, 0 failed
- ✅ `UnitTests`: 934 passed (verifies the shared `TestParser` change is regression-free)
- ✅ `ZorkOne.Tests`: 1260 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)