### PR TITLE
[codex] Fix rainbow local-global actions

### DIFF
--- a/UnitTests/TestParser.cs
+++ b/UnitTests/TestParser.cs
@@ -28,7 +28,7 @@ public class TestParser : IntentParser
             "drink", "use", "count", "touch", "read", "turn", "wave", "move", "ring", "activate", "search",
             "smell", "turn on", "turn off", "throw", "light", "rub", "kiss", "wind", "kick", "deflate",
             "lower", "raise", "get", "inflate", "leave", "unlock", "lock", "climb", "extend", "lift", "shake",
-            "oil", "lubricate"
+            "oil", "lubricate", "cross", "through", "look under"
         ];
 
         _allNouns = Repository.GetNouns(gameName);
@@ -42,7 +42,7 @@ public class TestParser : IntentParser
             "blue button", "brown button", "bolt", "bubble", "bodies", "gate", "lid", "switch", "slag", "engravings",
             "fromitz board", "board", "fromitz", "second fromitz board", "second board", "second",
             "second board", "second fromitz board", "second fromitz", "384",
-            "games", "tapes", "controls", "control panel", "light", "red light", "equipment"
+            "games", "tapes", "controls", "control panel", "light", "red light", "equipment", "rainbow"
         ];
 
         _allNouns = _allNouns.Union(specialNouns).ToArray();
@@ -141,6 +141,31 @@ public class TestParser : IntentParser
 
         // 4. Fallback: verb+noun matching after removing "the"
         input = input?.Replace("the ", "").Trim();
+
+        if (input?.StartsWith("look under ", StringComparison.OrdinalIgnoreCase) == true)
+        {
+            var noun = input["look under ".Length..].Trim();
+            if (_allNouns.Contains(noun))
+                return Task.FromResult<IntentBase>(new SimpleIntent
+                {
+                    Verb = "look under",
+                    Noun = noun,
+                    OriginalInput = input
+                });
+        }
+
+        if (input?.StartsWith("go through ", StringComparison.OrdinalIgnoreCase) == true)
+        {
+            var noun = input["go through ".Length..].Trim();
+            if (_allNouns.Contains(noun))
+                return Task.FromResult<IntentBase>(new SimpleIntent
+                {
+                    Verb = "go through",
+                    Noun = noun,
+                    OriginalInput = input
+                });
+        }
+
         var words = input?.Split(" ");
 
         if (words?.Length >= 2 && _verbs.Contains(words[0]) && _allNouns.Contains(words[1]))

--- a/UnitTests/TestParser.cs
+++ b/UnitTests/TestParser.cs
@@ -28,7 +28,7 @@ public class TestParser : IntentParser
             "drink", "use", "count", "touch", "read", "turn", "wave", "move", "ring", "activate", "search",
             "smell", "turn on", "turn off", "throw", "light", "rub", "kiss", "wind", "kick", "deflate",
             "lower", "raise", "get", "inflate", "leave", "unlock", "lock", "climb", "extend", "lift", "shake",
-            "oil", "lubricate", "cross", "through", "look under"
+            "oil", "lubricate", "cross", "through", "go"
         ];
 
         _allNouns = Repository.GetNouns(gameName);
@@ -148,8 +148,9 @@ public class TestParser : IntentParser
             if (_allNouns.Contains(noun))
                 return Task.FromResult<IntentBase>(new SimpleIntent
                 {
-                    Verb = "look under",
+                    Verb = "look",
                     Noun = noun,
+                    Adverb = "under",
                     OriginalInput = input
                 });
         }
@@ -160,8 +161,9 @@ public class TestParser : IntentParser
             if (_allNouns.Contains(noun))
                 return Task.FromResult<IntentBase>(new SimpleIntent
                 {
-                    Verb = "go through",
+                    Verb = "go",
                     Noun = noun,
+                    Adverb = "through",
                     OriginalInput = input
                 });
         }

--- a/ZorkOne.Tests/Places/AragainFallsTests.cs
+++ b/ZorkOne.Tests/Places/AragainFallsTests.cs
@@ -1,0 +1,53 @@
+using FluentAssertions;
+using GameEngine;
+using ZorkOne.Location;
+
+namespace ZorkOne.Tests.Places;
+
+[TestFixture]
+public class AragainFallsTests : EngineTestsBase
+{
+    [Test]
+    public async Task LookUnderRainbow_DescribesRiver()
+    {
+        var target = GetTarget();
+        target.Context.CurrentLocation = Repository.GetLocation<AragainFalls>();
+
+        var response = await target.GetResponse("look under rainbow");
+
+        response.Should().Contain("The Frigid River flows under the rainbow.");
+    }
+
+    [Test]
+    public async Task ThroughRainbow_WhenRainbowIsNotSolid_Refuses()
+    {
+        var target = GetTarget();
+        target.Context.CurrentLocation = Repository.GetLocation<AragainFalls>();
+
+        var response = await target.GetResponse("through rainbow");
+
+        response.Should().Contain("Can you walk on water vapor?");
+    }
+
+    [Test]
+    public async Task GoThroughRainbow_WhenRainbowIsNotSolid_Refuses()
+    {
+        var target = GetTarget();
+        target.Context.CurrentLocation = Repository.GetLocation<AragainFalls>();
+
+        var response = await target.GetResponse("go through rainbow");
+
+        response.Should().Contain("Can you walk on water vapor?");
+    }
+
+    [Test]
+    public async Task CrossRainbow_WhenRainbowIsNotSolid_Refuses()
+    {
+        var target = GetTarget();
+        target.Context.CurrentLocation = Repository.GetLocation<AragainFalls>();
+
+        var response = await target.GetResponse("cross rainbow");
+
+        response.Should().Contain("Can you walk on water vapor?");
+    }
+}

--- a/ZorkOne.Tests/Places/AragainFallsTests.cs
+++ b/ZorkOne.Tests/Places/AragainFallsTests.cs
@@ -1,5 +1,8 @@
 using FluentAssertions;
 using GameEngine;
+using Model.Intent;
+using Model.Interface;
+using Moq;
 using ZorkOne.Location;
 
 namespace ZorkOne.Tests.Places;
@@ -8,9 +11,37 @@ namespace ZorkOne.Tests.Places;
 public class AragainFallsTests : EngineTestsBase
 {
     [Test]
+    public async Task LookUnderRainbow_AtEndOfRainbow_DescribesRiver()
+    {
+        var target = GetTarget();
+        target.Context.CurrentLocation = Repository.GetLocation<EndOfRainbow>();
+
+        var response = await target.GetResponse("look under rainbow");
+
+        response.Should().Contain("The Frigid River flows under the rainbow.");
+    }
+
+    [Test]
     public async Task LookUnderRainbow_DescribesRiver()
     {
         var target = GetTarget();
+        target.Context.CurrentLocation = Repository.GetLocation<AragainFalls>();
+
+        var response = await target.GetResponse("look under rainbow");
+
+        response.Should().Contain("The Frigid River flows under the rainbow.");
+    }
+
+    [Test]
+    public async Task LookUnderRainbow_WithProductionParserShape_DescribesRiver()
+    {
+        var parser = ParserReturning(new SimpleIntent
+        {
+            Verb = "look",
+            Noun = "rainbow",
+            OriginalInput = "look under rainbow"
+        });
+        var target = GetTarget(parser.Object);
         target.Context.CurrentLocation = Repository.GetLocation<AragainFalls>();
 
         var response = await target.GetResponse("look under rainbow");
@@ -30,6 +61,23 @@ public class AragainFallsTests : EngineTestsBase
     }
 
     [Test]
+    public async Task GoThroughRainbow_WithProductionParserShape_Refuses()
+    {
+        var parser = ParserReturning(new SimpleIntent
+        {
+            Verb = "go",
+            Noun = "rainbow",
+            OriginalInput = "go through rainbow"
+        });
+        var target = GetTarget(parser.Object);
+        target.Context.CurrentLocation = Repository.GetLocation<AragainFalls>();
+
+        var response = await target.GetResponse("go through rainbow");
+
+        response.Should().Contain("Can you walk on water vapor?");
+    }
+
+    [Test]
     public async Task GoThroughRainbow_WhenRainbowIsNotSolid_Refuses()
     {
         var target = GetTarget();
@@ -41,6 +89,43 @@ public class AragainFallsTests : EngineTestsBase
     }
 
     [Test]
+    public async Task ThroughRainbow_AtEndOfRainbow_WhenRainbowIsNotSolid_Refuses()
+    {
+        var target = GetTarget();
+        target.Context.CurrentLocation = Repository.GetLocation<EndOfRainbow>();
+
+        var response = await target.GetResponse("through rainbow");
+
+        response.Should().Contain("Can you walk on water vapor?");
+    }
+
+    [Test]
+    public async Task CrossRainbow_AtEndOfRainbow_WhenRainbowIsSolid_MovesToAragainFalls()
+    {
+        var target = GetTarget();
+        target.Context.CurrentLocation = Repository.GetLocation<EndOfRainbow>();
+        Repository.GetLocation<EndOfRainbow>().RainbowIsSolid = true;
+
+        var response = await target.GetResponse("cross rainbow");
+
+        response.Should().Contain("Aragain Falls");
+        target.Context.CurrentLocation.Should().BeOfType<AragainFalls>();
+    }
+
+    [Test]
+    public async Task CrossRainbow_OnTheRainbow_WhenRainbowIsSolid_AsksForDirection()
+    {
+        var target = GetTarget();
+        target.Context.CurrentLocation = Repository.GetLocation<OnTheRainbow>();
+        Repository.GetLocation<EndOfRainbow>().RainbowIsSolid = true;
+
+        var response = await target.GetResponse("cross rainbow");
+
+        response.Should().Contain("You'll have to say which way...");
+        target.Context.CurrentLocation.Should().BeOfType<OnTheRainbow>();
+    }
+
+    [Test]
     public async Task CrossRainbow_WhenRainbowIsNotSolid_Refuses()
     {
         var target = GetTarget();
@@ -49,5 +134,17 @@ public class AragainFallsTests : EngineTestsBase
         var response = await target.GetResponse("cross rainbow");
 
         response.Should().Contain("Can you walk on water vapor?");
+    }
+
+    private static Mock<IIntentParser> ParserReturning(IntentBase intent)
+    {
+        var parser = new Mock<IIntentParser>();
+        parser.Setup(p => p.DetermineSystemIntentType(It.IsAny<string>())).Returns((IntentBase?)null);
+        parser.Setup(p => p.DetermineGlobalIntentType(It.IsAny<string>())).Returns((IntentBase?)null);
+        parser.Setup(p => p.ResolvePronounsAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<string?>()))
+            .ReturnsAsync((string?)null);
+        parser.Setup(p => p.DetermineComplexIntentType(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(intent);
+        return parser;
     }
 }

--- a/ZorkOne/Location/AragainFalls.cs
+++ b/ZorkOne/Location/AragainFalls.cs
@@ -44,14 +44,9 @@ public class AragainFalls : LocationWithNoStartingItems
     public override async Task<InteractionResult> RespondToSimpleInteraction(SimpleIntent action, IContext context,
         IGenerationClient client, IItemProcessorFactory itemProcessorFactory)
     {
-        if (action.Match(["cross"], ["rainbow"]))
-        {
-            if (!GetLocation<EndOfRainbow>().RainbowIsSolid)
-                return new PositiveInteractionResult("Can you walk on water vapor? ");
-
-            context.CurrentLocation = GetLocation<EndOfRainbow>();
-            return new PositiveInteractionResult(context.CurrentLocation.GetDescription(context));
-        }
+        var rainbowResult = RainbowInteraction.TryHandle(action, context, () => GetLocation<EndOfRainbow>());
+        if (rainbowResult is not null)
+            return rainbowResult;
 
         return await base.RespondToSimpleInteraction(action, context, client, itemProcessorFactory);
     }

--- a/ZorkOne/Location/EndOfRainbow.cs
+++ b/ZorkOne/Location/EndOfRainbow.cs
@@ -45,14 +45,9 @@ public class EndOfRainbow : LocationWithNoStartingItems
     public override async Task<InteractionResult> RespondToSimpleInteraction(SimpleIntent action, IContext context,
         IGenerationClient client, IItemProcessorFactory itemProcessorFactory)
     {
-        if (action.Match(["cross", "traverse"], ["rainbow"]))
-        {
-            if (!GetLocation<EndOfRainbow>().RainbowIsSolid)
-                return new PositiveInteractionResult("Can you walk on water vapor? ");
-
-            context.CurrentLocation = GetLocation<AragainFalls>();
-            return new PositiveInteractionResult(context.CurrentLocation.GetDescription(context));
-        }
+        var rainbowResult = RainbowInteraction.TryHandle(action, context, () => GetLocation<AragainFalls>());
+        if (rainbowResult is not null)
+            return rainbowResult;
 
         if (action.Match(["wave", "swing", "twirl"], GetItem<Sceptre>().NounsForMatching))
         {

--- a/ZorkOne/Location/OnTheRainbow.cs
+++ b/ZorkOne/Location/OnTheRainbow.cs
@@ -40,6 +40,10 @@ public class OnTheRainbow : LocationWithNoStartingItems
     public override async Task<InteractionResult> RespondToSimpleInteraction(SimpleIntent action, IContext context,
         IGenerationClient client, IItemProcessorFactory itemProcessorFactory)
     {
+        var rainbowResult = RainbowInteraction.TryHandle(action, context, () => null);
+        if (rainbowResult is not null)
+            return rainbowResult;
+
         if (action.Match(["wave", "swing", "twirl"], GetItem<Sceptre>().NounsForMatching))
         {
             if (!context.HasItem<Sceptre>() && GetItem<Sceptre>().CurrentLocation == GetLocation<EndOfRainbow>())

--- a/ZorkOne/Location/RainbowInteraction.cs
+++ b/ZorkOne/Location/RainbowInteraction.cs
@@ -1,0 +1,32 @@
+using GameEngine;
+using Model.Intent;
+using Model.Interface;
+using Model.Location;
+
+namespace ZorkOne.Location;
+
+internal static class RainbowInteraction
+{
+    private static readonly string[] RainbowNouns = ["rainbow"];
+    private static readonly string[] CrossRainbowVerbs = ["cross", "through", "traverse", "go through"];
+
+    public static InteractionResult? TryHandle(SimpleIntent action, IContext context, Func<ILocation?> destinationWhenSolid)
+    {
+        if (action.Match(["look under"], RainbowNouns))
+            return new PositiveInteractionResult("The Frigid River flows under the rainbow. ");
+
+        if (!action.Match(CrossRainbowVerbs, RainbowNouns))
+            return null;
+
+        // Zork treats RAINBOW as a local-global object; keep every rainbow room on one action table.
+        if (!Repository.GetLocation<EndOfRainbow>().RainbowIsSolid)
+            return new PositiveInteractionResult("Can you walk on water vapor? ");
+
+        var destination = destinationWhenSolid();
+        if (destination is null)
+            return new PositiveInteractionResult("You'll have to say which way... ");
+
+        context.CurrentLocation = destination;
+        return new PositiveInteractionResult(context.CurrentLocation.GetDescription(context));
+    }
+}

--- a/ZorkOne/Location/RainbowInteraction.cs
+++ b/ZorkOne/Location/RainbowInteraction.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using GameEngine;
 using Model.Intent;
 using Model.Interface;
@@ -8,14 +9,17 @@ namespace ZorkOne.Location;
 internal static class RainbowInteraction
 {
     private static readonly string[] RainbowNouns = ["rainbow"];
-    private static readonly string[] CrossRainbowVerbs = ["cross", "through", "traverse", "go through"];
+    private static readonly string[] CrossRainbowVerbs = ["cross", "through", "traverse"];
 
     public static InteractionResult? TryHandle(SimpleIntent action, IContext context, Func<ILocation?> destinationWhenSolid)
     {
-        if (action.Match(["look under"], RainbowNouns))
+        if (!action.MatchNounAndAdjective(RainbowNouns))
+            return null;
+
+        if (IsLookUnderRainbow(action))
             return new PositiveInteractionResult("The Frigid River flows under the rainbow. ");
 
-        if (!action.Match(CrossRainbowVerbs, RainbowNouns))
+        if (!IsCrossingRainbow(action))
             return null;
 
         // Zork treats RAINBOW as a local-global object; keep every rainbow room on one action table.
@@ -28,5 +32,28 @@ internal static class RainbowInteraction
 
         context.CurrentLocation = destination;
         return new PositiveInteractionResult(context.CurrentLocation.GetDescription(context));
+    }
+
+    private static bool IsLookUnderRainbow(SimpleIntent action)
+    {
+        return action.MatchVerb(["look"]) && IsAdverbOrOriginalInput(action, "under");
+    }
+
+    private static bool IsCrossingRainbow(SimpleIntent action)
+    {
+        return action.MatchVerb(CrossRainbowVerbs) ||
+               action.MatchVerb(["go", "walk", "move"]) && IsAdverbOrOriginalInput(action, "through");
+    }
+
+    private static bool IsAdverbOrOriginalInput(SimpleIntent action, string preposition)
+    {
+        if (action.Adverb?.Equals(preposition, StringComparison.OrdinalIgnoreCase) == true)
+            return true;
+
+        // The production parser often keeps single-noun prepositions only in OriginalInput.
+        var original = action.OriginalInput;
+        return !string.IsNullOrWhiteSpace(original) &&
+               Regex.IsMatch(original, $@"\b{Regex.Escape(preposition)}\s+(the\s+)?rainbow\b",
+                   RegexOptions.IgnoreCase);
     }
 }


### PR DESCRIPTION
## Summary

Fixes #336.

- Adds shared Zork I rainbow interaction handling for `cross`, `through`, `go through`, `traverse`, and `look under`.
- Wires the shared handler into Aragain Falls, End of Rainbow, and On the Rainbow so the local-global rainbow behavior stays consistent.
- Adds Aragain Falls regression tests for `look under rainbow`, `through rainbow`, `go through rainbow`, and existing `cross rainbow` behavior.
- Extends the deterministic test parser vocabulary so these original commands are expressible in normal Zork One tests.

## Root Cause

Aragain Falls had a one-off hard-coded `cross rainbow` handler, but the rainbow was not modeled like the original local-global object/action table. That left `LOOK-UNDER RAINBOW` and `THROUGH RAINBOW` falling through to generic failures instead of the canonical rainbow responses.

Original behavior was verified against the local ZIL reference at `zork1/1dungeon.zil:767`, `zork1/1dungeon.zil:2319`, `zork1/1dungeon.zil:2330`, `zork1/1dungeon.zil:2342`, and `zork1/1actions.zil:2634`.

## Validation

- Red first: `dotnet test ZorkOne.Tests --filter "FullyQualifiedName~AragainFallsTests"` failed with `look under rainbow` and `through rainbow` missing while `cross rainbow` passed.
- Green: `dotnet test ZorkOne.Tests --filter "FullyQualifiedName~AragainFallsTests"`
- Green: `dotnet test ZorkOne.Tests`
- Green: `dotnet test UnitTests --filter "FullyQualifiedName!~Lambda"`

Note: full `dotnet test UnitTests` is blocked on this machine by Windows Application Control loading Lambda/SecretsManager assemblies from `UnitTests/bin` (`0x800711C7`); the non-Lambda UnitTests subset passes.