### PR TITLE
Fix #36: implement the skeleton curse and fix skeleton noun ambiguity

### DIFF
--- a/ZorkOne.Tests/Things/SkeletonTests.cs
+++ b/ZorkOne.Tests/Things/SkeletonTests.cs
@@ -1,0 +1,115 @@
+using FluentAssertions;
+using GameEngine;
+using ZorkOne.Item;
+using ZorkOne.Location;
+using ZorkOne.Location.MazeLocation;
+
+namespace ZorkOne.Tests.Things;
+
+/// <summary>
+/// Issue #36: "messing with" the skeleton in Maze Five must trigger the classic skeleton curse —
+/// a ghost banishes everything in the room and the player's entire inventory to the Land of the
+/// Living Dead. The original SKELETON action routine (zork1/1actions.zil:931) fires on
+/// TAKE / RUB / MOVE / PUSH / RAISE / LOWER / ATTACK / KICK / KISS.
+/// </summary>
+[TestFixture]
+public class SkeletonTests : EngineTestsBase
+{
+    /// <summary>
+    /// Puts the player in Maze Five with the original room contents and a lit lamp plus a treasure
+    /// in inventory, so the room is visible and we have something to banish.
+    /// </summary>
+    private (GameEngine<ZorkI, ZorkIContext> target, Sword treasure, Lantern lamp) ArriveAtSkeleton()
+    {
+        var target = GetTarget();
+        var room = Repository.GetLocation<MazeFive>();
+        room.Init();
+
+        var lamp = Repository.GetItem<Lantern>();
+        lamp.IsOn = true;
+        target.Context.Take(lamp);
+
+        var treasure = Repository.GetItem<Sword>();
+        target.Context.Take(treasure);
+
+        target.Context.CurrentLocation = room;
+        return (target, treasure, lamp);
+    }
+
+    [TestCase("take skeleton")]
+    [TestCase("move skeleton")]
+    [TestCase("rub skeleton")]
+    [TestCase("push skeleton")]
+    [TestCase("kick skeleton")]
+    [TestCase("kiss skeleton")]
+    [TestCase("raise skeleton")]
+    [TestCase("lower skeleton")]
+    public async Task MessingWithSkeleton_TriggersCurse(string command)
+    {
+        var (target, treasure, lamp) = ArriveAtSkeleton();
+
+        var response = await target.GetResponse(command);
+
+        // The full ghost-and-curse message (the curse sentence used to be a //TODO).
+        response.Should().Contain("ghost");
+        response.Should().Contain("Land of the Living Dead");
+
+        var dead = Repository.GetLocation<LandOfTheDead>();
+
+        // The player's entire inventory is banished — lamp included.
+        target.Context.Items.Should().BeEmpty();
+        treasure.CurrentLocation.Should().Be(dead);
+        lamp.CurrentLocation.Should().Be(dead);
+
+        // Every other item in the room is banished too...
+        Repository.GetItem<RustyKnife>().CurrentLocation.Should().Be(dead);
+        Repository.GetItem<SkeletonKey>().CurrentLocation.Should().Be(dead);
+        Repository.GetItem<BagOfCoins>().CurrentLocation.Should().Be(dead);
+        Repository.GetItem<BurnedOutLantern>().CurrentLocation.Should().Be(dead);
+
+        // ...but the bones themselves stay put (the original robs the room's other contents only).
+        Repository.GetItem<Skeleton>().CurrentLocation.Should().Be(Repository.GetLocation<MazeFive>());
+    }
+
+    [Test]
+    public async Task TakeSkeleton_ResolvesToSkeleton_NoDisambiguation()
+    {
+        var (target, _, _) = ArriveAtSkeleton();
+
+        var response = await target.GetResponse("take skeleton");
+
+        // "skeleton" must unambiguously mean the bones — not prompt "skeleton key or ...?".
+        response.Should().NotContain("Do you mean");
+        response.Should().Contain("ghost");
+    }
+
+    [Test]
+    public async Task TakeKey_StillResolvesToTheKey()
+    {
+        var (target, _, _) = ArriveAtSkeleton();
+
+        var response = await target.GetResponse("take key");
+
+        response.Should().NotContain("Do you mean");
+        target.Context.HasItem<SkeletonKey>().Should().BeTrue();
+        // Picking up the key must not have fired the curse.
+        Repository.GetItem<Skeleton>().CurrentLocation.Should().Be(Repository.GetLocation<MazeFive>());
+    }
+
+    // The disambiguation prompt for "take skeleton" was caused by the key over-claiming the bare
+    // noun "skeleton". In the original, "skeleton" is only the key's *adjective* — so the bones own
+    // the noun, and "skeleton key" still resolves to the key.
+    [Test]
+    public void NounOwnership_SkeletonIsTheBones_KeyKeepsItsAdjectivePhrase()
+    {
+        GetTarget();
+        var bones = Repository.GetItem<Skeleton>();
+        var key = Repository.GetItem<SkeletonKey>();
+
+        bones.HasMatchingNoun("skeleton").HasItem.Should().BeTrue();
+        key.HasMatchingNoun("skeleton").HasItem.Should().BeFalse();
+
+        key.HasMatchingNoun("key").HasItem.Should().BeTrue();
+        key.HasMatchingNoun("skeleton key").HasItem.Should().BeTrue();
+    }
+}

--- a/ZorkOne.Tests/Things/SkeletonTests.cs
+++ b/ZorkOne.Tests/Things/SkeletonTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using GameEngine;
+using Model.Intent;
 using ZorkOne.Item;
 using ZorkOne.Location;
 using ZorkOne.Location.MazeLocation;
@@ -68,6 +69,34 @@ public class SkeletonTests : EngineTestsBase
         Repository.GetItem<BurnedOutLantern>().CurrentLocation.Should().Be(dead);
 
         // ...but the bones themselves stay put (the original robs the room's other contents only).
+        Repository.GetItem<Skeleton>().CurrentLocation.Should().Be(Repository.GetLocation<MazeFive>());
+    }
+
+    // ATTACK (and its synonyms — kill/stab/etc.) is part of the curse verb set, but the unit-test
+    // intent parser doesn't route bare "attack <noun>" to a simple interaction (combat only engages
+    // registered foes), so it can't be exercised through GetResponse. Drive the handler directly to
+    // prove the KillVerbs branch fires the curse and banishes the room + inventory.
+    [TestCase("attack")]
+    [TestCase("kill")]
+    [TestCase("stab")]
+    public async Task AttackSkeleton_FiresCurse_ViaHandler(string verb)
+    {
+        var (target, treasure, lamp) = ArriveAtSkeleton();
+        var skeleton = Repository.GetItem<Skeleton>();
+
+        var result = await skeleton.RespondToSimpleInteraction(
+            new SimpleIntent { Verb = verb, Noun = "skeleton", OriginalInput = $"{verb} skeleton" },
+            target.Context, Client.Object, null!);
+
+        result.Should().NotBeNull();
+        result!.InteractionMessage.Should().Contain("ghost");
+        result.InteractionMessage.Should().Contain("Land of the Living Dead");
+
+        var dead = Repository.GetLocation<LandOfTheDead>();
+        target.Context.Items.Should().BeEmpty();
+        treasure.CurrentLocation.Should().Be(dead);
+        lamp.CurrentLocation.Should().Be(dead);
+        Repository.GetItem<RustyKnife>().CurrentLocation.Should().Be(dead);
         Repository.GetItem<Skeleton>().CurrentLocation.Should().Be(Repository.GetLocation<MazeFive>());
     }
 

--- a/ZorkOne/Item/Skeleton.cs
+++ b/ZorkOne/Item/Skeleton.cs
@@ -1,26 +1,63 @@
+using GameEngine;
 using GameEngine.Item;
+using Model.AIGeneration;
+using Model.Intent;
+using Model.Interface;
 
 namespace ZorkOne.Item;
 
-public class Skeleton : ItemBase, ICanBeTakenAndDropped
+public class Skeleton : ItemBase
 {
     // The original Zork I source declares the skeleton (BONES object) with the synonyms
     // BONES, BODY and SKELETON, so "examine bones"/"examine body" should resolve here.
     public override string[] NounsForMatching =>
         ["skeleton", "bones", "body", "remains", "adventurer", "luckless adventurer"];
 
-    public override string CannotBeTakenDescription =>
-        "A ghost appears in the room and is appalled at your desecration of the remains of a fellow adventurer. " +
-        //TODO: "He casts a curse on your valuables and banishes them to the Land of the Living Dead. " +
-        "The ghost leaves, muttering obscenities. ";
+    // The classic skeleton curse fires for any of these verbs applied to the bones
+    // (zork1/1actions.zil:931 — SKELETON: <VERB? TAKE RUB MOVE PUSH RAISE LOWER ATTACK KICK KISS>).
+    // We assemble it from the engine's verb thesauruses (plus the literals it has no family for) so
+    // synonyms like "get"/"kill"/"touch" all trigger the ghost.
+    private static readonly string[] CurseVerbs =
+        Verbs.TakeVerbs                       // TAKE
+            .Concat(Verbs.TouchVerbs)         // RUB
+            .Concat(Verbs.PushVerbs)          // PUSH
+            .Concat(Verbs.KillVerbs)          // ATTACK
+            .Concat(["move", "raise", "lower", "kick", "kiss"])
+            .ToArray();
 
-    public override string NeverPickedUpDescription(ILocation currentLocation)
+    private const string CurseMessage =
+        "A ghost appears in the room and is appalled at your desecration of the remains of a fellow " +
+        "adventurer. He casts a curse on your valuables and banishes them to the Land of the Living " +
+        "Dead. The ghost leaves, muttering obscenities. ";
+
+    // The bones are cursed scenery, not a takeable item; they're listed via GenericDescription
+    // (the "fixed item" path in LocationBase.GetItemDescriptions).
+    public override string GenericDescription(ILocation? currentLocation)
     {
         return "A skeleton, probably the remains of a luckless adventurer, lies here. ";
     }
 
-    public string OnTheGroundDescription(ILocation currentLocation)
+    public override async Task<InteractionResult?> RespondToSimpleInteraction(SimpleIntent action, IContext context,
+        IGenerationClient client, IItemProcessorFactory itemProcessorFactory)
     {
-        return NeverPickedUpDescription(currentLocation);
+        // Only the bones trigger this; non-curse verbs (examine, smell, ...) fall through to the base.
+        if (!action.MatchNoun(NounsForMatching) || !action.MatchVerb(CurseVerbs))
+            return await base.RespondToSimpleInteraction(action, context, client, itemProcessorFactory);
+
+        var dead = Repository.GetLocation<LandOfTheDead>();
+
+        // ROB HERE -> LAND-OF-LIVING-DEAD: banish everything else in the room (knife, key, coins,
+        // burned-out lantern) but leave the bones themselves where they are. ToList() so we don't
+        // mutate the collection while iterating (ItemPlacedHere removes the item from its prior owner).
+        foreach (var item in ((ICanContainItems)context.CurrentLocation!).Items.ToList())
+            if (item is not Skeleton)
+                dead.ItemPlacedHere(item);
+
+        // ROB ADVENTURER -> LAND-OF-LIVING-DEAD: empty the player's pack — the lamp goes too, which
+        // is exactly why doing this in the dark maze famously strands you.
+        foreach (var item in context.Items.ToList())
+            dead.ItemPlacedHere(item);
+
+        return new PositiveInteractionResult(CurseMessage);
     }
 }

--- a/ZorkOne/Item/Skeleton.cs
+++ b/ZorkOne/Item/Skeleton.cs
@@ -15,14 +15,15 @@ public class Skeleton : ItemBase
 
     // The classic skeleton curse fires for any of these verbs applied to the bones
     // (zork1/1actions.zil:931 — SKELETON: <VERB? TAKE RUB MOVE PUSH RAISE LOWER ATTACK KICK KISS>).
-    // We assemble it from the engine's verb thesauruses (plus the literals it has no family for) so
-    // synonyms like "get"/"kill"/"touch" all trigger the ghost.
+    // We map each ZIL verb to the engine's thesaurus where one exists (so synonyms like "get"/"kill"/
+    // "touch" all trigger the ghost), but deliberately NOT to Verbs.PushVerbs — that family folds in
+    // machine-operation synonyms (toggle/flip/switch/activate/click) that read as nonsense on bones.
+    // PUSH/RAISE/LOWER/MOVE/KICK/KISS are spelled out with only their sensible "manhandle" synonyms.
     private static readonly string[] CurseVerbs =
         Verbs.TakeVerbs                       // TAKE
             .Concat(Verbs.TouchVerbs)         // RUB
-            .Concat(Verbs.PushVerbs)          // PUSH
             .Concat(Verbs.KillVerbs)          // ATTACK
-            .Concat(["move", "raise", "lower", "kick", "kiss"])
+            .Concat(["push", "depress", "shove", "move", "raise", "lift", "lower", "kick", "kiss"])
             .ToArray();
 
     private const string CurseMessage =
@@ -47,11 +48,12 @@ public class Skeleton : ItemBase
         var dead = Repository.GetLocation<LandOfTheDead>();
 
         // ROB HERE -> LAND-OF-LIVING-DEAD: banish everything else in the room (knife, key, coins,
-        // burned-out lantern) but leave the bones themselves where they are. ToList() so we don't
-        // mutate the collection while iterating (ItemPlacedHere removes the item from its prior owner).
-        foreach (var item in ((ICanContainItems)context.CurrentLocation!).Items.ToList())
-            if (item is not Skeleton)
-                dead.ItemPlacedHere(item);
+        // burned-out lantern). Only takeable items, matching ZIL ROB (it moves portable objects, not
+        // fixed scenery) — and that filter also excludes the bones themselves, which stay put. ToList()
+        // so we don't mutate the collection while iterating (ItemPlacedHere removes from the prior owner).
+        foreach (var item in ((ICanContainItems)context.CurrentLocation!).Items
+                     .Where(i => i is ICanBeTakenAndDropped).ToList())
+            dead.ItemPlacedHere(item);
 
         // ROB ADVENTURER -> LAND-OF-LIVING-DEAD: empty the player's pack — the lamp goes too, which
         // is exactly why doing this in the dark maze famously strands you.

--- a/ZorkOne/Item/SkeletonKey.cs
+++ b/ZorkOne/Item/SkeletonKey.cs
@@ -4,7 +4,11 @@ namespace ZorkOne.Item;
 
 public class SkeletonKey : ItemBase, ICanBeTakenAndDropped, IAmATool
 {
-    public override string[] NounsForMatching => ["key", "skeleton", "skeleton key"];
+    // In the original Zork I source the key is (SYNONYM KEY) (ADJECTIVE SKELETON) — "skeleton" is
+    // only an *adjective* of the key, never a bare noun. Claiming the bare noun "skeleton" made it
+    // collide with the Skeleton (the bones) and produced a spurious disambiguation prompt for
+    // "take skeleton" (issue #36). "skeleton key" still resolves here; bare "skeleton" means the bones.
+    public override string[] NounsForMatching => ["key", "skeleton key"];
 
     public string OnTheGroundDescription(ILocation currentLocation)
     {


### PR DESCRIPTION
## Summary

Fixes #36. "Messing with" the skeleton in Maze Five now triggers the classic **skeleton curse**, and two noun/verb bugs around the skeleton are corrected.

### The bug
- The curse never fired — the curse sentence was a literal `//TODO` in `Skeleton.cs` and there was no banishment logic anywhere.
- `take skeleton` / `move skeleton` produced a spurious **"Do you mean the luckless adventurer or the skeleton key?"** disambiguation prompt, because `SkeletonKey` over-claimed the bare noun `"skeleton"`.

### The fix
1. **`ZorkOne/Item/Skeleton.cs`** — Skeleton is now cursed scenery (no longer `ICanBeTakenAndDropped`). It overrides `RespondToSimpleInteraction` to fire on the original ZIL verb set (`TAKE RUB MOVE PUSH RAISE LOWER ATTACK KICK KISS`). On any curse verb it prints the full ghost-and-curse message and banishes **every other item in the room** plus the **player's entire inventory** (lamp included) to `LandOfTheDead`, leaving the bones in place — mirroring `zork1/1actions.zil:931`.
2. **`ZorkOne/Item/SkeletonKey.cs`** — drops the bare noun `"skeleton"` (now `["key", "skeleton key"]`). In the original, "skeleton" is only the key's *adjective* (`zork1/1dungeon.zil:843`), so the bones unambiguously own the noun while `skeleton key`/`key` still resolve to the key.

### Tests (TDD)
New `ZorkOne.Tests/Things/SkeletonTests.cs` (deterministic, real `Repository`):
- Curse fires for `take/move/rub/push/kick/kiss/raise/lower skeleton` — inventory empties, room items (knife, key, coins, burned-out lantern) land in `LandOfTheDead`, bones stay put.
- `take skeleton` resolves to the bones with no disambiguation prompt.
- `take key` still gets the `SkeletonKey`; direct noun-ownership assertion confirms the key no longer claims "skeleton".

Red→green confirmed. Full `ZorkOne.Tests` (1279) and engine `UnitTests` (934) pass with no regressions.

### Scoping notes
- `attack` is in the handler's verb set for real gameplay, but isn't in the deterministic engine test — the test parser doesn't route `attack` to a simple intent (combat only engages registered foes). The mechanism is proven by the six routable verbs.
- `take all` in that room now skips the (non-takeable) skeleton rather than firing the curse; fully replicating ZIL's "take all triggers the action routine" is out of scope for this issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)