### PR TITLE
Fix #317: "read gothic lettering" routes to the inscription, not a no-op

### DIFF
--- a/ZorkOne.Tests/LivingRoomTests.cs
+++ b/ZorkOne.Tests/LivingRoomTests.cs
@@ -1,0 +1,53 @@
+using FluentAssertions;
+using GameEngine;
+using Model.Intent;
+using ZorkOne.Location;
+
+namespace ZorkOne.Tests;
+
+/// <summary>
+///     Issue #317: the Living Room description calls the inscription above the west door
+///     "strange gothic lettering". When a player echoes that wording — e.g. "read gothic lettering"
+///     — the AI parser folds the adjective into the noun (Noun = "gothic lettering"), so the bare
+///     "lettering" entry in the handler's noun list never matched and the command silently failed.
+///     The fix adds the adjective forms to the noun list so the player's most natural action works.
+/// </summary>
+[TestFixture]
+public class LivingRoomTests : EngineTestsBase
+{
+    private const string Expected = "This space intentionally left blank";
+
+    // Drives the location handler directly with the compound noun the AI parser actually produces,
+    // since the unit-test parser would never assemble "gothic lettering" from these words.
+    private async Task<string?> ReadLettering(string verb, string noun)
+    {
+        var target = GetTarget();
+        target.Context.CurrentLocation = Repository.GetLocation<LivingRoom>();
+
+        var result = await Repository.GetLocation<LivingRoom>().RespondToSimpleInteraction(
+            new SimpleIntent { Verb = verb, Noun = noun, OriginalInput = $"{verb} {noun}" },
+            target.Context, Client.Object, null!);
+
+        return result?.InteractionMessage;
+    }
+
+    [TestCase("read", "gothic lettering")]
+    [TestCase("examine", "gothic lettering")]
+    [TestCase("read", "strange gothic lettering")]
+    public async Task ReadGothicLettering_Translates(string verb, string noun)
+    {
+        var message = await ReadLettering(verb, noun);
+
+        message.Should().Contain(Expected);
+    }
+
+    // Regression: the bare wording must still work.
+    [TestCase("read", "lettering")]
+    [TestCase("examine", "engravings")]
+    public async Task ReadBareLettering_StillTranslates(string verb, string noun)
+    {
+        var message = await ReadLettering(verb, noun);
+
+        message.Should().Contain(Expected);
+    }
+}

--- a/ZorkOne/Location/LivingRoom.cs
+++ b/ZorkOne/Location/LivingRoom.cs
@@ -63,7 +63,12 @@ public class LivingRoom : LocationBase
     public override async Task<InteractionResult> RespondToSimpleInteraction(SimpleIntent action, IContext context,
         IGenerationClient client, IItemProcessorFactory itemProcessorFactory)
     {
-        string[] nouns = ["lettering", "engraving", "engravings", "door"];
+        // The room description calls this "strange gothic lettering". The AI parser often folds the
+        // adjective(s) into the noun (Noun = "gothic lettering"), so the bare "lettering" entry never
+        // matched and a player echoing the room's own wording got no response (issue #317). List the
+        // adjective forms explicitly so the natural command works.
+        string[] nouns =
+            ["lettering", "gothic lettering", "strange gothic lettering", "engraving", "engravings", "door"];
         string[] verbs = ["read", "examine"];
 
         if (action.Match(verbs, nouns))


### PR DESCRIPTION
## Bug

In the Living Room, the room description calls the inscription above the west door **"strange gothic lettering"**. When a player echoes that wording — `read gothic lettering` or `examine gothic lettering` — the command silently did nothing. The bare `read lettering` worked.

```
> read gothic lettering
This action or command has no effect on the game.

> read lettering
The engravings translate to "This space intentionally left blank."
```

Fixes #317.

## Root cause

The AI intent parser folds the adjective(s) into the noun, returning `Noun = "gothic lettering"` rather than `Noun = "lettering"` + `Adjective = "gothic"`. `LivingRoom.RespondToSimpleInteraction` listed only the bare `"lettering"`, and `SimpleIntent.Match()` compares the `Noun` field exactly — so the compound form never matched.

## Fix

Added the adjective forms to the noun list in `ZorkOne/Location/LivingRoom.cs`:

```csharp
string[] nouns =
    ["lettering", "gothic lettering", "strange gothic lettering", "engraving", "engravings", "door"];
```

### Why not the "systemic" `Match()` change

The issue suggested an alternative: strip a leading adjective inside `Match()` so any bare-noun handler fires when an adjective is present. I deliberately avoided that — it causes a real regression. `TrapDoor.NounsForMatching` includes the bare `"door"`, and LivingRoom's list also has `"door"`, so a generic suffix/adjective strip would make `examine trap door` match `"door"` and wrongly return the lettering message. The targeted noun-list fix is contained and risk-free.

## TDD

`ZorkOne.Tests/LivingRoomTests.cs` drives the location handler directly with the compound noun the AI parser actually produces (the unit-test parser would never assemble `"gothic lettering"` from these words):

- `read gothic lettering`, `examine gothic lettering`, `read strange gothic lettering` → translate (red before, green after)
- `read lettering`, `examine engravings` → still translate (regression guard)

The three gothic-lettering cases failed (empty result) before the fix and pass after. Full `ZorkOne.Tests` suite: **1311 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)