### PR TITLE
Planetfall: SHAKE survival kit flings out and destroys the goo

### DIFF
--- a/Planetfall.Tests/HungerSystemTests.cs
+++ b/Planetfall.Tests/HungerSystemTests.cs
@@ -545,6 +545,67 @@ public class HungerSystemTests : EngineTestsBase
 
     #endregion
 
+    #region Survival Kit SHAKE Tests
+
+    [Test]
+    public async Task ShakeKit_WhenOpenWithGoo_FlingsAndDestroysAllGoo()
+    {
+        var target = GetTarget();
+        StartHere<Kitchen>();
+
+        PreventHungerAdvancement(target.Context);
+
+        var kit = GetItem<SurvivalKit>();
+        kit.IsOpen = true;
+        target.Context.ItemPlacedHere(kit);
+
+        var response = await target.GetResponse("shake kit");
+        response.Should().Contain("Colored goo flies all over everything. Yechh!");
+
+        // All three goo blobs are destroyed - the player's only food source is gone.
+        kit.Items.Should().NotContain(item => item is RedGoo);
+        kit.Items.Should().NotContain(item => item is BrownGoo);
+        kit.Items.Should().NotContain(item => item is GreenGoo);
+    }
+
+    [Test]
+    public async Task ShakeKit_WhenClosedWithGoo_StillDestroysAllGoo()
+    {
+        var target = GetTarget();
+        StartHere<Kitchen>();
+
+        PreventHungerAdvancement(target.Context);
+
+        // The original V-SHAKE only checks whether the goo is IN the kit, not OPENBIT,
+        // so shaking a closed kit destroys the goo just the same.
+        var kit = GetItem<SurvivalKit>();
+        kit.IsOpen = false;
+        target.Context.ItemPlacedHere(kit);
+
+        var response = await target.GetResponse("shake kit");
+        response.Should().Contain("Colored goo flies all over everything. Yechh!");
+        kit.Items.OfType<GooBase>().Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task ShakeKit_WhenAlreadyEmpty_DoesNotShowGooMessage()
+    {
+        var target = GetTarget();
+        StartHere<Kitchen>();
+
+        PreventHungerAdvancement(target.Context);
+
+        var kit = GetItem<SurvivalKit>();
+        kit.IsOpen = true;
+        kit.Items.Clear(); // No goo left to fling
+        target.Context.ItemPlacedHere(kit);
+
+        var response = await target.GetResponse("shake kit");
+        response.Should().NotContain("Colored goo flies all over everything");
+    }
+
+    #endregion
+
     #region Integration Tests
 
     [Test]

--- a/Planetfall/Item/Feinstein/SurvivalKit.cs
+++ b/Planetfall/Item/Feinstein/SurvivalKit.cs
@@ -60,6 +60,23 @@ public class SurvivalKit : OpenAndCloseContainerBase, ICanBeTakenAndDropped, ICa
                 : "There's nothing in the survival kit. ");
         }
 
+        // V-SHAKE special-cases the food kit: if any goo is inside, shaking flings it out and
+        // destroys all three blobs - the player's only food source. The original checks only
+        // whether the goo is IN the kit (not OPENBIT), so a closed kit is destroyed just the same.
+        // With no goo left, fall through to the default shake handling. See
+        // planetfall-source/verbs.zil:1167.
+        if (action.Match(["shake"], NounsForMatching))
+        {
+            var goo = Items.OfType<GooBase>().ToList();
+            if (goo.Count > 0)
+            {
+                foreach (var blob in goo)
+                    RemoveItem(blob);
+
+                return new PositiveInteractionResult("Colored goo flies all over everything. Yechh! ");
+            }
+        }
+
         return await base.RespondToSimpleInteraction(action, context, client, itemProcessorFactory);
     }
 }

--- a/UnitTests/TestParser.cs
+++ b/UnitTests/TestParser.cs
@@ -27,7 +27,7 @@ public class TestParser : IntentParser
             "deactivate", "type", "key", "punch", "push", "pull", "burn", "set", "search", "empty", "wear",
             "drink", "use", "count", "touch", "read", "turn", "wave", "move", "ring", "activate", "search",
             "smell", "turn on", "turn off", "throw", "light", "rub", "kiss", "wind", "kick", "deflate",
-            "lower", "raise", "get", "inflate", "leave", "unlock", "lock", "climb", "extend", "lift"
+            "lower", "raise", "get", "inflate", "leave", "unlock", "lock", "climb", "extend", "lift", "shake"
         ];
 
         _allNouns = Repository.GetNouns(gameName);


### PR DESCRIPTION
## Summary

Follow-up to #290 / issue #219. That issue called out `SHAKE` as the second missing food-kit verb, and explicitly recommended doing it as a **separate** change so the two behaviors (`EMPTY` vs `SHAKE`) don't contradict each other. This PR implements `SHAKE`.

`V-SHAKE` special-cases the food kit in the original, but the C# port had no shake handling, so `shake kit` fell through to the generic fallback. This restores the original behavior in `SurvivalKit.RespondToSimpleInteraction`:

- **Kit contains goo** → all three blobs (`RedGoo`, `BrownGoo`, `GreenGoo`) are destroyed and the game prints `Colored goo flies all over everything. Yechh!`. Unlike `EMPTY`, this has real gameplay consequences — it permanently removes the player's only food source.
- **Kit already empty** → falls through to the default shake handling (no goo message).

### Faithfulness to the original

The original `V-SHAKE` checks only whether the goo is `IN?` the kit — it does **not** check `OPENBIT` — so shaking a *closed* kit destroys the goo just the same. The implementation matches that (no open/closed guard), and there's a test asserting it. Ground truth: `planetfall-source/verbs.zil:1167` (quoted in #219).

This does not contradict the `EMPTY` behavior from #290: `EMPTY` refuses on a closed kit ("The kit is closed!") because `FOOD-KIT-F` checks `OPENBIT`, whereas `SHAKE` does not — each verb mirrors its own original routine.

## Parsing

`shake` was not in the test parser's verb list, so `shake kit` previously parsed to a `NullIntent`. Added `shake` to `TestParser._verbs`. `shake` is already a recognized verb in production (e.g. ZorkOne's `EntranceToHades` matches it), so no production parser change is needed.

## TDD

Three deterministic tests added to `Planetfall.Tests/HungerSystemTests.cs` (new `Survival Kit SHAKE Tests` region): open+goo (destroys all three), closed+goo (destroys all three), already-empty (no goo message). The goo-destroying tests were confirmed to fail before the fix and pass after.

- ✅ `Planetfall.Tests`: 2309 passed, 0 failed
- ✅ `UnitTests`: 924 passed (verifies the shared `TestParser` change is regression-free)
- ✅ `ZorkOne.Tests`: 1260 passed

## Note on stacking

This PR is **stacked on #290** (base branch `claude/quirky-wright-e67b9c`) because both changes touch `SurvivalKit.RespondToSimpleInteraction`; stacking keeps this diff to just the `SHAKE` additions and avoids a merge conflict. Once #290 merges, GitHub will retarget this PR to `main` (or I can retarget it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TtTNRhFrW59niZiiABwsxg)_