### PR TITLE
Fix #312 / #283: "look at <noun>" routes to examine, not a bare room look

### DIFF
--- a/GameEngine/GameEngine.cs
+++ b/GameEngine/GameEngine.cs
@@ -345,6 +345,27 @@ public class GameEngine<TInfocomGame, TContext> : IGameEngine
     }
 
     /// <summary>
+    ///     Rewrites a leading "look at &lt;noun&gt;" into the canonical "examine &lt;noun&gt;" so it routes
+    ///     through the examine-with-noun path instead of collapsing to the bare-room LOOK command
+    ///     (issues #312 / #283). Only the exact "look at " prefix followed by a noun is rewritten — bare
+    ///     "look"/"look around" and other "look &lt;preposition&gt;" phrases (e.g. "look under the rug",
+    ///     "look in the box") are intentionally left alone.
+    /// </summary>
+    internal static string? NormalizeLookAt(string? input)
+    {
+        if (string.IsNullOrWhiteSpace(input))
+            return input;
+
+        const string prefix = "look at ";
+        var trimmed = input.TrimStart();
+        if (!trimmed.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            return input;
+
+        var noun = trimmed[prefix.Length..].Trim();
+        return string.IsNullOrEmpty(noun) ? input : "examine " + noun;
+    }
+
+    /// <summary>
     ///     Processes a single sentence/command through the game engine.
     /// </summary>
     private async Task<string?> ProcessSingleSentence(string? playerInput)
@@ -367,6 +388,15 @@ public class GameEngine<TInfocomGame, TContext> : IGameEngine
         // 2. -------  Empty command. Does not count as a turn. No actor or turn processing.
         if (string.IsNullOrEmpty(playerInput))
             return PostProcessing(await GetGeneratedNoCommandResponse());
+
+        // 2b. ------- "look at <noun>" is an examine synonym, not the bare-room LOOK command. The AI
+        // parser (rule (f) in the system prompt) collapses "look at X" to a noun-less look intent for
+        // single-word nouns, re-describing the room instead of the object (issues #312 / #283). Rewrite
+        // it to the canonical "examine <noun>" here so it routes through the examine-with-noun path,
+        // while leaving the bare forms ("look", "look around") and other "look <prep>" phrases
+        // ("look under the rug", "look in the box") untouched.
+        playerInput = NormalizeLookAt(playerInput);
+        _currentInput = playerInput;
 
         Context.PreviousLocationName = LocationName;
 

--- a/GameEngine/GameEngine.cs
+++ b/GameEngine/GameEngine.cs
@@ -394,7 +394,9 @@ public class GameEngine<TInfocomGame, TContext> : IGameEngine
         // single-word nouns, re-describing the room instead of the object (issues #312 / #283). Rewrite
         // it to the canonical "examine <noun>" here so it routes through the examine-with-noun path,
         // while leaving the bare forms ("look", "look around") and other "look <prep>" phrases
-        // ("look under the rug", "look in the box") untouched.
+        // ("look under the rug", "look in the box") untouched. Note: because this runs before pronoun
+        // resolution and the LastInput capture below, a subsequent "again"/"g" replays "look at X" as
+        // "examine X" — harmless, since both produce the same examination output.
         playerInput = NormalizeLookAt(playerInput);
         _currentInput = playerInput;
 

--- a/Planetfall.Tests/ExamineVerbsTests.cs
+++ b/Planetfall.Tests/ExamineVerbsTests.cs
@@ -56,4 +56,31 @@ public class ExamineVerbsTests : EngineTestsBase
 
         response.Should().Contain("Double Fannucci");
     }
+
+    /// <summary>
+    ///     Issue #283: "look at &lt;single-word noun&gt;" was collapsing to the bare-room LOOK command,
+    ///     re-describing the room instead of examining the named object. "look at" must route to the
+    ///     same examine-with-noun path as "examine" / "inspect", including the single-word-noun case.
+    /// </summary>
+    [Test]
+    public async Task LookAt_Light_AtComputerRoom_RoutesLikeExamine()
+    {
+        var target = GetTarget();
+        StartHere<ComputerRoom>();
+
+        var response = await target.GetResponse("look at light");
+
+        response.Should().Contain("malfunction in the computer");
+    }
+
+    [Test]
+    public async Task LookAt_Controls_AtHelicopter_RoutesLikeExamine()
+    {
+        var target = GetTarget();
+        StartHere<Helicopter>();
+
+        var response = await target.GetResponse("look at controls");
+
+        response.Should().Contain("covered and locked");
+    }
 }

--- a/UnitTests/Engine/NormalizeLookAtTests.cs
+++ b/UnitTests/Engine/NormalizeLookAtTests.cs
@@ -1,0 +1,62 @@
+using FluentAssertions;
+using GameEngine;
+using ZorkOne;
+
+namespace UnitTests.Engine;
+
+/// <summary>
+///     Pins the conservative contract of <see cref="GameEngine{TInfocomGame,TContext}.NormalizeLookAt" />
+///     (issues #312 / #283). The behavioral <c>ExamineVerbsTests</c> in each game cover the positive
+///     "look at X routes to examine" path end-to-end; these unit tests lock the <em>negative</em> cases
+///     the integration tests leave implicit — bare "look", "look around" and other "look &lt;preposition&gt;"
+///     phrases must NOT be rewritten — so a future broadening of the prefix match is caught immediately.
+/// </summary>
+public class NormalizeLookAtTests
+{
+    // The static helper is generic-class-scoped; any closed generic exposes the same implementation.
+    private static string? Normalize(string? input) =>
+        GameEngine<ZorkI, ZorkIContext>.NormalizeLookAt(input);
+
+    [TestCase("look at mailbox", "examine mailbox")]
+    [TestCase("look at door", "examine door")]
+    [TestCase("look at jade figurine", "examine jade figurine")]
+    [TestCase("look at the lamp", "examine the lamp")]
+    [TestCase("LOOK AT MAILBOX", "examine MAILBOX")] // case-insensitive prefix, noun case preserved
+    [TestCase("  look at mailbox", "examine mailbox")] // leading whitespace tolerated
+    [TestCase("look at   mailbox", "examine mailbox")] // collapses padding after the prefix
+    public void Rewrites_LookAtNoun_ToExamine(string input, string expected)
+    {
+        Normalize(input).Should().Be(expected);
+    }
+
+    [TestCase("look")] // bare room-description command
+    [TestCase("look around")]
+    [TestCase("l")]
+    [TestCase("look under the rug")] // distinct "look <preposition>" interactions
+    [TestCase("look in the box")]
+    [TestCase("look through the crack")]
+    [TestCase("look behind the painting")]
+    [TestCase("examine mailbox")] // already canonical — untouched
+    [TestCase("take lamp")]
+    [TestCase("quickly look at the lamp")] // only a leading prefix is rewritten, not a mid-sentence one
+    public void LeavesUnrelatedInput_Untouched(string input)
+    {
+        Normalize(input).Should().Be(input);
+    }
+
+    [TestCase("look at")] // verb phrase with no noun — nothing to examine, leave alone
+    [TestCase("look at ")]
+    [TestCase("look at   ")]
+    public void LeavesNounlessLookAt_Untouched(string input)
+    {
+        Normalize(input).Should().Be(input);
+    }
+
+    [TestCase(null)]
+    [TestCase("")]
+    [TestCase("   ")]
+    public void HandlesNullOrBlank_Untouched(string? input)
+    {
+        Normalize(input).Should().Be(input);
+    }
+}

--- a/ZorkOne.Tests/ExamineVerbsTests.cs
+++ b/ZorkOne.Tests/ExamineVerbsTests.cs
@@ -60,4 +60,43 @@ public class ExamineVerbsTests : EngineTestsBase
 
         response.Should().Contain("ugly person staring back at you");
     }
+
+    /// <summary>
+    ///     Issue #312: "look at &lt;single-word noun&gt;" was collapsing to the bare-room LOOK command,
+    ///     re-describing the room instead of examining the named object. "look at" must route to the
+    ///     same examine-with-noun path as "examine" / "inspect", including the single-word-noun case.
+    /// </summary>
+    [Test]
+    public async Task LookAt_Mailbox_AtWestOfHouse_RoutesLikeExamine()
+    {
+        var target = GetTarget();
+        target.Context.CurrentLocation = Repository.GetLocation<WestOfHouse>();
+
+        var response = await target.GetResponse("look at mailbox");
+
+        response.Should().Contain("The small mailbox is closed.");
+        response.Should().NotContain("open field");
+    }
+
+    [Test]
+    public async Task LookAt_Door_AtWestOfHouse_RoutesLikeExamine()
+    {
+        var target = GetTarget();
+        target.Context.CurrentLocation = Repository.GetLocation<WestOfHouse>();
+
+        var response = await target.GetResponse("look at door");
+
+        response.Should().Contain("The door is closed.");
+    }
+
+    [Test]
+    public async Task LookAt_House_AtWestOfHouse_RoutesLikeExamine()
+    {
+        var target = GetTarget();
+        target.Context.CurrentLocation = Repository.GetLocation<WestOfHouse>();
+
+        var response = await target.GetResponse("look at house");
+
+        response.Should().Contain("beautiful colonial house");
+    }
 }


### PR DESCRIPTION
## Problem

In both **Zork I** (#312) and **Planetfall** (#283), `look at <noun>` returned the **current room's description** instead of examining the named object. `examine` / `x` / `inspect` all worked; only the `look at` synonym was broken.

The reported tell: `look at <single-word noun>` collapsed to a bare room look, while `look at <multi-word noun phrase>` resolved correctly — a word-count artifact in intent parsing where the noun is dropped for single-token nouns and the room is re-described.

## Root cause

`look at X` reaches the AI parser, whose `look` rule normalizes it to a noun-less `look` intent (dropping the noun) for single-word nouns. The bare-`look` global command only exact-matches `look` / `l` / `look around`, so the collapse happens upstream in parsing — exactly the risk flagged in #207.

## Fix

Normalize a leading `look at <noun>` to the canonical `examine <noun>` **before** parsing (`GameEngine.NormalizeLookAt`), so it routes through the proven examine-with-noun path. Conservative by design:

- Bare `look` / `look around` — untouched.
- Other `look <preposition>` phrases (`look under the rug`, `look in the box`, `look through the crack`) — untouched.
- Only an exact `look at ` prefix followed by a noun is rewritten.

## Tests (TDD)

Added regression tests asserting `look at <single-word noun>` returns the object's examination text, not the room description:

- **Zork I**: `look at mailbox` / `look at door` / `look at house` at West Of House.
- **Planetfall**: `look at light` (Computer Room) / `look at controls` (Helicopter).

Red before the fix (noun dropped → no examine output), green after.

Full suites pass with no regressions: UnitTests (934), ZorkOne.Tests (1305), Planetfall.Tests (2412).

Closes #312
Closes #283

🤖 Generated with [Claude Code](https://claude.com/claude-code)