### PR TITLE
[codex] Fix Aragain Falls down warning

### DIFF
--- a/ZorkOne.Tests/GameSpecificTests.cs
+++ b/ZorkOne.Tests/GameSpecificTests.cs
@@ -210,4 +210,16 @@ public class GameSpecificTests : EngineTestsBase
         Repository.GetItem<Leaflet>().CurrentLocation.Should().BeNull();
         target.Context.HasItem<Leaflet>().Should().BeFalse();
     }
+
+    [Test]
+    public async Task AragainFalls_Down_ReturnsFallsSpecificWarning()
+    {
+        var target = GetTarget();
+        target.Context.CurrentLocation = Repository.GetLocation<AragainFalls>();
+
+        var response = await target.GetResponse("down");
+
+        response.Should().Contain("It's a long way...");
+        target.Context.CurrentLocation.Should().BeOfType<AragainFalls>();
+    }
 }

--- a/ZorkOne/Location/AragainFalls.cs
+++ b/ZorkOne/Location/AragainFalls.cs
@@ -21,6 +21,12 @@ public class AragainFalls : LocationWithNoStartingItems
                 Direction.W,
                 new MovementParameters
                     { CanGo = _ => GetLocation<EndOfRainbow>().RainbowIsSolid, Location = GetLocation<OnTheRainbow>() }
+            },
+            {
+                // Original Zork gives Aragain Falls a room-specific warning here instead of
+                // falling through to the generic blocked-movement response.
+                Direction.Down,
+                new MovementParameters { CanGo = _ => false, CustomFailureMessage = "It's a long way..." }
             }
         };
     }


### PR DESCRIPTION
## Summary
- Add an Aragain Falls `down` movement entry with the canonical room-specific warning.
- Add a Zork I regression test proving `down` returns `It's a long way...` and leaves the player at Aragain Falls.

## Root Cause
`AragainFalls` did not define `Direction.Down`, so movement fell through to the generic `You cannot go that way.` response. The original ZIL room definition includes a dedicated DOWN failure message at `zork1/1dungeon.zil:2323`.

## Validation
- `C:\Users\arsin\.dotnet\dotnet.exe test ZorkOne.Tests --filter "FullyQualifiedName~AragainFallsTests.Down_ReturnsFallsSpecificWarning"`
- `C:\Users\arsin\.dotnet\dotnet.exe test ZorkOne.Tests`

Fixes #335