### PR TITLE
[codex] Add Planetfall god mode clock reset

### DIFF
--- a/GameEngine/StaticCommand/Implementation/GodModeProcessor.cs
+++ b/GameEngine/StaticCommand/Implementation/GodModeProcessor.cs
@@ -19,6 +19,10 @@ public class GodModeProcessor : IGlobalCommand
         if (input.Contains(" go ")) return Task.FromResult(Go(input, context));
         if (input.Contains(" where ")) return Task.FromResult(Where(input));
 
+        if (context is IResettableClockContext clockContext &&
+            ResetClock(input, clockContext) is { } clockResetResult)
+            return Task.FromResult(clockResetResult);
+
         // Issue #277: toggle the survival clocks (sleep/hunger) for deterministic playtesting. Only
         // games whose context tracks those clocks (Planetfall) implement ISurvivalClockContext.
         if (context is ISurvivalClockContext survivalContext &&
@@ -26,6 +30,17 @@ public class GodModeProcessor : IGlobalCommand
             return Task.FromResult(survivalResult);
 
         return Task.FromResult("Invalid use of God mode. Bad adventurer! ");
+    }
+
+    private static string? ResetClock(string input, IResettableClockContext context)
+    {
+        var words = input.ToLowerInvariant().Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        if (!words.Contains("reset") || (!words.Contains("time") && !words.Contains("clock")))
+            return null;
+
+        const int walkthroughResetTime = 2000;
+        context.ResetClockForGodMode(walkthroughResetTime);
+        return $"God mode: chronometer reset to {walkthroughResetTime}.";
     }
 
     /// <summary>

--- a/Model/Interface/IResettableClockContext.cs
+++ b/Model/Interface/IResettableClockContext.cs
@@ -1,0 +1,14 @@
+namespace Model.Interface;
+
+/// <summary>
+///     Marker interface for game contexts with a clock that can be reset by god mode for deterministic
+///     playtesting. Games without a resettable clock do not implement this, so the command falls through
+///     to the generic god-mode error.
+/// </summary>
+public interface IResettableClockContext
+{
+    /// <summary>
+    ///     Resets the game's clock so it lands on the requested value after normal turn processing.
+    /// </summary>
+    void ResetClockForGodMode(int targetTime);
+}

--- a/Planetfall.Tests/ShuttleTests.cs
+++ b/Planetfall.Tests/ShuttleTests.cs
@@ -704,6 +704,26 @@ public class ShuttleTests : EngineTestsBase
         GetLocation<AlfieControlEast>().Activated.Should().BeFalse();
     }
 
+    [TestCase("god mode reset time")]
+    [TestCase("god mode reset clock")]
+    public async Task GodModeResetTime_AllowsAlfieActivationAfterEveningCutoff(string resetCommand)
+    {
+        var target = GetTarget();
+        Take<ShuttleAccessCard>();
+        StartHere<AlfieControlEast>();
+
+        Repository.GetItem<Chronometer>().CurrentTime = 6500;
+
+        var resetResponse = await target.GetResponse(resetCommand);
+        resetResponse.Should().Contain("God mode: chronometer reset to 2000.");
+        Repository.GetItem<Chronometer>().CurrentTime.Should().Be(2000);
+
+        var activationResponse = await target.GetResponse("slide shuttle access card through slot");
+
+        activationResponse.Should().Contain("A recording of a deep male voice says \"Shuttle controls activated.\"");
+        GetLocation<AlfieControlEast>().Activated.Should().BeTrue();
+    }
+
     [Test]
     public async Task PushLever_FloydCommentsWhenPresent()
     {

--- a/Planetfall/PlanetfallContext.cs
+++ b/Planetfall/PlanetfallContext.cs
@@ -6,8 +6,10 @@ using Utilities;
 
 namespace Planetfall;
 
-public class PlanetfallContext : Context<PlanetfallGame>, ITimeBasedContext, ISurvivalClockContext
+public class PlanetfallContext : Context<PlanetfallGame>, ITimeBasedContext, ISurvivalClockContext, IResettableClockContext
 {
+    private const int TurnTimeIncrement = 54;
+
     [UsedImplicitly]
     public int Day { get; set; } = 1;
 
@@ -238,9 +240,15 @@ public class PlanetfallContext : Context<PlanetfallGame>, ITimeBasedContext, ISu
 
     public override string? ProcessEndOfTurn()
     {
-        Repository.GetItem<Chronometer>().CurrentTime += 54;
+        Repository.GetItem<Chronometer>().CurrentTime += TurnTimeIncrement;
         SleepJustOccurred = false;
         return base.ProcessEndOfTurn();
+    }
+
+    public void ResetClockForGodMode(int targetTime)
+    {
+        // God-mode commands still take a Planetfall turn, so compensate for the end-of-turn tick.
+        Repository.GetItem<Chronometer>().CurrentTime = targetTime - TurnTimeIncrement;
     }
 
     /// <summary>

--- a/UnitTests/GlobalCommands/GodModeTests.cs
+++ b/UnitTests/GlobalCommands/GodModeTests.cs
@@ -19,4 +19,14 @@ public class GodModeTests : EngineTestsBase
         var kitchen = Repository.GetLocation<Kitchen>();
         kitchen.Items.Should().OnlyHaveUniqueItems();
     }
+
+    [Test]
+    public async Task GodModeResetTime_IsInvalidOutsidePlanetfall()
+    {
+        var engine = GetTarget();
+
+        var response = await engine.GetResponse("god mode reset time");
+
+        response.Should().Contain("Invalid use of God mode. Bad adventurer!");
+    }
 }


### PR DESCRIPTION
## Summary

- Add `god mode reset time` / `god mode reset clock` through the existing shared `GodModeProcessor` path.
- Add a resettable-clock context capability implemented by `PlanetfallContext`, so games without a resettable clock still get the generic god-mode error.
- Reset Planetfall's chronometer to the walkthrough's deterministic `2000` value after normal end-of-turn clock processing.

Fixes #333.

## Validation

- `& "C:\Program Files\JetBrains\Rider\r2r\2026.1.3R\C686829B693D123126FA3F333333994\windows-x64\dotnet\dotnet.exe" test Planetfall.Tests --filter "FullyQualifiedName~GodModeResetTime_AllowsAlfieActivationAfterEveningCutoff"`
- `& "C:\Program Files\JetBrains\Rider\r2r\2026.1.3R\C686829B693D123126FA3F333333994\windows-x64\dotnet\dotnet.exe" test Planetfall.Tests`
- `& "C:\Program Files\JetBrains\Rider\r2r\2026.1.3R\C686829B693D123126FA3F333333994\windows-x64\dotnet\dotnet.exe" test UnitTests`

Generated with Codex.
