### PR TITLE
Fix mailbox examination contents

### DIFF
--- a/ZorkOne.Tests/Things/MailboxTests.cs
+++ b/ZorkOne.Tests/Things/MailboxTests.cs
@@ -1,0 +1,36 @@
+using FluentAssertions;
+using GameEngine;
+using ZorkOne.Location;
+
+namespace ZorkOne.Tests.Things;
+
+public class MailboxTests : EngineTestsBase
+{
+    [Test]
+    public async Task Should_ListContents_When_ExaminingOpenMailbox()
+    {
+        var target = GetTarget();
+        target.Context.CurrentLocation = Repository.GetLocation<WestOfHouse>();
+
+        await target.GetResponse("open mailbox");
+        var response = await target.GetResponse("examine mailbox");
+
+        response.Should().Contain("leaflet");
+        response.Should().NotBe("It's open. ");
+    }
+
+    [Test]
+    public async Task Should_SayEmpty_When_ExaminingOpenEmptyMailbox()
+    {
+        var target = GetTarget();
+        target.Context.CurrentLocation = Repository.GetLocation<WestOfHouse>();
+
+        await target.GetResponse("open mailbox");
+        await target.GetResponse("take leaflet");
+        var response = await target.GetResponse("examine mailbox");
+
+        response.Should().Contain("open");
+        response.Should().Contain("empty");
+        response.Should().NotContain("leaflet");
+    }
+}

--- a/ZorkOne/Item/Mailbox.cs
+++ b/ZorkOne/Item/Mailbox.cs
@@ -11,7 +11,10 @@ public class Mailbox : OpenAndCloseContainerBase, ICanBeExamined
     public override string Name => "mailbox";
 
     public string ExaminationDescription =>
-        ((IOpenAndClose)this).IsOpen ? "It's open. " : "The small mailbox is closed. ";
+        ((IOpenAndClose)this).IsOpen
+            // Open containers must keep their contents visible on re-examination.
+            ? Items.Any() ? ItemListDescription("mailbox", null) : "The small mailbox is open and empty. "
+            : "The small mailbox is closed. ";
 
     public override string GenericDescription(ILocation? currentLocation)
     {


### PR DESCRIPTION
## Summary
- list mailbox contents when examining an open mailbox
- add regression tests for open mailbox with leaflet and open empty mailbox

Fixes #331

## Tests
- `& "C:\Program Files\JetBrains\Rider\r2r\2026.1.3R\C686829B693D123126FA3F333333994\windows-x64\dotnet\dotnet.exe" test ZorkOne.Tests --filter "FullyQualifiedName~MailboxTests"`
- `& "C:\Program Files\JetBrains\Rider\r2r\2026.1.3R\C686829B693D123126FA3F333333994\windows-x64\dotnet\dotnet.exe" test ZorkOne.Tests`
