### PR TITLE
Fix #297: guard rift ladder handler on ladder state, not command text

### DIFF
--- a/Planetfall.Tests/AdminCorridorTests.cs
+++ b/Planetfall.Tests/AdminCorridorTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using Planetfall.Item.Kalamontee;
+using Planetfall.Location.Kalamontee;
 using Planetfall.Location.Kalamontee.Admin;
 
 namespace Planetfall.Tests;
@@ -94,5 +95,89 @@ public class AdminCorridorTests : EngineTestsBase
 
         response.Should().Contain("too wide to jump");
         Context.CurrentLocation.Should().BeOfType<AdminCorridor>();
+    }
+
+    // Issue #297, Divergence A: once the ladder has plunged into the rift it is out of scope
+    // entirely (not carried, not in any room, not spanning). The handler used to match on the
+    // command text alone and still narrate destroying a ladder that no longer exists.
+    [Test]
+    public async Task PlaceLadderAcrossRift_LadderAlreadyLostFromGame_DoesNotNarrateLoss()
+    {
+        var target = GetTarget();
+        StartHere<AdminCorridor>();
+        var ladder = GetItem<Ladder>();
+        ladder.IsExtended = false;
+        ladder.IsAcrossRift = false;
+        ladder.CurrentLocation = null;
+
+        var response = await target.GetResponse("place ladder across rift");
+
+        response.Should().NotContain("lost forever");
+        response.Should().NotContain("plunges into the rift");
+        // The command had no effect: the ladder is still gone and certainly didn't span the rift.
+        ladder.CurrentLocation.Should().BeNull();
+        ladder.IsAcrossRift.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task PutLadderAcrossRift_LadderAlreadyLostFromGame_DoesNotNarrateLoss()
+    {
+        var target = GetTarget();
+        StartHere<AdminCorridor>();
+        var ladder = GetItem<Ladder>();
+        ladder.IsExtended = false;
+        ladder.IsAcrossRift = false;
+        ladder.CurrentLocation = null;
+
+        var response = await target.GetResponse("put ladder across rift");
+
+        response.Should().NotContain("lost forever");
+        response.Should().NotContain("plunges into the rift");
+        // The command had no effect: the ladder is still gone and certainly didn't span the rift.
+        ladder.CurrentLocation.Should().BeNull();
+        ladder.IsAcrossRift.Should().BeFalse();
+    }
+
+    // Issue #297 follow-up: the ladder must actually be in scope (here or carried) to bridge the
+    // rift. Left in another room, the handler must not silently span the rift with an absent ladder.
+    [Test]
+    public async Task PlaceLadderAcrossRift_LadderInAnotherRoom_DoesNotSpanRift()
+    {
+        var target = GetTarget();
+        StartHere<AdminCorridor>();
+        var ladder = GetItem<Ladder>();
+        ladder.IsExtended = true;
+        ladder.IsAcrossRift = false;
+        // The (extended) ladder is sitting in a different room — not at the rift, not carried.
+        GetLocation<StorageWest>().ItemPlacedHere(ladder);
+
+        var response = await target.GetResponse("place ladder across rift");
+
+        response.Should().NotContain("swings out across the rift");
+        response.Should().NotContain("spanning the precipice");
+        ladder.IsAcrossRift.Should().BeFalse();
+        // The ladder stays put; it was never moved to the rift.
+        ladder.CurrentLocation.Should().Be(GetLocation<StorageWest>());
+    }
+
+    // Issue #297, Divergence B: placing the ladder when it already spans the rift used to
+    // re-narrate success and add the same instance to AdminCorridorNorth.Items a second time.
+    // The original prints "The ladder already spans the rift." and does nothing.
+    [Test]
+    public async Task PlaceLadderAcrossRift_AlreadySpanning_SaysAlreadySpansAndDoesNotDuplicate()
+    {
+        var target = GetTarget();
+        StartHere<AdminCorridor>();
+        var ladder = GetItem<Ladder>();
+        ladder.IsExtended = true;
+        ladder.IsAcrossRift = true;
+        // The real spanning state: present in the corridor and mirrored into the north room.
+        GetLocation<AdminCorridor>().ItemPlacedHere(ladder);
+        GetLocation<AdminCorridorNorth>().Items.Add(ladder);
+
+        var response = await target.GetResponse("place ladder across rift");
+
+        response.Should().Contain("already spans the rift");
+        GetLocation<AdminCorridorNorth>().Items.Count(i => i is Ladder).Should().Be(1);
     }
 }

--- a/Planetfall/Location/Kalamontee/Admin/AdminCorridor.cs
+++ b/Planetfall/Location/Kalamontee/Admin/AdminCorridor.cs
@@ -57,6 +57,23 @@ internal class AdminCorridor : RiftLocationBase
 
         if (match)
         {
+            // action.Match keys off the player's words, not the ladder's presence/state. Guard on
+            // the ladder's actual state, mirroring the ZIL LADDER-FCN ordering
+            // (planetfall-source/compone.zil:697-712), or we narrate against a ladder that
+            // isn't here (issue #297).
+
+            // Already spans the rift — checked first, as the ZIL does (LADDER-FLAG branch). Don't
+            // re-narrate success or re-add the instance (Divergence B).
+            if (ladder.IsAcrossRift)
+                return new PositiveInteractionResult("The ladder already spans the rift. ");
+
+            // The ladder must actually be in scope to bridge the rift: here in the corridor or
+            // carried. If it plunged into the rift (Divergence A) or was simply left in another
+            // room, the original's parser can't resolve "ladder" to run its action routine at all,
+            // so let normal routing answer instead of narrating against a ladder that isn't here.
+            if (!ladder.IsHereButNotInInventory(context) && !context.HasItem<Ladder>())
+                return await base.RespondToMultiNounInteraction(action, context);
+
             if (!ladder.IsExtended)
             {
                 ladder.CurrentLocation?.Items.Remove(ladder);
@@ -66,7 +83,7 @@ internal class AdminCorridor : RiftLocationBase
             }
 
             ladder.IsAcrossRift = true;
-            // Like the Zork kitchen window, the ladder exists in both places now. 
+            // Like the Zork kitchen window, the ladder exists in both places now.
             GetLocation<AdminCorridorNorth>().Items.Add(ladder);
             return new PositiveInteractionResult(
                 "The ladder swings out across the rift and comes to rest on the far edge, spanning the precipice. ");

--- a/UnitTests/IntentMappings/base-mappings.json
+++ b/UnitTests/IntentMappings/base-mappings.json
@@ -86,6 +86,7 @@
     { "inputs": ["throw sword at mirror"], "verb": "throw", "nounOne": "sword", "nounTwo": "mirror", "preposition": "at", "originalInput": "throw sword at mirror" },
     { "inputs": ["throw garlic at mirror"], "verb": "throw", "nounOne": "garlic", "nounTwo": "mirror", "preposition": "at", "originalInput": "throw garlic at mirror" },
     { "inputs": ["place ladder across rift"], "verb": "place", "nounOne": "ladder", "nounTwo": "rift", "preposition": "across", "originalInput": "place ladder across rift" },
+    { "inputs": ["put ladder across rift"], "verb": "put", "nounOne": "ladder", "nounTwo": "rift", "preposition": "across", "originalInput": "put ladder across rift" },
     { "inputs": ["put flask under spout"], "verb": "put", "nounOne": "flask", "nounTwo": "spout", "preposition": "under", "originalInput": "put flask under spout" },
     { "inputs": ["put trident in boat"], "verb": "put", "nounOne": "trident", "nounTwo": "boat", "preposition": "in", "originalInput": "put trident in boat" },
     { "inputs": ["put bar in boat"], "verb": "put", "nounOne": "bar", "nounTwo": "boat", "preposition": "in", "originalInput": "put bar in boat" },


### PR DESCRIPTION
## Summary

Fixes #297 — the Admin Corridor rift-bridging handler (`AdminCorridor.RespondToMultiNounInteraction`) matched on the **command text** (verb + ladder-noun + rift-noun + preposition) and never checked the ladder's actual state, producing two user-visible divergences from the original Planetfall.

- **Divergence A** — with no ladder anywhere in the game (already plunged into the rift), `place`/`put ladder across rift` still narrated *"...plunges into the rift and is lost forever."* — destroying a ladder the player doesn't have.
- **Divergence B** — with the ladder already spanning (`IsAcrossRift == true`), placing it again re-ran the success branch, re-narrated *"...spanning the precipice."* and called `GetLocation<AdminCorridorNorth>().Items.Add(ladder)` a second time (duplicate instance / state-integrity leak). The original prints *"The ladder already spans the rift."* and does nothing.

## Root cause

`action.Match(...)` keys off the player's words, not the ladder's presence. So the handler kept firing after the ladder was gone (`CurrentLocation == null`, `!IsExtended` still true → re-narrated loss) and had no `IsAcrossRift` short-circuit (repeat placement re-narrated success and re-added the ladder).

## Fix

Guard on the ladder's real state, mirroring the ZIL `LADDER-FCN` ordering (`planetfall-source/compone.zil:697-712`):

1. **`IsAcrossRift` checked first** (the `LADDER-FLAG` branch) → *"The ladder already spans the rift."*, no duplicate add (B).
2. The ladder must actually be **in scope** (in the corridor or carried) to bridge the rift; otherwise fall through to normal routing (A). In the original, once the ladder is `<REMOVE>`d the parser can't resolve "ladder" to run its action routine at all.
3. Then the original too-short/loss and extend/span branches, unchanged.

The in-scope check also fixes a latent case surfaced in review: a ladder **left in another room** previously spanned the rift with an absent ladder.

## Test plan (TDD — red before, green after)

In `Planetfall.Tests/AdminCorridorTests.cs`:
- `PlaceLadderAcrossRift_LadderAlreadyLostFromGame_DoesNotNarrateLoss` (A, place)
- `PutLadderAcrossRift_LadderAlreadyLostFromGame_DoesNotNarrateLoss` (A, put)
- `PlaceLadderAcrossRift_AlreadySpanning_SaysAlreadySpansAndDoesNotDuplicate` (B — asserts the message **and** exactly one ladder in `AdminCorridorNorth.Items`)
- `PlaceLadderAcrossRift_LadderInAnotherRoom_DoesNotSpanRift` (in-scope guard)

Adds a `put ladder across rift` entry to `UnitTests/IntentMappings/base-mappings.json` so the test parser routes it as a `MultiNounIntent` (mirroring the production `IntentParser`).

All suites pass: **Planetfall.Tests 2331**, **UnitTests 934** (1 pre-existing skip). No file or logical overlap with #296 (sibling room `AdminCorridorSouth`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)