### PR TITLE
fix(#222): replace flat 33% Floyd card reveal with day-keyed escalating odds

### DIFF
--- a/Planetfall.Tests/FloydTests.cs
+++ b/Planetfall.Tests/FloydTests.cs
@@ -325,7 +325,7 @@ public class FloydTests : EngineTestsBase
         Take<KitchenAccessCard>();
         GetItem<Floyd>().IsOn = true;
         GetItem<Floyd>().CurrentLocation = GetLocation<MessHall>();
-        GetItem<Floyd>().Chooser = Mock.Of<IRandomChooser>(r => r.RollDiceSuccess(3) == true);
+        target.Context.Day = 4; // Day > 3 guarantees reveal without dice
 
         var response = await target.GetResponse("slide kitchen access card through slot");
 
@@ -341,7 +341,6 @@ public class FloydTests : EngineTestsBase
         Take<KitchenAccessCard>();
         GetItem<Floyd>().IsOn = true;
         GetItem<Floyd>().CurrentLocation = GetLocation<Library>();
-        GetItem<Floyd>().Chooser = Mock.Of<IRandomChooser>(r => r.RollDiceSuccess(3) == true);
 
         var response = await target.GetResponse("slide kitchen access card through slot");
 
@@ -356,7 +355,10 @@ public class FloydTests : EngineTestsBase
         Take<KitchenAccessCard>();
         GetItem<Floyd>().IsOn = true;
         GetItem<Floyd>().CurrentLocation = GetLocation<MessHall>();
-        GetItem<Floyd>().Chooser = Mock.Of<IRandomChooser>(r => r.RollDiceSuccess(3) == false);
+        var mockChooser = new Mock<IRandomChooser>();
+        mockChooser.Setup(r => r.RollDice(100)).Returns(100); // > 8 threshold, fails on Day 2
+        GetItem<Floyd>().Chooser = mockChooser.Object;
+        target.Context.Day = 2;
 
         var response = await target.GetResponse("slide kitchen access card through slot");
 
@@ -370,7 +372,6 @@ public class FloydTests : EngineTestsBase
         StartHere<MessHall>();
         Take<KitchenAccessCard>();
         GetItem<Floyd>().CurrentLocation = GetLocation<MessHall>();
-        GetItem<Floyd>().Chooser = Mock.Of<IRandomChooser>(r => r.RollDiceSuccess(3) == true);
 
         var response = await target.GetResponse("slide kitchen access card through slot");
 
@@ -386,11 +387,105 @@ public class FloydTests : EngineTestsBase
         GetItem<Floyd>().IsOn = true;
         GetItem<Floyd>().Items.Clear();
         GetItem<Floyd>().CurrentLocation = GetLocation<MessHall>();
-        GetItem<Floyd>().Chooser = Mock.Of<IRandomChooser>(r => r.RollDiceSuccess(3) == true);
+        target.Context.Day = 4; // Would guarantee reveal if Floyd still had the card
 
         var response = await target.GetResponse("slide kitchen access card through slot");
 
         response.Should().NotContain("Floyd claps his hands with excitement");
+    }
+
+    [Test]
+    public async Task DoesFloydOfferCard_Day1_NeverReveals()
+    {
+        var target = GetTarget();
+        StartHere<MessHall>();
+        Take<KitchenAccessCard>();
+        var floyd = GetItem<Floyd>();
+        floyd.IsOn = true;
+        floyd.CurrentLocation = GetLocation<MessHall>();
+        // Force dice to always "succeed" so only the Day 1 gate can block the reveal
+        var mockChooser = new Mock<IRandomChooser>();
+        mockChooser.Setup(r => r.RollDiceSuccess(3)).Returns(true);
+        mockChooser.Setup(r => r.RollDice(100)).Returns(1);
+        floyd.Chooser = mockChooser.Object;
+        target.Context.Day = 1;
+
+        var response = await target.GetResponse("slide kitchen access card through slot");
+
+        response.Should().NotContain("Floyd claps his hands with excitement");
+    }
+
+    [Test]
+    public async Task DoesFloydOfferCard_Day2_RevealsWhenRollSucceeds()
+    {
+        var target = GetTarget();
+        StartHere<MessHall>();
+        Take<KitchenAccessCard>();
+        var floyd = GetItem<Floyd>();
+        floyd.IsOn = true;
+        floyd.CurrentLocation = GetLocation<MessHall>();
+        var mockChooser = new Mock<IRandomChooser>();
+        mockChooser.Setup(r => r.RollDice(100)).Returns(8); // <= 8 threshold, succeeds on Day 2
+        floyd.Chooser = mockChooser.Object;
+        target.Context.Day = 2;
+
+        var response = await target.GetResponse("slide kitchen access card through slot");
+
+        response.Should().Contain("Floyd claps his hands with excitement");
+    }
+
+    [Test]
+    public async Task DoesFloydOfferCard_Day4_AlwaysReveals()
+    {
+        var target = GetTarget();
+        StartHere<MessHall>();
+        Take<KitchenAccessCard>();
+        var floyd = GetItem<Floyd>();
+        floyd.IsOn = true;
+        floyd.CurrentLocation = GetLocation<MessHall>();
+        // Mock would fail on Day 2/3, but Day 4 is unconditional
+        var mockChooser = new Mock<IRandomChooser>();
+        mockChooser.Setup(r => r.RollDice(100)).Returns(100);
+        floyd.Chooser = mockChooser.Object;
+        target.Context.Day = 4;
+
+        var response = await target.GetResponse("slide kitchen access card through slot");
+
+        response.Should().Contain("Floyd claps his hands with excitement");
+        GetItem<Floyd>().ItemBeingHeld.Should().BeOfType<LowerElevatorAccessCard>();
+    }
+
+    [Test]
+    public async Task DoesFloydOfferCard_AlreadyRevealed_NoDoubleReveal()
+    {
+        var target = GetTarget();
+        StartHere<MessHall>();
+        Take<KitchenAccessCard>();
+        var floyd = GetItem<Floyd>();
+        floyd.IsOn = true;
+        floyd.CurrentLocation = GetLocation<MessHall>();
+        floyd.LowerElevatorCardRevealed = true; // Card was already shown once
+        target.Context.Day = 4; // Would guarantee reveal if not already revealed
+
+        var response = await target.GetResponse("slide kitchen access card through slot");
+
+        response.Should().NotContain("Floyd claps his hands with excitement");
+    }
+
+    [Test]
+    public async Task DoesFloydOfferCard_RevealSetsFlag()
+    {
+        var target = GetTarget();
+        StartHere<MessHall>();
+        Take<KitchenAccessCard>();
+        var floyd = GetItem<Floyd>();
+        floyd.IsOn = true;
+        floyd.CurrentLocation = GetLocation<MessHall>();
+        target.Context.Day = 4;
+
+        await target.GetResponse("slide kitchen access card through slot");
+
+        GetItem<Floyd>().LowerElevatorCardRevealed.Should().BeTrue();
     }
 
     [Test]

--- a/Planetfall/Item/Kalamontee/Mech/FloydPart/Floyd.cs
+++ b/Planetfall/Item/Kalamontee/Mech/FloydPart/Floyd.cs
@@ -53,6 +53,12 @@ public class Floyd : QuirkyCompanion, IAmANamedPerson, ICanHoldItems, ICanBeGive
 
     [UsedImplicitly] public bool HasGottenTheFromitzBoard { get; set; }
 
+    /// <summary>
+    /// Set when Floyd has shown the player his lower-elevator card (CARD-REVEALED in ZIL).
+    /// Also set by the SHOW handler (issue #203) so both paths share a single revealed flag.
+    /// </summary>
+    [UsedImplicitly] public bool LowerElevatorCardRevealed { get; set; }
+
     // When you initially turn on Floyd, nothing happens for 3 turns. This delay never happens
     // again if you turn him on/off another time.
     [UsedImplicitly] public int TurnOnCountdown { get; set; } = 3;

--- a/Planetfall/Item/Kalamontee/Mech/FloydPart/FloydInventoryManager.cs
+++ b/Planetfall/Item/Kalamontee/Mech/FloydPart/FloydInventoryManager.cs
@@ -4,6 +4,15 @@ namespace Planetfall.Item.Kalamontee.Mech.FloydPart;
 
 public class FloydInventoryManager(Floyd floyd)
 {
+    // Per-day reveal percentages derived from FLOYD-REVEAL-CARD-F (planetfall-source/globals.zil:1440-1468).
+    // The ZIL uses INTERNAL-MOVES < 5000 for a within-day split (5%/10% on Day 2, 20%/40% on Day 3).
+    // We approximate each day with its average chance; the Day gate and post-Day-3 guarantee are exact.
+    private static readonly Dictionary<int, int> RevealPercentByDay = new()
+    {
+        { 2, 8 },   // ~5% first half, ~10% second half → average ≈ 8%
+        { 3, 30 },  // ~20% first half, ~40% second half → average ≈ 30%
+    };
+
     public InteractionResult OfferItem(IItem item, IContext context)
     {
         if (floyd.ItemBeingHeld != null)
@@ -37,11 +46,19 @@ public class FloydInventoryManager(Floyd floyd)
 
     public string? OfferLowerElevatorCard(IContext context, IRandomChooser chooser)
     {
-        if (!IsFloydInRoom(context) ||
-            !floyd.IsOn ||
-            !floyd.Items.Any() ||
-            !chooser.RollDiceSuccess(3))
+        if (!IsFloydInRoom(context) || !floyd.IsOn || !floyd.Items.Any() || floyd.LowerElevatorCardRevealed)
             return null;
+
+        // Day 1: never reveal (globals.zil:1440-1468 has no clause matching Day 1)
+        var day = context is PlanetfallContext pfContext ? pfContext.Day : 1;
+        if (day <= 1)
+            return null;
+
+        // Day > 3: always reveal; Day 2-3: escalating percent chance
+        if (RevealPercentByDay.TryGetValue(day, out var percent) && chooser.RollDice(100) > percent)
+            return null;
+
+        floyd.LowerElevatorCardRevealed = true;
 
         // Remove it from inside, put it in his hand.
         floyd.Items.Clear();


### PR DESCRIPTION
## Summary

Fixes #222. Floyd's lower-elevator card reveal used a flat ~33% chance per qualifying turn with no day gate. Per `FLOYD-REVEAL-CARD-F` (`planetfall-source/globals.zil:1440-1468`), the correct behaviour is:

| Day | Chance |
|-----|--------|
| 1   | Never  |
| 2   | ~8% (ZIL: 5% first half / 10% second half; approximated as average) |
| 3   | ~30% (ZIL: 20% first half / 40% second half; approximated as average) |
| > 3 | Always (guaranteed) |

- **`FloydInventoryManager.OfferLowerElevatorCard`** — replaced `RollDiceSuccess(3)` with a day-keyed percent table driving `RollDice(100)`, exact for the Day 1 gate and post-Day-3 guarantee, approximate for the within-day INTERNAL-MOVES split.
- **`Floyd.LowerElevatorCardRevealed`** — new serialised flag (CARD-REVEALED analog); set when the daemon fires; guards against double-reveal. Issue #203's SHOW handler can set the same flag so both paths share a single revealed state.
- **`FloydTests`** — updated existing tests to match the new day/dice API; added proving tests for Day 1 (never), Day 2 boundary roll, Day 4 (guaranteed), already-revealed guard, and flag-set-on-reveal.

## Test plan

- [ ] `DoesFloydOfferCard_Day1_NeverReveals` — red against old code (flat 33% revealed on Day 1), green after fix
- [ ] `DoesFloydOfferCard_Day2_RevealsWhenRollSucceeds` — red against old code (dice mock prevented reveal), green after fix
- [ ] `DoesFloydOfferCard_Day4_AlwaysReveals` — red against old code (dice mock `Returns(100)` prevented reveal), green after fix
- [ ] `DoesFloydOfferCard_AlreadyRevealed_NoDoubleReveal` — tests shared flag; red before `LowerElevatorCardRevealed` existed
- [ ] `DoesFloydOfferCard_RevealSetsFlag` — confirms the flag is set on reveal
- [ ] All existing `DoesFloydOfferCard_*` tests updated and passing
- [ ] `dotnet test Planetfall.Tests` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CCG7t8FHYEbP3w38s9uYfh

---
_Generated by [Claude Code](https://claude.ai/code/session_01CCG7t8FHYEbP3w38s9uYfh)_