### PR TITLE
Follow-up #324: fix Path setter cache staleness and align [JsonIgnore] style

### DIFF
--- a/Planetfall.Tests/ComputerTerminalTests.cs
+++ b/Planetfall.Tests/ComputerTerminalTests.cs
@@ -502,4 +502,19 @@ public class ComputerTerminalTests : EngineTestsBase
             "pressing 0 from a leaf should navigate up to the parent submenu, not feep");
         response.Should().NotContain(MenuState.NoEffect);
     }
+
+    [Test]
+    public void MenuState_Should_InvalidateCurrentItemCache_When_PathIsDirectlyReassigned()
+    {
+        // Prove that assigning Path directly (as the JSON deserializer does) invalidates
+        // the cached CurrentItem so the new path is reflected on next access.
+        var state = new MenuState();
+        state.GoDown(1); // navigate into History submenu; warms the cache
+        var before = state.CurrentItem;
+
+        state.Path = [2]; // direct reassignment — simulates JSON deserializer
+
+        state.CurrentItem.Should().NotBeSameAs(before,
+            "reassigning Path must invalidate the cache so CurrentItem reflects the new path");
+    }
 }

--- a/Planetfall/Item/Lawanda/Library/Computer/MenuState.cs
+++ b/Planetfall/Item/Lawanda/Library/Computer/MenuState.cs
@@ -1,3 +1,5 @@
+using Newtonsoft.Json;
+
 namespace Planetfall.Item.Lawanda.Library.Computer;
 
 /// <summary>
@@ -11,18 +13,27 @@ public class MenuState
     internal const string ReachedLowestLevel =
         "\"Yuu hav reect xe loowist levul uv xe liibreree indeks. Pleez tiip zeeroo tuu goo tuu aa hiiyur levul. If yuu reekwiir asistins, kawl xe liibrereein.\"";
 
+    private List<int> _path = [];
+
     // Breadcrumb path: 1-based child indices from the root. Empty = at MainMenu.
     // Storing the path (not the MenuItem object) is what survives JSON serialization —
-    // MenuItem.Parent is internal so Newtonsoft.Json skips it, making CurrentItem.Parent
+    // MenuItem.Parent was internal so Newtonsoft.Json skipped it, making CurrentItem.Parent
     // null after a round-trip and breaking GoUp() (issue #323).
-    [UsedImplicitly] public List<int> Path { get; set; } = [];
+    // The setter invalidates _current so the cache never returns a stale result if Path
+    // is reassigned (e.g. by the JSON deserializer on a new instance).
+    [UsedImplicitly]
+    public List<int> Path
+    {
+        get => _path;
+        set { _path = value; _current = null; }
+    }
 
     // Cached result of walking Path from the root. Invalidated whenever Path mutates.
-    [Newtonsoft.Json.JsonIgnore] private MenuItem? _current;
+    [JsonIgnore] private MenuItem? _current;
 
     // Computed from Path; cached so repeated accesses within one method call don't
     // re-allocate a fresh child list at every level.
-    [Newtonsoft.Json.JsonIgnore]
+    [JsonIgnore]
     public MenuItem CurrentItem => _current ??= BuildCurrentItem();
 
     private MenuItem BuildCurrentItem()


### PR DESCRIPTION
Two small follow-ups from the [PR #324](https://github.com/arsindelve/ZorkAI/pull/324) review thread.

## Changes

**Cache staleness** — `MenuState.Path` had a plain auto-property setter. If `Path` were ever assigned directly on an already-navigated instance (the JSON deserializer does this on a fresh instance where `_current` is already `null`, so no live bug today), the cached `_current` would not be invalidated. Added a backing field `_path` with an explicit setter that nulls `_current` on every assignment, closing the latent footgun.

**Style alignment** — `[Newtonsoft.Json.JsonIgnore]` was fully qualified. Every other file in the codebase (`Context.cs`, `PlanetfallContext.cs`, etc.) uses `using Newtonsoft.Json;` + bare `[JsonIgnore]`. Aligned to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)