### PR TITLE
Fix #316: "say Ulysses" (and say-verb synonyms / quoted names) dismisses the cyclops

### DIFF
--- a/ZorkOne.Tests/People/CyclopsTests.cs
+++ b/ZorkOne.Tests/People/CyclopsTests.cs
@@ -51,6 +51,39 @@ public class CyclopsTests : EngineTestsBase
     }
 
     [Test]
+    public async Task SayUlysses_Response()
+    {
+        // Issue #316: the canonical walkthrough phrasing "say Ulysses" must also dismiss the
+        // cyclops, not just the bare name "Ulysses".
+        var target = GetTarget();
+        target.Context.CurrentLocation = Repository.GetLocation<CyclopsRoom>();
+        target.Context.ItemPlacedHere(Repository.GetItem<Torch>());
+
+        var response = await target.GetResponse("say Ulysses");
+
+        response.Should()
+            .Contain(
+                "The cyclops, hearing the name of his father's deadly nemesis, " +
+                "flees the room by knocking down the wall on the east of the room");
+    }
+
+    [Test]
+    public async Task SayOdysseus_Response()
+    {
+        // Issue #316: "say Odysseus" must also dismiss the cyclops.
+        var target = GetTarget();
+        target.Context.CurrentLocation = Repository.GetLocation<CyclopsRoom>();
+        target.Context.ItemPlacedHere(Repository.GetItem<Torch>());
+
+        var response = await target.GetResponse("say Odysseus");
+
+        response.Should()
+            .Contain(
+                "The cyclops, hearing the name of his father's deadly nemesis, " +
+                "flees the room by knocking down the wall on the east of the room");
+    }
+
+    [Test]
     public async Task Asleep_Odysseus_Response()
     {
         var target = GetTarget();

--- a/ZorkOne.Tests/People/CyclopsTests.cs
+++ b/ZorkOne.Tests/People/CyclopsTests.cs
@@ -104,6 +104,8 @@ public class CyclopsTests : EngineTestsBase
     [TestCase("shout Ulysses")]
     [TestCase("whisper Odysseus")]
     [TestCase("recite \"Ulysses\"")]
+    [TestCase("say 'Ulysses'")]
+    [TestCase("say \"Odysseus\"")]
     public async Task SayVerbSynonyms_DismissTheCyclops(string command)
     {
         // Issue #316: any Verbs.SayVerbs synonym (not just "say") should prefix the name.

--- a/ZorkOne.Tests/People/CyclopsTests.cs
+++ b/ZorkOne.Tests/People/CyclopsTests.cs
@@ -84,6 +84,38 @@ public class CyclopsTests : EngineTestsBase
     }
 
     [Test]
+    public async Task SayUlyssesInQuotes_Response()
+    {
+        // Issue #316: the name may also be quoted, e.g. say "Ulysses".
+        var target = GetTarget();
+        target.Context.CurrentLocation = Repository.GetLocation<CyclopsRoom>();
+        target.Context.ItemPlacedHere(Repository.GetItem<Torch>());
+
+        var response = await target.GetResponse("say \"Ulysses\"");
+
+        response.Should()
+            .Contain(
+                "The cyclops, hearing the name of his father's deadly nemesis, " +
+                "flees the room by knocking down the wall on the east of the room");
+    }
+
+    [Test]
+    public async Task UlyssesInQuotes_Response()
+    {
+        // Issue #316: a bare quoted name "Ulysses" must work too.
+        var target = GetTarget();
+        target.Context.CurrentLocation = Repository.GetLocation<CyclopsRoom>();
+        target.Context.ItemPlacedHere(Repository.GetItem<Torch>());
+
+        var response = await target.GetResponse("\"Ulysses\"");
+
+        response.Should()
+            .Contain(
+                "The cyclops, hearing the name of his father's deadly nemesis, " +
+                "flees the room by knocking down the wall on the east of the room");
+    }
+
+    [Test]
     public async Task Asleep_Odysseus_Response()
     {
         var target = GetTarget();

--- a/ZorkOne.Tests/People/CyclopsTests.cs
+++ b/ZorkOne.Tests/People/CyclopsTests.cs
@@ -120,6 +120,22 @@ public class CyclopsTests : EngineTestsBase
     }
 
     [Test]
+    public async Task Tell_IsNotTreatedAsASpeakVerb()
+    {
+        // Issue #316 review: "tell" is a named-address lead-in ("tell floyd ..."), not untargeted
+        // speech, so it is excluded from the speak-verb prefix (matching ConversationHandler).
+        // "tell ulysses" must therefore NOT dismiss the cyclops.
+        var target = GetTarget();
+        target.Context.CurrentLocation = Repository.GetLocation<CyclopsRoom>();
+        target.Context.ItemPlacedHere(Repository.GetItem<Torch>());
+
+        var response = await target.GetResponse("tell ulysses");
+
+        response.Should().NotContain("flees the room by knocking down the wall");
+        Repository.GetItem<Cyclops>().CurrentLocation.Should().Be(Repository.GetLocation<CyclopsRoom>());
+    }
+
+    [Test]
     public async Task UlyssesInQuotes_Response()
     {
         // Issue #316: a bare quoted name "Ulysses" must work too.

--- a/ZorkOne.Tests/People/CyclopsTests.cs
+++ b/ZorkOne.Tests/People/CyclopsTests.cs
@@ -99,6 +99,26 @@ public class CyclopsTests : EngineTestsBase
                 "flees the room by knocking down the wall on the east of the room");
     }
 
+    [TestCase("speak Ulysses")]
+    [TestCase("utter Ulysses")]
+    [TestCase("shout Ulysses")]
+    [TestCase("whisper Odysseus")]
+    [TestCase("recite \"Ulysses\"")]
+    public async Task SayVerbSynonyms_DismissTheCyclops(string command)
+    {
+        // Issue #316: any Verbs.SayVerbs synonym (not just "say") should prefix the name.
+        var target = GetTarget();
+        target.Context.CurrentLocation = Repository.GetLocation<CyclopsRoom>();
+        target.Context.ItemPlacedHere(Repository.GetItem<Torch>());
+
+        var response = await target.GetResponse(command);
+
+        response.Should()
+            .Contain(
+                "The cyclops, hearing the name of his father's deadly nemesis, " +
+                "flees the room by knocking down the wall on the east of the room");
+    }
+
     [Test]
     public async Task UlyssesInQuotes_Response()
     {

--- a/ZorkOne/Location/MazeLocation/CyclopsRoom.cs
+++ b/ZorkOne/Location/MazeLocation/CyclopsRoom.cs
@@ -1,5 +1,6 @@
 using GameEngine.IntentEngine;
 using GameEngine.Location;
+using Model;
 using Model.AIGeneration;
 using Model.Intent;
 using Model.Interface;
@@ -75,10 +76,15 @@ internal class CyclopsRoom : DarkLocation
 
         // Issue #316: accept the canonical walkthrough phrasing "say Ulysses" as well as the bare
         // name, with or without surrounding quotes (e.g. say "Ulysses"). Strip a leading "say "
-        // verb prefix and any wrapping quotes before matching so every form triggers the flee.
+        // verb prefix (any Verbs.SayVerbs synonym) and any wrapping quotes before matching so every
+        // form triggers the flee.
         var normalized = input.ToLower().Trim();
-        if (normalized.StartsWith("say "))
-            normalized = normalized[4..].Trim();
+        foreach (var sayVerb in Verbs.SayVerbs)
+            if (normalized.StartsWith(sayVerb + " "))
+            {
+                normalized = normalized[(sayVerb.Length + 1)..].Trim();
+                break;
+            }
         normalized = normalized.Trim('"', '\'', '“', '”', '‘', '’').Trim();
 
         if (!new List<string> { "ulysses", "odysseus" }.Contains(normalized)

--- a/ZorkOne/Location/MazeLocation/CyclopsRoom.cs
+++ b/ZorkOne/Location/MazeLocation/CyclopsRoom.cs
@@ -73,7 +73,13 @@ internal class CyclopsRoom : DarkLocation
         if (string.IsNullOrEmpty(input))
             return await base.RespondToSpecificLocationInteraction(input, context, client);
 
-        if (!new List<string> { "ulysses", "odysseus" }.Contains(input.ToLower().Trim())
+        // Issue #316: accept the canonical walkthrough phrasing "say Ulysses" as well as the bare
+        // name. Strip a leading "say " verb prefix before matching so both forms trigger the flee.
+        var normalized = input.ToLower().Trim();
+        if (normalized.StartsWith("say "))
+            normalized = normalized[4..].Trim();
+
+        if (!new List<string> { "ulysses", "odysseus" }.Contains(normalized)
             || !HasItem<Cyclops>()
             || GetItem<Cyclops>().IsSleeping)
             return await base.RespondToSpecificLocationInteraction(input, context, client);

--- a/ZorkOne/Location/MazeLocation/CyclopsRoom.cs
+++ b/ZorkOne/Location/MazeLocation/CyclopsRoom.cs
@@ -75,16 +75,14 @@ internal class CyclopsRoom : DarkLocation
             return await base.RespondToSpecificLocationInteraction(input, context, client);
 
         // Issue #316: accept the canonical walkthrough phrasing "say Ulysses" as well as the bare
-        // name, with or without surrounding quotes (e.g. say "Ulysses"). Strip a leading "say "
-        // verb prefix (any Verbs.SayVerbs synonym) and any wrapping quotes before matching so every
-        // form triggers the flee.
+        // name, with or without surrounding quotes (e.g. say "Ulysses"). Strip a leading speak-aloud
+        // verb prefix and any wrapping quotes before matching so every form triggers the flee. We
+        // exclude "tell" from Verbs.SayVerbs because it is a *named*-address lead-in ("tell floyd …"),
+        // not untargeted speech — matching the precedent in ConversationHandler.NamelessSpeechVerbs.
         var normalized = input.ToLower().Trim();
-        foreach (var sayVerb in Verbs.SayVerbs)
-            if (normalized.StartsWith(sayVerb + " "))
-            {
-                normalized = normalized[(sayVerb.Length + 1)..].Trim();
-                break;
-            }
+        var matchedVerb = Verbs.SayVerbs.FirstOrDefault(v => v != "tell" && normalized.StartsWith(v + " "));
+        if (matchedVerb != null)
+            normalized = normalized[(matchedVerb.Length + 1)..].Trim();
         normalized = normalized.Trim('"', '\'', '“', '”', '‘', '’').Trim();
 
         if (!new List<string> { "ulysses", "odysseus" }.Contains(normalized)

--- a/ZorkOne/Location/MazeLocation/CyclopsRoom.cs
+++ b/ZorkOne/Location/MazeLocation/CyclopsRoom.cs
@@ -74,10 +74,12 @@ internal class CyclopsRoom : DarkLocation
             return await base.RespondToSpecificLocationInteraction(input, context, client);
 
         // Issue #316: accept the canonical walkthrough phrasing "say Ulysses" as well as the bare
-        // name. Strip a leading "say " verb prefix before matching so both forms trigger the flee.
+        // name, with or without surrounding quotes (e.g. say "Ulysses"). Strip a leading "say "
+        // verb prefix and any wrapping quotes before matching so every form triggers the flee.
         var normalized = input.ToLower().Trim();
         if (normalized.StartsWith("say "))
             normalized = normalized[4..].Trim();
+        normalized = normalized.Trim('"', '\'', '“', '”', '‘', '’').Trim();
 
         if (!new List<string> { "ulysses", "odysseus" }.Contains(normalized)
             || !HasItem<Cyclops>()


### PR DESCRIPTION
## Summary

Fixes #316 — in the Cyclops Room, the canonical Zork I solution phrase `say Ulysses` had no effect. Only the bare name `Ulysses`/`Odysseus` dismissed the cyclops, so a player following any standard walkthrough got a misleading "no effect" message on the room's main puzzle.

## Root cause

`CyclopsRoom.RespondToSpecificLocationInteraction` matched the **raw** input against `{"ulysses", "odysseus"}`. `"say ulysses"` was never in that list, so it fell through to the base handler and returned no-effect. The `say` verb prefix was never stripped.

## Changes

- **Strip a leading say-verb prefix before matching.** Uses `Verbs.SayVerbs` (`say`, `speak`, `utter`, `shout`, `yell`, `whisper`, `recite`, …) as the single source of truth rather than a hardcoded `"say "`.
- **Strip wrapping quotes** (straight and curly, single and double) so quoted forms like `say "Ulysses"` and `"Ulysses"` also work.

Both `Ulysses` and `Odysseus` continue to work bare, as before.

## Tests (TDD)

Added to `ZorkOne.Tests/People/CyclopsTests.cs`:
- `SayUlysses_Response`, `SayOdysseus_Response` — the `say <name>` forms
- `SayUlyssesInQuotes_Response`, `UlyssesInQuotes_Response` — quoted forms
- `SayVerbSynonyms_DismissTheCyclops` — parameterized over `speak`/`utter`/`shout`/`whisper`/`recite` (quoted and unquoted)

Red confirmed before the fix (no-effect instead of flee), green after. Full `ZorkOne.Tests` suite: **1312 passed, 0 failed**.

## Original behavior (ZIL — ground truth)

In the original Zork I, `SAY ULYSSES` is the documented solution; the V-SAY routine triggered the cyclops-flee regardless of whether `say` prefixed the name. This restores that behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
