### PR TITLE
[codex] Fix North-South Passage room name

### DIFF
--- a/ZorkOne.Tests/Places/NorthSouthPassageTests.cs
+++ b/ZorkOne.Tests/Places/NorthSouthPassageTests.cs
@@ -1,0 +1,30 @@
+using FluentAssertions;
+using GameEngine;
+using ZorkOne.Location;
+
+namespace ZorkOne.Tests.Places;
+
+[TestFixture]
+public class NorthSouthPassageTests
+{
+    [SetUp]
+    public void SetUp()
+    {
+        Repository.Reset();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        Repository.Reset();
+    }
+
+    [Test]
+    public void Name_ShouldNotIncludeTrailingWhitespace()
+    {
+        var location = Repository.GetLocation<NorthSouthPassage>();
+
+        location.Name.Should().Be("North-South Passage");
+        location.Name.Should().Be(location.Name.TrimEnd());
+    }
+}

--- a/ZorkOne/Location/NorthSouthPassage.cs
+++ b/ZorkOne/Location/NorthSouthPassage.cs
@@ -6,7 +6,8 @@ namespace ZorkOne.Location;
 
 public class NorthSouthPassage : DarkLocation
 {
-    public override string Name => "North-South Passage\n";
+    // Room names are serialized as area keys, so keep formatting whitespace out of the name.
+    public override string Name => "North-South Passage";
 
     protected override Dictionary<Direction, MovementParameters> Map(IContext context)
     {


### PR DESCRIPTION
## What changed

- Removed the embedded trailing newline from the Zork I `NorthSouthPassage.Name` value.
- Added a focused regression test asserting the room name is exactly `North-South Passage` and has no trailing whitespace.

## Why

Issue #339 reported that the literal newline leaked into player-facing room title formatting and structured API/harness state as `North-South Passage\n`.

The original ZIL room metadata uses the plain description `North-South Passage`, so this restores the canonical room title while keeping formatting whitespace out of serialized area keys.

Fixes #339.

## Validation

- `dotnet test ZorkOne.Tests --filter "Name_ShouldNotIncludeTrailingWhitespace"`
- `dotnet test ZorkOne.Tests`