### PR TITLE
Fix #342: block taking room items in the dark via the TakeIntent path

### DIFF
--- a/GameEngine/Item/ItemProcessor/TakeOrDropInteractionProcessor.cs
+++ b/GameEngine/Item/ItemProcessor/TakeOrDropInteractionProcessor.cs
@@ -191,6 +191,14 @@ public class TakeOrDropInteractionProcessor : IVerbProcessor
         if (castItem is null)
             return new NoNounMatchInteractionResult();
 
+        // Issue #342: TakeIntent (a live AI "take" tag) is dispatched here directly from GameEngine,
+        // bypassing the darkness guard that SimpleIntent goes through in SimpleInteractionEngine. Mirror
+        // the original parser, which only resolves room-visible objects when lit - an item already in
+        // inventory stays takeable (falls through to the "already have that" case below) since the player
+        // can always feel what they're carrying regardless of light.
+        if (context.ItIsDarkHere && !context.Items.Contains(castItem))
+            return new PositiveInteractionResult("It's too dark to see! ");
+
         if (!string.IsNullOrEmpty(castItem.CannotBeTakenDescription))
         {
             ((ItemBase)castItem).OnFailingToBeTaken(context);

--- a/GameEngine/StaticCommand/Implementation/TakeEverythingProcessor.cs
+++ b/GameEngine/StaticCommand/Implementation/TakeEverythingProcessor.cs
@@ -17,6 +17,12 @@ public class TakeEverythingProcessor : IGlobalCommand
         Runtime runtime
         )
     {
+        // Issue #342 follow-up: "take all" is a global command matched before the AI parser ever
+        // runs, so none of the TakeIntent/SimpleIntent darkness guards apply to it. Gate here too,
+        // matching the established per-global-command convention (see LookProcessor.LookAround).
+        if (context.ItIsDarkHere)
+            return "It's too dark to see! ";
+
         var items = ((ICanContainItems)context.CurrentLocation).GetAllItemsRecursively;
 
         if (!items.Any(s => s is ICanBeTakenAndDropped || !string.IsNullOrEmpty(s.CannotBeTakenDescription)))

--- a/GameEngine/StaticCommand/Implementation/TakeEverythingProcessor.cs
+++ b/GameEngine/StaticCommand/Implementation/TakeEverythingProcessor.cs
@@ -72,6 +72,15 @@ public class TakeEverythingProcessor : IGlobalCommand
                 continue;
             }
 
+            // Issue #342 follow-up: a live AI TakeIntent that resolves multiple nouns (e.g. "take rope
+            // and knife") reaches this method directly instead of TakeIt, so it needs the same darkness
+            // guard - an item not already in inventory must not be resolvable while the room is dark.
+            if (context.ItIsDarkHere && !context.Items.Contains(item))
+            {
+                sb.AppendLine($"{noun}: It's too dark to see! ");
+                continue;
+            }
+
             // Check if the item is actually available in scope (room or inventory containers)
             var itemsInLocation = ((ICanContainItems)context.CurrentLocation).GetAllItemsRecursively;
             var itemsInInventory = context.GetAllItemsRecursively;

--- a/UnitTests/GlobalCommands/TakeAllDropAllTests.cs
+++ b/UnitTests/GlobalCommands/TakeAllDropAllTests.cs
@@ -11,6 +11,10 @@ public class TakeAllDropAllTests : EngineTestsBase
     {
         var target = GetTarget();
         Client.Setup(s => s.GenerateNarration(It.IsAny<TakeAllNothingHere>(), It.IsAny<string>())).ReturnsAsync("nothing here buddy");
+        // Cellar is a DarkLocation; bring a lit lantern so this exercises the empty-room narration
+        // rather than the (correct, see issue #342) darkness guard added to TakeEverythingProcessor.
+        target.Context.Take(Repository.GetItem<Lantern>());
+        Repository.GetItem<Lantern>().IsOn = true;
         target.Context.CurrentLocation = Repository.GetLocation<Cellar>();
         var response = await target.GetResponse("take all");
         response.Should().Contain("nothing here buddy");
@@ -21,6 +25,10 @@ public class TakeAllDropAllTests : EngineTestsBase
     {
         var target = GetTarget();
         Client.Setup(s => s.GenerateNarration(It.IsAny<TakeAllNothingHere>(), It.IsAny<string>())).ReturnsAsync("nothing here buddy");
+        // MazeFour is a DarkLocation; bring a lit lantern so this exercises the empty-room narration
+        // rather than the (correct, see issue #342) darkness guard added to TakeEverythingProcessor.
+        target.Context.Take(Repository.GetItem<Lantern>());
+        Repository.GetItem<Lantern>().IsOn = true;
         target.Context.CurrentLocation = Repository.GetLocation<MazeFour>();
         var response = await target.GetResponse("take all");
         response.Should().Contain("nothing here buddy");

--- a/UnitTests/SingleNounProcessors/TakeProcessorTests.cs
+++ b/UnitTests/SingleNounProcessors/TakeProcessorTests.cs
@@ -162,6 +162,26 @@ public class TakeProcessorTests : EngineTestsBase
     }
 
     [Test]
+    public async Task TakeAll_InDarkRoom_SaysTooDarkAndDoesNotTakeAnything()
+    {
+        // PR review follow-up to issue #342: the plain "take all"/"take everything" global command
+        // (GlobalCommandFactory -> TakeEverythingProcessor.Process) is matched before the AI parser
+        // ever runs, so none of the TakeIntent/SimpleIntent darkness guards apply to it. TestParser
+        // doesn't override global-command matching, so GetResponse("take all") exercises the exact
+        // same real dispatch path production uses here.
+        var target = GetTarget();
+        target.Context.CurrentLocation = Repository.GetLocation<Attic>();
+
+        target.Context.ItIsDarkHere.Should().BeTrue();
+
+        var result = await target.GetResponse("take all");
+
+        result.Should().Contain("too dark");
+        target.Context.HasItem<Rope>().Should().BeFalse();
+        target.Context.HasItem<NastyKnife>().Should().BeFalse();
+    }
+
+    [Test]
     public async Task TakeMultipleItems_InDarkRoom_ViaTakeIntent_DoesNotTakeAnyOfThem()
     {
         // PR review follow-up to issue #342: a live AI TakeIntent can resolve more than one noun for

--- a/UnitTests/SingleNounProcessors/TakeProcessorTests.cs
+++ b/UnitTests/SingleNounProcessors/TakeProcessorTests.cs
@@ -120,6 +120,48 @@ public class TakeProcessorTests : EngineTestsBase
     }
 
     [Test]
+    public async Task TakeItem_InDarkRoom_ViaTakeIntent_SaysTooDarkAndDoesNotTakeIt()
+    {
+        // Issue #342: production's real AI parser tags a bare "take rope" as a TakeIntent, which
+        // GameEngine dispatches straight to TakeOrDropInteractionProcessor.Process(TakeIntent, ...),
+        // bypassing the darkness guard that SimpleIntent goes through in SimpleInteractionEngine.
+        // TestParser (used by every other test in this file via GetResponse) always resolves "take X"
+        // to a SimpleIntent, so it can't reproduce this - the TakeIntent-facing overload has to be
+        // invoked directly, exactly as GameEngine.cs does for a live AI-tagged "take" intent.
+        var target = GetTarget();
+        target.Context.CurrentLocation = Repository.GetLocation<Attic>();
+
+        target.Context.ItIsDarkHere.Should().BeTrue();
+
+        var processor = new TakeOrDropInteractionProcessor(TakeAndDropParser.Object);
+        var (_, message) = await processor.Process(
+            new TakeIntent { Noun = "rope", OriginalInput = "take rope" }, target.Context, Client.Object);
+
+        message.Should().Contain("too dark");
+        target.Context.HasItem<Rope>().Should().BeFalse();
+    }
+
+    [Test]
+    public async Task TakeItem_ViaTakeIntent_SucceedsAfterRelightingLantern()
+    {
+        // Control for the test above: once there's light again, the same TakeIntent path should
+        // still let the player take the rope.
+        var target = GetTarget();
+        target.Context.CurrentLocation = Repository.GetLocation<Attic>();
+        target.Context.Take(Repository.GetItem<Lantern>());
+        Repository.GetItem<Lantern>().IsOn = true;
+
+        target.Context.ItIsDarkHere.Should().BeFalse();
+
+        var processor = new TakeOrDropInteractionProcessor(TakeAndDropParser.Object);
+        var (_, message) = await processor.Process(
+            new TakeIntent { Noun = "rope", OriginalInput = "take rope" }, target.Context, Client.Object);
+
+        message.Should().Contain("Taken");
+        target.Context.HasItem<Rope>().Should().BeTrue();
+    }
+
+    [Test]
     public async Task TakeItem_Disambiguation()
     {
         var target = GetTarget();

--- a/UnitTests/SingleNounProcessors/TakeProcessorTests.cs
+++ b/UnitTests/SingleNounProcessors/TakeProcessorTests.cs
@@ -162,6 +162,28 @@ public class TakeProcessorTests : EngineTestsBase
     }
 
     [Test]
+    public async Task TakeMultipleItems_InDarkRoom_ViaTakeIntent_DoesNotTakeAnyOfThem()
+    {
+        // PR review follow-up to issue #342: a live AI TakeIntent can resolve more than one noun for
+        // a single command (e.g. "take rope and knife"), which GetItemsToTake routes to
+        // TakeEverythingProcessor.TakeAll instead of TakeIt - a separate branch that had its own,
+        // still-unguarded darkness gap even after the single-item TakeIt fix above.
+        var target = GetTarget();
+        target.Context.CurrentLocation = Repository.GetLocation<Attic>();
+
+        target.Context.ItIsDarkHere.Should().BeTrue();
+
+        var processor = new TakeOrDropInteractionProcessor(TakeAndDropParser.Object);
+        var (_, message) = await processor.Process(
+            new TakeIntent { Noun = "rope", OriginalInput = "take rope and knife" }, target.Context, Client.Object);
+
+        message.Should().NotContain("Taken");
+        message.Should().Contain("too dark");
+        target.Context.HasItem<Rope>().Should().BeFalse();
+        target.Context.HasItem<NastyKnife>().Should().BeFalse();
+    }
+
+    [Test]
     public async Task TakeItem_Disambiguation()
     {
         var target = GetTarget();


### PR DESCRIPTION
## Summary

Fixes #342. In production, the real AI parser tags a bare command like `take rope` as a `TakeIntent`, which `GameEngine.cs` dispatches directly to `TakeOrDropInteractionProcessor.Process(TakeIntent, ...)`. That path never checked `context.ItIsDarkHere`, so a player could `take` a room object while the room was pitch black (e.g. turning off the lantern in the Attic and still taking the rope) — a regression of the original `SimpleIntent` darkness guard in `SimpleInteractionEngine`, which only covers verb+noun input the AI parser tags generically rather than as an explicit take/drop intent.

- `TakeOrDropInteractionProcessor.TakeIt` now returns `"It's too dark to see! "` when the room is dark and the resolved item isn't already in the player's inventory, mirroring the original ZIL parser (only resolves room-visible objects when lit; inventory items remain accessible regardless of light).
- Items already carried are unaffected (falls through to the existing "You already have that!" case).

## Root cause

- `GameEngine/GameEngine.cs` routes `TakeIntent`/`DropIntent` straight to `TakeOrDropInteractionProcessor`, bypassing `SimpleInteractionEngine`'s darkness guard (`GameEngine/IntentEngine/SimpleInteractionEngine.cs:43`).
- `TakeOrDropInteractionProcessor.TakeIt` (`GameEngine/Item/ItemProcessor/TakeOrDropInteractionProcessor.cs`) called `context.Take(castItem)` without any darkness check.
- The existing test suite couldn't catch this because `TestParser` (used by all engine-level tests) always resolves `take <noun>` to a `SimpleIntent`, never a `TakeIntent` — so the buggy `TakeIntent`-facing code path had zero test coverage.

## Test plan

- Added `TakeItem_InDarkRoom_ViaTakeIntent_SaysTooDarkAndDoesNotTakeIt` in `UnitTests/SingleNounProcessors/TakeProcessorTests.cs`, which invokes `TakeOrDropInteractionProcessor.Process(TakeIntent, ...)` directly (the same call GameEngine makes for a live AI-tagged "take") against a real `Attic`/`Rope` Repository setup with no light source. Confirmed it fails before the fix ("Taken." / rope in inventory) and passes after.
- Added a control test, `TakeItem_ViaTakeIntent_SucceedsAfterRelightingLantern`, verifying the same path still succeeds once the lantern is turned back on.
- [x] `dotnet test UnitTests` — 981 passed, 1 skipped
- [x] `dotnet test ZorkOne.Tests` — 1725 passed
- [x] `dotnet test Planetfall.Tests` — 2841 passed
- [x] `dotnet test EscapeRoom.Tests` — 7 passed
- [x] `dotnet build` (full solution) — succeeded


---
_Generated by [Claude Code](https://claude.ai/code/session_01F18JTxpasRuobYe9LBC4LW)_