### PR TITLE
Don't split multi-sentence input on periods inside quoted speech (#292)

### DIFF
--- a/GameEngine/ConversationHandler.cs
+++ b/GameEngine/ConversationHandler.cs
@@ -220,6 +220,9 @@ public class ConversationHandler(
         return inner.Length > 0;
     }
 
+    // SentenceSplitter.IsDoubleQuote is a deliberate copy of this set so the two stages agree on what
+    // counts as quoted speech (the splitter must not break a line inside the quotes this method strips).
+    // Keep the recognized quote characters in sync across both.
     private static bool IsDoubleQuote(char c) => c is '"' or '“' or '”';
 
     /// <summary>

--- a/GameEngine/ConversationHandler.cs
+++ b/GameEngine/ConversationHandler.cs
@@ -209,21 +209,16 @@ public class ConversationHandler(
     private static bool TryStripQuotedSpeech(string text, out string inner)
     {
         inner = string.Empty;
-        if (text.Length == 0 || !IsDoubleQuote(text[0]))
+        if (text.Length == 0 || !SpeechQuotes.IsDoubleQuote(text[0]))
             return false;
 
         var body = text[1..];
-        if (body.Length > 0 && IsDoubleQuote(body[^1]))
+        if (body.Length > 0 && SpeechQuotes.IsDoubleQuote(body[^1]))
             body = body[..^1];
 
         inner = body.Trim();
         return inner.Length > 0;
     }
-
-    // SentenceSplitter.IsDoubleQuote is a deliberate copy of this set so the two stages agree on what
-    // counts as quoted speech (the splitter must not break a line inside the quotes this method strips).
-    // Keep the recognized quote characters in sync across both.
-    private static bool IsDoubleQuote(char c) => c is '"' or '“' or '”';
 
     /// <summary>
     /// Produces the response when the player addressed an absent known character. The narrator tells

--- a/GameEngine/SentenceSplitter.cs
+++ b/GameEngine/SentenceSplitter.cs
@@ -29,8 +29,11 @@ public static class SentenceSplitter
         if (string.IsNullOrWhiteSpace(input))
             return new List<string>();
 
-        // First, split on periods
-        var parts = input.Split('.');
+        // First, split on periods — but NOT on periods inside quoted speech. A period inside "…" is
+        // dialogue punctuation (`"hello. I love you"`), not a command delimiter; splitting there would
+        // tear one utterance into two turns and strip the opening quote off the remainder, which then
+        // leaks to the narrator instead of reaching the present NPC (issue #292, re-opening #284).
+        var parts = SplitOnUnquotedPeriods(input);
         var sentences = new List<string>();
 
         for (var i = 0; i < parts.Length; i++)
@@ -81,4 +84,44 @@ public static class SentenceSplitter
         // If no sentences were created, return empty list (not the original input)
         return sentences;
     }
+
+    /// <summary>
+    ///     Splits on top-level periods only — periods that are NOT inside a double-quote span are
+    ///     treated as command delimiters; periods inside <c>"…"</c> are kept as part of the segment.
+    ///     The returned segments mirror what <c>input.Split('.')</c> would produce (including empty
+    ///     segments for leading/trailing/consecutive periods), so the abbreviation and single-letter
+    ///     handling downstream is unchanged. An unterminated quote keeps the rest of the input in one
+    ///     segment, matching how ConversationHandler.TryStripQuotedSpeech tolerates a missing close.
+    /// </summary>
+    private static string[] SplitOnUnquotedPeriods(string input)
+    {
+        var parts = new List<string>();
+        var current = new StringBuilder();
+        var inQuotes = false;
+
+        foreach (var c in input)
+        {
+            if (IsDoubleQuote(c))
+            {
+                // Any double quote (straight or smart) toggles whether we are inside speech.
+                inQuotes = !inQuotes;
+                current.Append(c);
+            }
+            else if (c == '.' && !inQuotes)
+            {
+                parts.Add(current.ToString());
+                current.Clear();
+            }
+            else
+            {
+                current.Append(c);
+            }
+        }
+
+        parts.Add(current.ToString());
+        return parts.ToArray();
+    }
+
+    // Mirrors ConversationHandler.IsDoubleQuote so the two stages agree on what counts as speech.
+    private static bool IsDoubleQuote(char c) => c is '"' or '“' or '”';
 }

--- a/GameEngine/SentenceSplitter.cs
+++ b/GameEngine/SentenceSplitter.cs
@@ -123,5 +123,6 @@ public static class SentenceSplitter
     }
 
     // Mirrors ConversationHandler.IsDoubleQuote so the two stages agree on what counts as speech.
+    // Keep the recognized quote characters in sync with that copy.
     private static bool IsDoubleQuote(char c) => c is '"' or '“' or '”';
 }

--- a/GameEngine/SentenceSplitter.cs
+++ b/GameEngine/SentenceSplitter.cs
@@ -101,7 +101,7 @@ public static class SentenceSplitter
 
         foreach (var c in input)
         {
-            if (IsDoubleQuote(c))
+            if (SpeechQuotes.IsDoubleQuote(c))
             {
                 // Any double quote (straight or smart) toggles whether we are inside speech.
                 inQuotes = !inQuotes;
@@ -121,8 +121,4 @@ public static class SentenceSplitter
         parts.Add(current.ToString());
         return parts.ToArray();
     }
-
-    // Mirrors ConversationHandler.IsDoubleQuote so the two stages agree on what counts as speech.
-    // Keep the recognized quote characters in sync with that copy.
-    private static bool IsDoubleQuote(char c) => c is '"' or '“' or '”';
 }

--- a/GameEngine/SpeechQuotes.cs
+++ b/GameEngine/SpeechQuotes.cs
@@ -1,0 +1,14 @@
+namespace GameEngine;
+
+/// <summary>
+///     Recognizes the double-quote characters that delimit spoken dialogue in player input — straight
+///     (<c>"</c>) and both smart quotes (<c>“</c>/<c>”</c>). Shared by <see cref="SentenceSplitter" />
+///     (which must not split a command on a period inside quoted speech) and
+///     <see cref="ConversationHandler" /> (which strips these quotes when routing speech to an NPC), so
+///     the two stages always agree on exactly what counts as quoted speech — previously each kept its
+///     own copy that had to be edited in lockstep by convention.
+/// </summary>
+internal static class SpeechQuotes
+{
+    public static bool IsDoubleQuote(char c) => c is '"' or '“' or '”';
+}

--- a/UnitTests/SentenceSplitterTests.cs
+++ b/UnitTests/SentenceSplitterTests.cs
@@ -350,4 +350,15 @@ public class SentenceSplitterTests
         result[0].Should().Be("east");
         result[1].Should().Be("\"hello. I love you\"");
     }
+
+    [Test]
+    public void Split_MixedStraightAndSmartQuotePair_DoesNotSplit()
+    {
+        // The toggle treats any double quote as open-or-close, so a mismatched pair (straight open,
+        // smart close) still brackets the speech and protects the inner period.
+        var result = SentenceSplitter.Split("\"hello. I love you”");
+
+        result.Should().HaveCount(1);
+        result[0].Should().Be("\"hello. I love you”");
+    }
 }

--- a/UnitTests/SentenceSplitterTests.cs
+++ b/UnitTests/SentenceSplitterTests.cs
@@ -286,4 +286,68 @@ public class SentenceSplitterTests
         result[0].Should().Be("no");
         result[1].Should().Be("take lamp");
     }
+
+    // --- #292: a period INSIDE quoted speech is dialogue punctuation, not a command delimiter ----
+    // Quoted speech ("…") routes to the present NPC via ConversationHandler.TryStripQuotedSpeech,
+    // but that runs AFTER this splitter. If the splitter breaks "hello. I love you" on the inner
+    // period, only the first fragment keeps its opening quote and reaches the NPC; the rest leaks to
+    // the third-person narrator (re-opening the #284 bug). So periods inside quotes must not split.
+
+    [Test]
+    public void Split_PeriodInsideQuotes_DoesNotSplit()
+    {
+        var result = SentenceSplitter.Split("\"hello. I love you\"");
+
+        result.Should().HaveCount(1);
+        result[0].Should().Be("\"hello. I love you\"");
+    }
+
+    [Test]
+    public void Split_MultiplePeriodsInsideQuotes_DoesNotSplit()
+    {
+        var result = SentenceSplitter.Split("\"stop. drop. roll.\"");
+
+        result.Should().HaveCount(1);
+        result[0].Should().Be("\"stop. drop. roll.\"");
+    }
+
+    [Test]
+    public void Split_UnterminatedQuote_DoesNotSplitOnInnerPeriod()
+    {
+        // TryStripQuotedSpeech accepts an unterminated quote, so the splitter must keep it whole too.
+        var result = SentenceSplitter.Split("\"hello. I love you");
+
+        result.Should().HaveCount(1);
+        result[0].Should().Be("\"hello. I love you");
+    }
+
+    [Test]
+    public void Split_PeriodInsideSmartQuotes_DoesNotSplit()
+    {
+        var result = SentenceSplitter.Split("“hello. I love you”");
+
+        result.Should().HaveCount(1);
+        result[0].Should().Be("“hello. I love you”");
+    }
+
+    [Test]
+    public void Split_QuotedClauseThenChainedCommand_SplitsAtOutsidePeriod()
+    {
+        // The period inside the quotes is protected; the period after the closing quote still splits.
+        var result = SentenceSplitter.Split("say \"hello. there\". north");
+
+        result.Should().HaveCount(2);
+        result[0].Should().Be("say \"hello. there\"");
+        result[1].Should().Be("north");
+    }
+
+    [Test]
+    public void Split_CommandThenQuotedSpeech_SplitsAtOutsidePeriodOnly()
+    {
+        var result = SentenceSplitter.Split("east. \"hello. I love you\"");
+
+        result.Should().HaveCount(2);
+        result[0].Should().Be("east");
+        result[1].Should().Be("\"hello. I love you\"");
+    }
 }


### PR DESCRIPTION
Fixes #292.

## Problem

`SentenceSplitter` split on **every** period via `input.Split('.')`, with no awareness of quotes. A single quoted utterance containing a sentence-ending period — e.g. `"hello. I love you"` — was torn into two game turns before `ConversationHandler` ever saw it:

- Fragment 1 `"hello` keeps its opening quote → reaches the present `ICanBeTalkedTo` NPC via `TryStripQuotedSpeech` ✅
- Fragment 2 `I love you"` loses its opening quote → not quoted, not a `say`-verb, not a greeting → falls through to the **third-person narrator** ❌

That re-opened the exact #284 nameless-speech leak. It also made the NPC's `ITurnBasedActor.Act()` fire **twice** from one line, so Blather escalated to the brig at double speed (the "return to your post" + "drags you to the brig" double-beat from a single input).

## Fix

Make the split quote-aware (`GameEngine/SentenceSplitter.cs`): a period inside a double-quote span (straight `"` or smart `“`/`”`, mirroring `ConversationHandler.IsDoubleQuote`) is dialogue punctuation and does **not** split. Periods outside quotes still split exactly as before, so command chaining (`take lamp. go north`) and the existing abbreviation / single-letter-direction handling are untouched. An unterminated quote keeps the remainder in one segment, matching `TryStripQuotedSpeech`'s leniency.

The helper returns segments shaped exactly like `input.Split('.')` (including empty segments for leading/trailing/consecutive periods), so no downstream logic changed.

## TDD

Per the repo's mandatory TDD rule:

1. **Red** — added 6 cases to `UnitTests/SentenceSplitterTests.cs` (period inside quotes, multiple inner periods, unterminated quote, smart quotes, quoted-clause-then-chained-command, command-then-quoted-speech). Confirmed all 6 failed for the right reason (`Expected 1 item, found 2: {"\"hello", "I love you\""}`).
2. **Green** — applied the quote-aware split; all 6 pass.
3. **No regressions** — ran each suite separately:
   - `UnitTests`: 930 passed
   - `ZorkOne.Tests`: 1260 passed (the `say treasure` / `say temple` / LoudRoom puzzle paths intact)
   - `Planetfall.Tests`: 2303 passed (Blather/Floyd conversation routing intact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017xk6ZpUaZtdfYXeY4tNfMm

---
_Generated by [Claude Code](https://claude.ai/code/session_017xk6ZpUaZtdfYXeY4tNfMm)_