### PR TITLE
Fix #311: stop printing the Bat Room vampire bat description twice on entry

### DIFF
--- a/ZorkOne.Tests/Places/BatRoomTests.cs
+++ b/ZorkOne.Tests/Places/BatRoomTests.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using FluentAssertions;
 using GameEngine;
 using Model.Interface;
@@ -101,6 +102,27 @@ public class BatRoomTests : EngineTestsBase
         response.Should().NotContain("Fweep!");
         response.Should().Contain("deranged and holding his nose");
         target.Context.CurrentLocation.Should().Be(Repository.GetLocation<BatRoom>());
+    }
+
+    [Test]
+    public async Task EnterFromTheSouthWithGarlic_DescribesBatExactlyOnce()
+    {
+        var target = GetTarget();
+        target.Context.Take(Repository.GetItem<Lantern>());
+        Repository.GetItem<Lantern>().IsOn = true;
+        target.Context.Take(Repository.GetItem<Garlic>());
+        target.Context.CurrentLocation = Repository.GetLocation<SqueakyRoom>();
+
+        // Act - enter the Bat Room from the south (the Squeaky Room)
+        var response = await target.GetResponse("north");
+        Console.WriteLine(response);
+
+        response.Should().NotContain("Fweep!");
+        target.Context.CurrentLocation.Should().Be(Repository.GetLocation<BatRoom>());
+
+        // The bat must be described once, not twice. The room's static item listing already
+        // includes the bat, so AfterEnterLocation must not append it again.
+        Regex.Matches(response, "vampire bat").Count.Should().Be(1);
     }
 
     [Test]

--- a/ZorkOne/Location/BatRoom.cs
+++ b/ZorkOne/Location/BatRoom.cs
@@ -97,13 +97,11 @@ internal class BatRoom : DarkLocation
     public override Task<string> AfterEnterLocation(IContext context, ILocation previousLocation,
         IGenerationClient generationClient)
     {
-        var response = "";
-
-        if (IsSafeFromBat(context))
-            response +=
-                "\nIn the corner of the room on the ceiling is a large vampire bat who is obviously deranged and holding his nose. ";
-
-        response += LocationHelper.CheckSwordGlowingBrightly<Bat, BatRoom>(context);
+        // Don't describe the bat here - the room's static item listing already renders the bat via
+        // Bat.NeverPickedUpDescription. Appending it again printed the bat twice on room entry (#311).
+        // The player only ever sees this room when safe from the bat; otherwise BeforeEnterLocation
+        // carries them off before the room is described.
+        var response = LocationHelper.CheckSwordGlowingBrightly<Bat, BatRoom>(context);
 
         if (!string.IsNullOrEmpty(response))
             return Task.FromResult(response);


### PR DESCRIPTION
## Bug

Entering the **Bat Room** (Zork I coal mine) printed the vampire bat description **twice** on movement-triggered entry, in both narrator-off and narrator-on modes. Fixes #311.

## Root cause

Two sources emitted the same line:
1. The room's static item listing, via `Bat.NeverPickedUpDescription` (the standard item-self-description pattern).
2. `BatRoom.AfterEnterLocation`, which manually appended an identical hard-coded copy of the bat line.

## Fix

Removed the redundant description from `AfterEnterLocation`, keeping only the sword-glow check, and rely on the item listing as the single source. The `IsSafeFromBat` gate there was unnecessary: the player only ever sees the room when safe; otherwise `BeforeEnterLocation` carries them off before the room is described.

## TDD

- **Red:** Added `EnterFromTheSouthWithGarlic_DescribesBatExactlyOnce` — enters the Bat Room from the Squeaky Room with garlic and asserts `"vampire bat"` appears exactly once. It failed because the bat was listed twice.
- **Green:** Minimal change to `BatRoom.AfterEnterLocation`.
- **Verify:** New test passes; full **ZorkOne.Tests (1303 passed)** and **UnitTests (934 passed)** suites green, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)