### PR TITLE
Fix failed take of non-takeable items mutating structured inventory

### DIFF
--- a/GameEngine/Item/ItemProcessor/TakeOrDropInteractionProcessor.cs
+++ b/GameEngine/Item/ItemProcessor/TakeOrDropInteractionProcessor.cs
@@ -208,13 +208,15 @@ public class TakeOrDropInteractionProcessor : IVerbProcessor
         if (!context.HaveRoomForItem(castItem))
             return new PositiveInteractionResult("Your load is too heavy. ");
 
-        context.Take(castItem);
-        context.RememberAntecedentNoun(castItem.NounsForMatching.FirstOrDefault());
-
         // This happens if you try to take something that is a legit object in the room,
         // but it has not been marked with this interface because it cannot be taken. Think doors and engravings.
+        // Check this *before* mutating inventory - otherwise a failed take (issue #345) still leaves
+        // the item sitting in context.Items even though the player-facing response is a no-op.
         if (castItem is not ICanBeTakenAndDropped takeItem)
             return new NoNounMatchInteractionResult();
+
+        context.Take(castItem);
+        context.RememberAntecedentNoun(castItem.NounsForMatching.FirstOrDefault());
 
         var onTakenText = takeItem.OnBeingTaken(context, container);
         container?.OnItemRemovedFromHere(castItem, context);

--- a/ZorkOne.Tests/KitchenWindowTests.cs
+++ b/ZorkOne.Tests/KitchenWindowTests.cs
@@ -1,5 +1,8 @@
 using FluentAssertions;
 using GameEngine;
+using GameEngine.Item.ItemProcessor;
+using Model.Intent;
+using Model.Interaction;
 using ZorkOne.Item;
 using ZorkOne.Location;
 
@@ -357,6 +360,26 @@ public class KitchenWindowTests : EngineTestsBase
 
             response.Should().Contain("The kitchen window is closed.");
             target.Context.CurrentLocation.Should().BeOfType<BehindHouse>();
+        }
+
+        /// <summary>
+        /// issue #345: in production the AI parser classifies "take window" as a TakeIntent, routed to
+        /// TakeOrDropInteractionProcessor.Process(TakeIntent, ...) -> TakeIt. The window is scenery (not
+        /// ICanBeTakenAndDropped), so this must not mutate the structured inventory even though the
+        /// player-facing response is a no-op ("no effect on the game").
+        /// </summary>
+        [Test]
+        public async Task TakeWindow_ViaTakeIntent_DoesNotAddWindowToInventory()
+        {
+            var target = GetTarget();
+            target.Context.CurrentLocation = Repository.GetLocation<BehindHouse>();
+
+            var processor = new TakeOrDropInteractionProcessor(TakeAndDropParser.Object);
+            var (result, _) = await processor.Process(
+                new TakeIntent { OriginalInput = "take window", Noun = "window" }, target.Context, Client.Object);
+
+            result.Should().BeOfType<PositiveInteractionResult>();
+            target.Context.Items.Should().NotContain(Repository.GetItem<KitchenWindow>());
         }
     }
 


### PR DESCRIPTION
## Summary

- Fixes #345: taking a visible but non-takeable object (e.g. the kitchen window) silently added it to the structured/API inventory even though the player-facing response was a no-op ("This action or command has no effect on the game.").
- Root cause: `TakeOrDropInteractionProcessor.TakeIt` called `context.Take(castItem)` and `context.RememberAntecedentNoun(...)` *before* checking whether the item implements `ICanBeTakenAndDropped`. For scenery objects like `KitchenWindow` (which only implements `IOpenAndClose`/`ICanBeExamined`), the method still mutated inventory and then returned `NoNounMatchInteractionResult`, leaving the state contaminated.
- Fix: move the `ICanBeTakenAndDropped` check to run before the `context.Take` mutation, while keeping it after the other early-return checks (`CannotBeTakenDescription`, already-have-it, closed container, too-heavy) so items like the trophy case/mailbox that report a `CannotBeTakenDescription` without implementing `ICanBeTakenAndDropped` still get their normal message.

## Test plan

- [x] Added a failing-first regression test (`ZorkOne.Tests/KitchenWindowTests.cs`) that drives `TakeOrDropInteractionProcessor.Process(TakeIntent, ...)` directly with the kitchen window and asserts it's never added to `context.Items`. Confirmed it failed before the fix and passes after.
- [x] `dotnet test UnitTests` - 979 passed
- [x] `dotnet test ZorkOne.Tests` - 1726 passed
- [x] `dotnet test Planetfall.Tests` - 2841 passed
- [x] `dotnet test EscapeRoom.Tests` - 7 passed
- [x] `dotnet build` - solution builds cleanly

https://claude.ai/code/session_01V4txkgmKG4WWbvARKJpGHd


---
_Generated by [Claude Code](https://claude.ai/code/session_01V4txkgmKG4WWbvARKJpGHd)_