### PR TITLE
Fix #87: enforce "you would drown" barrier on Reservoir North shore

### DIFF
--- a/ZorkOne.Tests/Places/ReservoirTests.cs
+++ b/ZorkOne.Tests/Places/ReservoirTests.cs
@@ -1,0 +1,152 @@
+using FluentAssertions;
+using GameEngine;
+using Model.Location;
+using ZorkOne.Item;
+using ZorkOne.Location;
+
+namespace ZorkOne.Tests.Places;
+
+[TestFixture]
+public class ReservoirTests : EngineTestsBase
+{
+    // Issue #87: the two reservoir shores must be symmetric. In the original game both shores only
+    // let you step onto the middle RESERVOIR room when the water is low:
+    //   zork1/1dungeon.zil:1769  RESERVOIR-SOUTH  (NORTH TO RESERVOIR IF LOW-TIDE ELSE "You would drown.")
+    //   zork1/1dungeon.zil:1796  RESERVOIR-NORTH  (SOUTH TO RESERVOIR IF LOW-TIDE ELSE "You would drown.")
+    // The shores never kill you; they gate the crossing with the "You would drown." barrier. Only the
+    // middle RESERVOIR room drowns you (when the fill daemon fires while you stand there). The bug was
+    // that ReservoirNorth's south exit was unconditional, so a full reservoir let you walk in and die.
+
+    private GameEngine<ZorkI, ZorkIContext> GetLitTarget<TLocation>() where TLocation : class, ILocation, new()
+    {
+        var target = GetTarget();
+        target.Context.CurrentLocation = Repository.GetLocation<TLocation>();
+        target.Context.Take(Repository.GetItem<Lantern>());
+        Repository.GetItem<Lantern>().IsOn = true;
+        return target;
+    }
+
+    [Test]
+    public async Task ReservoirNorth_GoSouth_WhenFull_IsBlockedAndDoesNotDrown()
+    {
+        var target = GetLitTarget<ReservoirNorth>();
+        var south = Repository.GetLocation<ReservoirSouth>();
+        south.IsFull = true;
+        south.IsDrained = south.IsFilling = south.IsDraining = false;
+
+        var response = await target.GetResponse("go south");
+
+        response.Should().Contain("You would drown.");
+        target.Context.CurrentLocation.Should().Be(Repository.GetLocation<ReservoirNorth>());
+        target.Context.DeathCounter.Should().Be(0);
+    }
+
+    [Test]
+    public async Task ReservoirNorth_GoSouth_WhenDrained_Succeeds()
+    {
+        var target = GetLitTarget<ReservoirNorth>();
+        var south = Repository.GetLocation<ReservoirSouth>();
+        south.IsDrained = true;
+        south.IsFull = south.IsFilling = south.IsDraining = false;
+
+        await target.GetResponse("go south");
+
+        target.Context.CurrentLocation.Should().Be(Repository.GetLocation<Reservoir>());
+        target.Context.DeathCounter.Should().Be(0);
+    }
+
+    [Test]
+    public async Task ReservoirSouth_GoNorth_WhenFull_IsBlocked()
+    {
+        var target = GetLitTarget<ReservoirSouth>();
+        var south = Repository.GetLocation<ReservoirSouth>();
+        south.IsFull = true;
+        south.IsDrained = south.IsFilling = south.IsDraining = false;
+
+        var response = await target.GetResponse("go north");
+
+        response.Should().Contain("You would drown.");
+        target.Context.CurrentLocation.Should().Be(Repository.GetLocation<ReservoirSouth>());
+        target.Context.DeathCounter.Should().Be(0);
+    }
+
+    [Test]
+    public async Task ReservoirSouth_GoNorth_WhenDrained_Succeeds()
+    {
+        var target = GetLitTarget<ReservoirSouth>();
+        var south = Repository.GetLocation<ReservoirSouth>();
+        south.IsDrained = true;
+        south.IsFull = south.IsFilling = south.IsDraining = false;
+
+        await target.GetResponse("go north");
+
+        target.Context.CurrentLocation.Should().Be(Repository.GetLocation<Reservoir>());
+        target.Context.DeathCounter.Should().Be(0);
+    }
+
+    // Issue #87 follow-up: Reservoir North's room description must track the water state, just as the
+    // south shore's does. It is reachable in every fill state (cross while drained, close the gates and
+    // it fills around you, etc.), so a static "the water level is lowered / a wide stream" description
+    // contradicts the "You would drown." barrier whenever the reservoir is actually full or filling.
+
+    [Test]
+    public async Task ReservoirNorth_Look_WhenFull_DescribesUncrossableWater()
+    {
+        var target = GetLitTarget<ReservoirNorth>();
+        var south = Repository.GetLocation<ReservoirSouth>();
+        south.IsFull = true;
+        south.IsDrained = south.IsFilling = south.IsDraining = false;
+
+        var response = await target.GetResponse("look");
+
+        response.Should().NotContain("water level lowered");
+        response.Should().NotContain("wide stream");
+        response.Should().Contain("too deep");
+    }
+
+    [Test]
+    public async Task ReservoirNorth_Look_WhenDrained_DescribesLowWater()
+    {
+        var target = GetLitTarget<ReservoirNorth>();
+        var south = Repository.GetLocation<ReservoirSouth>();
+        south.IsDrained = true;
+        south.IsFull = south.IsFilling = south.IsDraining = false;
+
+        var response = await target.GetResponse("look");
+
+        response.Should().Contain("with the water level lowered");
+        response.Should().Contain("wide stream");
+    }
+
+    [Test]
+    public async Task ReservoirNorth_Look_WhenFilling_WarnsWaterRising()
+    {
+        var target = GetLitTarget<ReservoirNorth>();
+        var south = Repository.GetLocation<ReservoirSouth>();
+        // Issue #233 invariant: a refill stays low-tide (IsDrained) until the reservoir is full again,
+        // so a realistic "filling" state has BOTH IsFilling and IsDrained set. The rising-water text must
+        // win and the drained "wide stream" line must be suppressed.
+        south.IsFilling = true;
+        south.IsDrained = true;
+        south.IsFull = south.IsDraining = false;
+
+        var response = await target.GetResponse("look");
+
+        response.Should().Contain("rising");
+        response.Should().Contain("impossible to cross");
+        response.Should().NotContain("wide stream");
+    }
+
+    [Test]
+    public async Task ReservoirNorth_Look_WhenDraining_NotesWaterDropping()
+    {
+        var target = GetLitTarget<ReservoirNorth>();
+        var south = Repository.GetLocation<ReservoirSouth>();
+        south.IsDraining = true;
+        south.IsFull = south.IsDrained = south.IsFilling = false;
+
+        var response = await target.GetResponse("look");
+
+        response.Should().Contain("dropping");
+    }
+}

--- a/ZorkOne/Location/ReservoirNorth.cs
+++ b/ZorkOne/Location/ReservoirNorth.cs
@@ -10,19 +10,51 @@ public class ReservoirNorth : DarkLocation
 
     protected override Dictionary<Direction, MovementParameters> Map(IContext context)
     {
+        // Issue #87: both shores must gate the crossing identically. In the original game RESERVOIR-NORTH's
+        // south exit is "(SOUTH TO RESERVOIR IF LOW-TIDE ELSE \"You would drown.\")" (zork1/1dungeon.zil:1796),
+        // mirroring RESERVOIR-SOUTH's north exit. The fill state lives on ReservoirSouth, so read its shared
+        // CanCross gate here — keeping both shores in lockstep so they can't drift apart again.
+        var south = GetLocation<ReservoirSouth>();
         return new Dictionary<Direction, MovementParameters>
         {
-            { Direction.S, new MovementParameters { Location = GetLocation<Reservoir>() } },
+            {
+                Direction.S,
+                new MovementParameters
+                {
+                    CanGo = _ => south.CanCross,
+                    CustomFailureMessage = "You would drown.",
+                    Location = GetLocation<Reservoir>()
+                }
+            },
             { Direction.N, new MovementParameters { Location = GetLocation<AtlantisRoom>() } }
         };
     }
 
     protected override string GetContextBasedDescription(IContext context)
     {
-        return
-            "You are in a large cavernous room, the south of which was formerly a lake. However, with the water level " +
-            "lowered, there is merely a wide stream running through there.\nThere is a slimy stairway leaving " +
-            "the room to the north.";
+        // Issue #87 follow-up: like the south shore, this room's body must track the reservoir's fill
+        // state (owned by ReservoirSouth) — a static "water level lowered / wide stream" line contradicts
+        // the "You would drown." barrier on the south exit whenever the water is high or rising.
+        //
+        // A switch picks exactly one body, so the states can never double up. Order matters: during a
+        // refill the reservoir stays low-tide (IsDrained) until full (issue #233), so IsFilling must be
+        // checked before IsDrained. The default arm (full / indeterminate) describes deep, uncrossable
+        // water, which matches the blocked CanCross gate and so can never contradict it. The slimy
+        // stairway to the north is a fixed exit, always appended.
+        var south = GetLocation<ReservoirSouth>();
+        var body = south switch
+        {
+            { IsFilling: true } =>
+                "You are in a large cavernous room, the south of which is a wide area which was formerly a reservoir, but now is merely a stream. You notice, however, that the level of the stream is rising quickly and that before long it will be impossible to cross here.",
+            { IsDraining: true } =>
+                "You are in a large cavernous room. To the south is a large lake, too deep to cross. You notice, however, that the water level appears to be dropping at a rapid rate. Before long, it might be possible to cross to the other side from here.",
+            { IsDrained: true } =>
+                "You are in a large cavernous room, the south of which was formerly a lake. However, with the water level lowered, there is merely a wide stream running through there.",
+            _ =>
+                "You are in a large cavernous room on the north shore of a large lake, far too deep and wide for crossing."
+        };
+
+        return body + "\nThere is a slimy stairway leaving the room to the north.";
     }
 
     public override void Init()

--- a/ZorkOne/Location/ReservoirSouth.cs
+++ b/ZorkOne/Location/ReservoirSouth.cs
@@ -19,6 +19,13 @@ public class ReservoirSouth : DarkLocation, ITurnBasedActor
 
     public int FillingCountDown { get; set; }
 
+    /// <summary>
+    /// Whether the reservoir is currently low enough to walk across to the opposite shore — the ZIL
+    /// LOW-TIDE gate (zork1/1dungeon.zil). Owned here because this room holds the fill state; both shores
+    /// read it so their "you would drown" barriers stay symmetric (issue #87).
+    /// </summary>
+    public bool CanCross => IsDrained || (IsFilling && !IsFull);
+
     public override string Name => "Reservoir South";
 
     public Task<string> Act(IContext context, IGenerationClient client)
@@ -75,7 +82,7 @@ public class ReservoirSouth : DarkLocation, ITurnBasedActor
                 Direction.N,
                 new MovementParameters
                 {
-                    CanGo = _ => IsDrained || (IsFilling && !IsFull), CustomFailureMessage = "You would drown.",
+                    CanGo = _ => CanCross, CustomFailureMessage = "You would drown.",
                     Location = GetLocation<Reservoir>()
                 }
             }
@@ -84,20 +91,25 @@ public class ReservoirSouth : DarkLocation, ITurnBasedActor
 
     protected override string GetContextBasedDescription(IContext context)
     {
-        return (IsFull && !IsFilling && !IsDraining
-                   ? "You are in a long room on the south shore of a large lake, far too deep and wide for crossing. "
-                   : "") +
-               (IsDrained && !IsDraining && !IsFilling
-                   ? "You are in a long room, to the north of which was formerly a lake. However, with the water level lowered, there is merely a wide stream running through the center of the room. "
-                   : "") +
-               (IsDraining
-                   ? "You are in a long room. To the north is a large lake, too deep to cross. You notice, however, that the water level appears to be dropping at a rapid rate. Before long, it might be possible to cross to the other side from here. "
-                   : "") +
-               (IsFilling
-                   ? "You are in a long room, to the north of which is a wide area which was formerly a reservoir, but now is merely a stream. You notice, however, that the level of the stream is rising quickly and that before long it will be impossible to cross here. "
-                   : "") +
-               "There is a path along the stream to the east or west, a steep pathway climbing southwest along the edge " +
-               "of a chasm, and a path leading into a canyon to the southeast.";
+        // A switch picks exactly one body, so the fill states can never double up. Order matters: during a
+        // refill the reservoir stays low-tide (IsDrained) until full (issue #233), so IsFilling must be
+        // checked before IsDrained. The default arm (full / indeterminate) describes deep, uncrossable
+        // water, matching the blocked CanCross gate so it can never contradict it. This mirrors the
+        // identical structure on ReservoirNorth (issue #87). The path exits are fixed, always appended.
+        var body = this switch
+        {
+            { IsFilling: true } =>
+                "You are in a long room, to the north of which is a wide area which was formerly a reservoir, but now is merely a stream. You notice, however, that the level of the stream is rising quickly and that before long it will be impossible to cross here.",
+            { IsDraining: true } =>
+                "You are in a long room. To the north is a large lake, too deep to cross. You notice, however, that the water level appears to be dropping at a rapid rate. Before long, it might be possible to cross to the other side from here.",
+            { IsDrained: true } =>
+                "You are in a long room, to the north of which was formerly a lake. However, with the water level lowered, there is merely a wide stream running through the center of the room.",
+            _ =>
+                "You are in a long room on the south shore of a large lake, far too deep and wide for crossing."
+        };
+
+        return body + " There is a path along the stream to the east or west, a steep pathway climbing " +
+               "southwest along the edge of a chasm, and a path leading into a canyon to the southeast.";
     }
 
     public override void Init()


### PR DESCRIPTION
Fixes #87.

## The bug
`ReservoirNorth`'s south exit into the middle `Reservoir` was **unconditional**, while `ReservoirSouth`'s north exit was correctly gated. So when the reservoir was full/risen, you could walk south off the north shore into the flooded reservoir — and the middle room's turn-based actor drowned you on the same turn — instead of being stopped by the safe `"You would drown."` barrier.

The original game gates **both** shores symmetrically:

```zil
RESERVOIR-SOUTH  (NORTH TO RESERVOIR IF LOW-TIDE ELSE "You would drown.")
RESERVOIR-NORTH  (SOUTH TO RESERVOIR IF LOW-TIDE ELSE "You would drown.")
```

The shores never kill you — only the middle room does, when the fill daemon fires while you stand there. Crossing is meant to be gated at the shore exits.

## The fix
- **Shared gate.** Extracted a single `CanCross` predicate on `ReservoirSouth` (the fill-state owner) — `IsDrained || (IsFilling && !IsFull)` — and read it from both shores' `Map`. The two shores can no longer drift apart, which was the root cause.
- **Honest description.** `ReservoirNorth`'s room text was static ("the water level lowered… a wide stream"), which contradicted the `"You would drown."` gate whenever the water was actually high or rising. It now tracks the fill state like the south shore. Both shores use the same `switch`-based, state-exclusive description whose default arm describes deep, uncrossable water — so it can never contradict the blocked gate, even in an indeterminate state. Order respects the #233 invariant (a refill stays low-tide until full, so `IsFilling` is checked before `IsDrained`).

## Tests (TDD)
New `ZorkOne.Tests/Places/ReservoirTests.cs` — 8 deterministic tests (real `Repository`, lit lamp):
- **Crossing** (both shores × full/drained): full → blocked with `"You would drown."`, stays put, `DeathCounter == 0`; drained → crosses into `Reservoir`.
- **Description** (north shore × full/drained/filling/draining), including the realistic refill state where `IsDrained` stays set.

The north-crossing-when-full test was **red** before the fix (player walked in and `*** You have died ***`, reincarnating in the Forest) and the description tests leaked the low-water text; all **green** after. Full `ZorkOne.Tests` suite: **1268 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)