### PR TITLE
Fix #116: real disease death clock + working medicine vial (Planetfall)

### DIFF
--- a/Planetfall.Tests/SicknessSystemTests.cs
+++ b/Planetfall.Tests/SicknessSystemTests.cs
@@ -1,0 +1,228 @@
+using FluentAssertions;
+using GameEngine;
+using Model.Interface;
+using Moq;
+using Planetfall.Item.Feinstein;
+using Planetfall.Item.Lawanda;
+using Planetfall.Location.Kalamontee;
+using Utilities;
+
+namespace Planetfall.Tests;
+
+/// <summary>
+/// Tests for the Planetfall disease mechanic (issue #116). The disease is a death clock that
+/// advances one level per day, steadily eats carrying capacity (10 per level, mirroring the
+/// original's LOAD-ALLOWED), kills the player at level 9, and can be partially rolled back by
+/// drinking the experimental medicine vial.
+///
+/// ZIL ground truth (read-only reference): globals.zil:2330-2369 (progression + death),
+/// comptwo.zil:170-185 (the medicine effect).
+/// </summary>
+public class SicknessSystemTests : EngineTestsBase
+{
+    [SetUp]
+    public void DisableRandomDreams()
+    {
+        // Wake-up triggers a random dream; force it off so the wake/death assertions are deterministic.
+        var chooser = new Mock<IRandomChooser>();
+        chooser.Setup(c => c.RollDice(It.IsAny<int>())).Returns(100);
+        chooser.Setup(c => c.RollDiceSuccess(It.IsAny<int>())).Returns(false);
+        SleepEngine.Chooser = chooser.Object;
+    }
+
+    [TearDown]
+    public void ResetChooser()
+    {
+        SleepEngine.Chooser = new RandomChooser();
+    }
+
+    [Test]
+    public void SicknessCounter_StartsAtOne()
+    {
+        var context = GetTarget().Context;
+        context.SicknessCounter.Should().Be(1);
+    }
+
+    [Test]
+    public void SicknessDescription_DerivesFromCounter_NotDay()
+    {
+        var context = GetTarget().Context;
+
+        // Bumping the day must NOT change the health description - only the mutable counter does.
+        context.Day = 7;
+        context.SicknessCounter = 3;
+        context.SicknessDescription.Should().Be("You feel a bit sick and feverish. ");
+
+        context.SicknessCounter = 1;
+        context.SicknessDescription.Should().Be("You are in perfect health. ");
+    }
+
+    [Test]
+    public void EachSickDay_RaisesLevel_AndLowersCarryLimitByTen()
+    {
+        var target = GetTarget();
+        var context = target.Context;
+        StartHere<BedLocation>();
+
+        context.SicknessCounter = 3;
+        var limitBefore = context.EffectiveLoadAllowed;
+
+        context.SleepNotifications.QueueFallAsleep(context.CurrentTime);
+        var result = SleepEngine.ProcessFallAsleep(context);
+
+        context.SicknessCounter.Should().Be(4);
+        context.EffectiveLoadAllowed.Should().Be(limitBefore - 10);
+        // Symptom/health description reflects the new level.
+        context.SicknessDescription.Should().Be("You feel a bit sick and feverish. ");
+        result.Should().NotBeNull();
+    }
+
+    [Test]
+    public void CarryLimit_DropsTenPerSicknessLevel()
+    {
+        var context = GetTarget().Context;
+
+        context.SicknessCounter = 1;
+        var fullLimit = context.EffectiveLoadAllowed;
+
+        context.SicknessCounter = 2;
+        context.EffectiveLoadAllowed.Should().Be(fullLimit - 10);
+
+        context.SicknessCounter = 5;
+        context.EffectiveLoadAllowed.Should().Be(fullLimit - 40);
+    }
+
+    [Test]
+    public void HaveRoomForItem_RejectsWhenOverEffectiveLimit()
+    {
+        var context = GetTarget().Context;
+        var brush = GetItem<Brush>();
+
+        // Healthy: there is plenty of room.
+        context.SicknessCounter = 1;
+        var fullLimit = context.EffectiveLoadAllowed;
+        context.HaveRoomForItem(brush).Should().BeTrue();
+
+        // Crank the disease high enough to drive the effective load limit to zero; now there is no room.
+        context.SicknessCounter = 1 + fullLimit / 10 + 1;
+        context.EffectiveLoadAllowed.Should().BeLessThanOrEqualTo(0);
+        context.HaveRoomForItem(brush).Should().BeFalse();
+    }
+
+    [Test]
+    public void ReachingLevelNine_KillsPlayerWithIllnessText()
+    {
+        var target = GetTarget();
+        var context = target.Context;
+        StartHere<BedLocation>();
+
+        context.Day = 8;
+        context.SicknessCounter = 8;
+        context.SleepNotifications.QueueFallAsleep(context.CurrentTime);
+
+        var result = SleepEngine.ProcessFallAsleep(context);
+
+        context.SicknessCounter.Should().Be(9);
+        result.Should().Contain("You finally succumb to the ravages of your illness and collapse.");
+        result.Should().Contain("You have died");
+    }
+
+    [Test]
+    public void Untreated_StillDiesOnSchedule()
+    {
+        // Regression of current behavior: with no treatment the disease tracks the day and the
+        // player dies on the ninth day's wake-up.
+        var target = GetTarget();
+        var context = target.Context;
+        StartHere<BedLocation>();
+
+        // Default counter equals the starting day (1); walk both forward in lock-step.
+        for (var day = 1; day <= 7; day++)
+        {
+            context.SleepNotifications.QueueFallAsleep(context.CurrentTime);
+            var midResult = SleepEngine.ProcessFallAsleep(context);
+            midResult.Should().NotContain("You have died");
+        }
+
+        // Eighth sleep takes the counter to 9 -> death.
+        context.SleepNotifications.QueueFallAsleep(context.CurrentTime);
+        var result = SleepEngine.ProcessFallAsleep(context);
+        result.Should().Contain("You have died");
+    }
+
+    [Test]
+    public void DrinkingMedicine_LowersSicknessByTwo_AndRestoresTwentyCapacity()
+    {
+        var context = GetTarget().Context;
+        var medicine = GetItem<Medicine>();
+
+        context.SicknessCounter = 5;
+        var limitBefore = context.EffectiveLoadAllowed;
+
+        var (message, wasConsumed) = medicine.OnDrinking(context);
+
+        context.SicknessCounter.Should().Be(3);
+        context.EffectiveLoadAllowed.Should().Be(limitBefore + 20);
+        message.Should().Contain("bitter");
+        wasConsumed.Should().BeTrue(); // one-shot: the engine destroys the medicine after drinking
+    }
+
+    [Test]
+    public void DrinkingMedicine_PushesDeathBackTwoDays()
+    {
+        var target = GetTarget();
+        var context = target.Context;
+        StartHere<BedLocation>();
+
+        context.Day = 8;
+        context.SicknessCounter = 8;
+
+        // Treat the disease: level 8 -> 6, so it now takes three more sick days to reach 9.
+        GetItem<Medicine>().OnDrinking(context);
+        context.SicknessCounter.Should().Be(6);
+
+        // The very next wake-up no longer kills - the clock was rolled back.
+        context.SleepNotifications.QueueFallAsleep(context.CurrentTime);
+        var result = SleepEngine.ProcessFallAsleep(context);
+
+        context.SicknessCounter.Should().Be(7);
+        result.Should().NotContain("You have died");
+    }
+
+    [Test]
+    public void DrinkingMedicine_NeverDropsBelowLevelOne()
+    {
+        var context = GetTarget().Context;
+
+        context.SicknessCounter = 1;
+        GetItem<Medicine>().OnDrinking(context);
+
+        context.SicknessCounter.Should().Be(1);
+    }
+
+    [Test]
+    public async Task DrinkingMedicineThroughEngine_IsOneShot_AndEmptiesTheBottle()
+    {
+        var target = GetTarget();
+        var context = target.Context;
+
+        context.SicknessCounter = 5;
+
+        // Hold the open bottle (with its medicine inside) so the drink command can reach it.
+        var bottle = GetItem<MedicineBottle>();
+        bottle.IsOpen = true;
+        context.ItemPlacedHere(bottle);
+        bottle.Items.Should().ContainSingle();
+
+        var first = await target.GetResponse("drink medicine");
+        first.Should().Contain("bitter");
+        context.SicknessCounter.Should().Be(3);
+
+        // One-shot: the medicine is gone and the bottle is now empty.
+        bottle.Items.Should().BeEmpty();
+
+        // A second drink does nothing to the disease.
+        await target.GetResponse("drink medicine");
+        context.SicknessCounter.Should().Be(3);
+    }
+}

--- a/Planetfall.Tests/SleepEngineTests.cs
+++ b/Planetfall.Tests/SleepEngineTests.cs
@@ -435,12 +435,15 @@ public class SleepEngineTests : EngineTestsBase
         var pfContext = target.Context;
         StartHere<BedLocation>();
 
+        // Issue #116: death is now driven by the sickness counter reaching 9, not the calendar day.
+        // Untreated, the counter tracks the day, so the ninth night still kills the player.
         pfContext.Day = 8;
+        pfContext.SicknessCounter = 8;
         pfContext.SleepNotifications.QueueFallAsleep(pfContext.CurrentTime);
 
         var result = SleepEngine.ProcessFallAsleep(pfContext);
 
-        result.Should().Contain("don't seem to have survived the night");
+        result.Should().Contain("You finally succumb to the ravages of your illness and collapse.");
         result.Should().Contain("You have died");
     }
 

--- a/Planetfall/Item/Lawanda/Medicine.cs
+++ b/Planetfall/Item/Lawanda/Medicine.cs
@@ -6,8 +6,12 @@ internal class Medicine : ItemBase, IAmADrink
 
     public (string Message, bool WasConsumed) OnDrinking(IContext context)
     {
+        // Issue #116: the experimental disease-suppression medicine (comptwo.zil:170-185) rolls the
+        // sickness clock back two levels, which also restores 20 carrying capacity (EffectiveLoadAllowed is
+        // derived from the counter). It's a one-shot stopgap: returning WasConsumed = true makes the engine
+        // destroy the medicine, emptying the bottle so a second drink finds nothing.
         if (context is PlanetfallContext pc)
-            pc.HasTakenExperimentalMedicine = true;
+            pc.SicknessCounter = Math.Max(1, pc.SicknessCounter - 2);
 
         return ("The medicine tasted extremely bitter. ", true);
     }

--- a/Planetfall/Item/Lawanda/MedicineBottle.cs
+++ b/Planetfall/Item/Lawanda/MedicineBottle.cs
@@ -22,7 +22,8 @@ internal class MedicineBottle : OpenAndCloseContainerBase, ICanBeTakenAndDropped
                    : "");
     }
 
-    // TODO: The medicine bottle is now empty.
+    // Issue #116: drinking the medicine is one-shot - the engine destroys the Medicine on consumption,
+    // so Items.Any() goes false and the descriptions above stop mentioning the contents (empty bottle).
 
     public override string NeverPickedUpDescription(ILocation currentLocation)
     {

--- a/Planetfall/PlanetfallContext.cs
+++ b/Planetfall/PlanetfallContext.cs
@@ -55,7 +55,37 @@ public class PlanetfallContext : Context<PlanetfallGame>, ITimeBasedContext, ISu
 
     [UsedImplicitly] public TiredLevel Tired { get; set; } = TiredLevel.WellRested;
 
-    [UsedImplicitly] public bool HasTakenExperimentalMedicine { get; set; }
+    /// <summary>
+    ///     Issue #116: the disease is a real death clock, not a cosmetic day-derived value. This mutable
+    ///     counter advances one level per day (in <see cref="SleepEngine"/> on waking), reaching 9 = death.
+    ///     The experimental medicine vial rolls it back two levels. It starts at 1 (== the opening Day), so
+    ///     an untreated player's level tracks the day and they still die on the original day-9 schedule;
+    ///     treating the disease decouples the two and pushes death back. Mirrors the original's
+    ///     SICKNESS-LEVEL (globals.zil:2330-2369).
+    /// </summary>
+    [UsedImplicitly] public int SicknessCounter { get; set; } = 1;
+
+    /// <summary>
+    ///     Base carrying capacity before any disease penalty. Mirrors the original's LOAD-ALLOWED default.
+    /// </summary>
+    private const int BaseLoadAllowed = 100;
+
+    /// <summary>
+    ///     Issue #116: each sick level above the first shaves 10 off the carrying capacity, mirroring the
+    ///     original daemon's `LOAD-ALLOWED -= 10` per sick day (globals.zil:2330). Drinking the medicine
+    ///     drops the sickness level by two, which restores 20 - exactly the original's `LOAD-ALLOWED += 20`
+    ///     (comptwo.zil:170-185).
+    /// </summary>
+    public int EffectiveLoadAllowed => BaseLoadAllowed - 10 * Math.Max(0, SicknessCounter - 1);
+
+    /// <summary>
+    ///     Issue #116: enforce the disease's carrying-capacity squeeze. Planetfall previously had no weight
+    ///     limit at all; now the effective limit shrinks as the player gets sicker.
+    /// </summary>
+    public override bool HaveRoomForItem(IItem item)
+    {
+        return CalculateTotalSize() + item.Size <= EffectiveLoadAllowed;
+    }
 
     /// <summary>
     /// Flag indicating that sleep was just processed this turn.
@@ -85,7 +115,9 @@ public class PlanetfallContext : Context<PlanetfallGame>, ITimeBasedContext, ISu
     [UsedImplicitly]
     public HashSet<string> UsedFloydActionCommentPrompts { get; set; } = [];
 
-    public string SicknessDescription => ((SicknessLevel)Day).GetDescription();
+    // Issue #116: derive the health description from the mutable sickness counter, not the calendar day,
+    // so treating the disease actually changes how the player feels. Clamp into the enum's 1-8 range.
+    public string SicknessDescription => ((SicknessLevel)Math.Clamp(SicknessCounter, 1, 8)).GetDescription();
     
     [UsedImplicitly]
     public int CurrentTime => Repository.GetItem<Chronometer>().CurrentTime;

--- a/Planetfall/SleepEngine.cs
+++ b/Planetfall/SleepEngine.cs
@@ -136,10 +136,14 @@ public class SleepEngine
         // Advance day
         context.Day++;
 
-        // Check for day 9 death
-        if (context.Day >= 9)
+        // Issue #116: advance the disease one level per day (mirrors the I-SICKNESS-WARNINGS daemon's
+        // once-per-day SICKNESS-LEVEL increment, globals.zil:2330). Death is tied to the sickness counter,
+        // not the calendar - so treating the illness (which lowers the counter) actually postpones death.
+        // Untreated, the counter tracks the day and the player still dies on the original day-9 schedule.
+        context.SicknessCounter++;
+        if (context.SicknessCounter >= 9)
             return new DeathProcessor().Process(
-                "Unfortunately, you don't seem to have survived the night.",
+                "You finally succumb to the ravages of your illness and collapse.",
                 context).InteractionMessage;
 
         // Reset chronometer to morning time for the new day
@@ -192,8 +196,9 @@ public class SleepEngine
         }
         else
         {
-            // Health-based message (sickness gets worse each day)
-            var sicknessLevel = (SicknessLevel)context.Day;
+            // Health-based message (sickness gets worse each day). Issue #116: read the mutable sickness
+            // counter, not the calendar day, so a treated player wakes feeling better.
+            var sicknessLevel = (SicknessLevel)Math.Clamp(context.SicknessCounter, 1, 8);
             if (sicknessLevel < SicknessLevel.Meh)
                 message += "You wake up feeling refreshed and ready to face the challenges of this mysterious world. ";
             else if (sicknessLevel < SicknessLevel.ReallySick)


### PR DESCRIPTION
Closes #116.

The Planetfall disease was cosmetic: sickness was derived from the day number, death was a fixed day-9 sleep death, the carrying-capacity penalty was missing, and the experimental medicine vial did nothing (it set a flag nothing ever read). This makes the disease a real **death clock you can partially reset**, mirroring the original.

## Changes

**`PlanetfallContext`**
- Add a mutable `SicknessCounter` (starts at `1`, == the opening `Day`) — the single source of truth for the disease, decoupled from the calendar.
- `SicknessDescription` now derives from the counter instead of `Day`, so treating the disease actually changes how the player feels.
- Add `EffectiveLoadAllowed` = base `100` − `10` per sick level (mirrors the original's `LOAD-ALLOWED`) and override `HaveRoomForItem` so carrying capacity shrinks as the player gets sicker. (Planetfall previously had no weight limit at all.)

**`SleepEngine`**
- Advance `SicknessCounter` one level per day on waking (mirrors the `I-SICKNESS-WARNINGS` daemon) and kill the player at **level 9** with the illness death text — *"You finally succumb to the ravages of your illness and collapse."* — replacing the calendar day-9 death. Untreated, the counter tracks the day so death still lands on the day-9 schedule; treating the disease postpones it.
- Wake-up health message reads the counter too.

**`Medicine` / `MedicineBottle`**
- `Medicine.OnDrinking` rolls the sickness level back two (which restores 20 capacity via the derived limit), replacing the now-removed unread `HasTakenExperimentalMedicine` flag. One-shot: `WasConsumed` makes the engine destroy the medicine, emptying the bottle (resolves the stale `// TODO` there).

## Tests (TDD)

New `SicknessSystemTests` (11 tests) covers: per-day level escalation + the −10 capacity drop, symptom/description matching the level, the level-9 illness death, untreated death-on-schedule (regression of current behavior), the medicine effect (−2 level / +20 capacity / level-1 floor), death postponement after treatment, and the one-shot bottle emptying through the real engine. Updated the existing day-9 death test for the new sickness-driven death.

Each behavioral test was confirmed to fail against the pre-fix behavior (inert vial; calendar death) and pass after. Full Planetfall suite green: **2435 passed, 0 failed**.

ZIL ground truth used read-only for verification (no code copied): `globals.zil:2330-2369` (progression + death), `comptwo.zil:170-185` (medicine effect).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QGnAcizp69ictUnUUN9BpN

---
_Generated by [Claude Code](https://claude.ai/code/session_01QGnAcizp69ictUnUUN9BpN)_