### PR TITLE
Fix #341: singular "it" after "take all" no longer drops the whole set

### DIFF
--- a/GameEngine/Context.cs
+++ b/GameEngine/Context.cs
@@ -76,7 +76,15 @@ public abstract class Context<T> : IContext where T : IInfocomGame, new()
 
     public void RememberAntecedentNoun(string? noun)
     {
-        if (!string.IsNullOrEmpty(noun) && !LastNouns.Contains(noun, StringComparer.OrdinalIgnoreCase))
+        if (string.IsNullOrEmpty(noun))
+            return;
+
+        // The singular "it" antecedent always tracks the most recently handled object, even during a
+        // multi-object action like "take rope and knife" - mirroring the original's PERFORM updating
+        // P-IT-OBJECT to the current PRSO on every object it processes (issue #341).
+        LastNoun = noun;
+
+        if (!LastNouns.Contains(noun, StringComparer.OrdinalIgnoreCase))
             LastNouns.Add(noun);
     }
 
@@ -89,7 +97,13 @@ public abstract class Context<T> : IContext where T : IInfocomGame, new()
             .ToList();
 
         if (set.Count > 0)
+        {
             LastNouns = set;
+            // "it" resolves to the LAST object this batch action handled (e.g. the last item a
+            // bare "take all" picked up), not the whole set - "them" is the collection pronoun
+            // covered by LastNouns above (issue #341).
+            LastNoun = set[^1];
+        }
     }
 
     public int Moves { get; set; }

--- a/GameEngine/GameEngine.cs
+++ b/GameEngine/GameEngine.cs
@@ -451,7 +451,8 @@ public class GameEngine<TInfocomGame, TContext> : IGameEngine
             && (!string.IsNullOrEmpty(Context.LastInput) || !string.IsNullOrEmpty(Context.LastResponse)))
         {
             var resolved = await _parser.ResolvePronounsAsync(_currentInput!, Context.LastInput, Context.LastResponse);
-            if (resolved != null && !resolved.Equals(_currentInput, StringComparison.OrdinalIgnoreCase))
+            if (resolved != null && !resolved.Equals(_currentInput, StringComparison.OrdinalIgnoreCase)
+                && !ResolverConflatedSingularItWithASet(_currentInput!, resolved))
             {
                 _currentInput = resolved;
             }
@@ -558,6 +559,27 @@ public class GameEngine<TInfocomGame, TContext> : IGameEngine
             return context.LastNouns.Any(noun => context.HasMatchingNoun(noun).HasItem);
 
         return false;
+    }
+
+    /// <summary>
+    ///     True when the AI pronoun resolver rewrote a SINGULAR "it" into a multi-object noun phrase,
+    ///     e.g. "drop it" -&gt; "drop rope and knife" (issue #341). This happens after a multi-object
+    ///     action like "take all": the resolver's only context is the previous command/response naming
+    ///     every object that was handled, so it conflates "it" with the whole set instead of the one
+    ///     object the player actually meant. "them" is the collection pronoun (issue #248) and is not
+    ///     affected - this guard only fires when the ORIGINAL command used singular "it". When it fires,
+    ///     the rewrite is discarded and the deterministic <see cref="ItProcessor" /> downstream resolves
+    ///     "it" from the single last-handled antecedent instead.
+    /// </summary>
+    private static bool ResolverConflatedSingularItWithASet(string original, string resolved)
+    {
+        if (!Regex.IsMatch(original, @"\bit\b", RegexOptions.IgnoreCase))
+            return false;
+
+        // A correct singular rewrite swaps "it" for exactly one noun phrase. A rewrite that introduces
+        // a conjunction the original didn't already have means the resolver named more than one object.
+        return Regex.IsMatch(resolved, @"\band\b", RegexOptions.IgnoreCase)
+               && !Regex.IsMatch(original, @"\band\b", RegexOptions.IgnoreCase);
     }
 
     public IContext RestoreGame(string data)

--- a/UnitTests/GlobalCommands/PronounResolutionTests.cs
+++ b/UnitTests/GlobalCommands/PronounResolutionTests.cs
@@ -1,4 +1,6 @@
+using System.Text.RegularExpressions;
 using GameEngine;
+using ZorkOne.GlobalCommand;
 
 namespace UnitTests.GlobalCommands;
 
@@ -336,6 +338,79 @@ public class PronounResolutionTests : EngineTestsBase
             result.Should().NotContain("What item are you referring to");
             result.Should().Contain("Dropped");
             target.Context.HasItem<Lantern>().Should().BeFalse();
+        }
+    }
+
+    /// <summary>
+    /// Issue #341 (AB-044): in production, after a multi-object "take all", the AI pronoun resolver's
+    /// only context is the "take all" command and a response naming every item taken - so it conflates
+    /// singular "it" with the whole object set, and "drop it" ends up dropping everything. Singular
+    /// "it" must resolve to just the last object the multi-object action handled; "them" (issue #248)
+    /// remains the collection pronoun.
+    /// </summary>
+    [TestFixture]
+    public class TakeAllThenSingularIt : PronounResolutionTests
+    {
+        /// <summary>
+        /// Mimics the production gpt-4o-mini pronoun resolver's failure mode: after "take all", it
+        /// rewrites singular "it" into a conjunction of every item named in the previous response,
+        /// exactly like its own "take them" -&gt; "take sword and shield" example would for a plural
+        /// pronoun (see the resolver's prompt examples) - except here the player used singular "it".
+        /// </summary>
+        private sealed class ConflatesSingularItWithTakenSetParser()
+            : TestParser(new ZorkOneGlobalCommandFactory())
+        {
+            public override Task<string?> ResolvePronounsAsync(string input, string? lastInput, string? lastResponse)
+            {
+                if (Regex.IsMatch(input, @"\bit\b", RegexOptions.IgnoreCase)
+                    && (lastInput ?? string.Empty).Trim().Equals("take all", StringComparison.OrdinalIgnoreCase))
+                    return Task.FromResult<string?>(
+                        Regex.Replace(input, @"\bit\b", "rope and knife", RegexOptions.IgnoreCase));
+
+                return base.ResolvePronounsAsync(input, lastInput, lastResponse);
+            }
+        }
+
+        [Test]
+        public async Task DropIt_AfterTakeAll_DropsOnlyTheLastItemTaken()
+        {
+            var parser = new ConflatesSingularItWithTakenSetParser();
+            var target = GetTarget(parser);
+            // The Attic is a DarkLocation; a lit lamp is needed to see well enough to drop things there.
+            var lantern = GetItem<Lantern>();
+            lantern.IsOn = true;
+            target.Context.ItemPlacedHere(lantern);
+            target.Context.CurrentLocation = Repository.GetLocation<Attic>();
+
+            await target.GetResponse("take all");
+            target.Context.HasItem<Rope>().Should().BeTrue();
+            target.Context.HasItem<NastyKnife>().Should().BeTrue();
+
+            var result = await target.GetResponse("drop it");
+
+            target.Context.HasItem<NastyKnife>().Should().BeFalse(
+                because: "singular 'it' should resolve to the last item handled by 'take all'");
+            target.Context.HasItem<Rope>().Should().BeTrue(
+                because: "'it' is singular and must not drop the whole object set taken by 'take all'");
+            result.Should().Contain("Dropped");
+        }
+
+        [Test]
+        public async Task DropThem_AfterTakeAll_StillDropsTheWholeSet()
+        {
+            // Guards against over-correcting: plural "them" (issue #248) must still resolve to
+            // everything "take all" picked up.
+            var target = GetTarget();
+            var lantern = GetItem<Lantern>();
+            lantern.IsOn = true;
+            target.Context.ItemPlacedHere(lantern);
+            target.Context.CurrentLocation = Repository.GetLocation<Attic>();
+
+            await target.GetResponse("take all");
+            await target.GetResponse("drop them");
+
+            target.Context.HasItem<Rope>().Should().BeFalse();
+            target.Context.HasItem<NastyKnife>().Should().BeFalse();
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes #341. After a multi-object `take all`, singular `drop it` could drop the whole set of items instead of just one:

```
> take all
rope: Taken.
knife: Taken.

> drop it
rope: Dropped
knife: Dropped
```

Root cause: the AI pronoun resolver's only context after `take all` is that broad command plus a response naming every item taken, so it could rewrite singular `it` into a multi-object phrase (e.g. `drop rope and knife`), and the take/drop pipeline would then drop everything.

Fix:
- `GameEngine.ProcessSingleSentence` now rejects any AI resolver rewrite that turns a singular `it` into a conjunction (`and`) the original command didn't already have, and falls back to the deterministic `ItProcessor` instead (`GameEngine/GameEngine.cs`).
- `Context.RememberAntecedentNoun`/`RememberAntecedentNouns` now also update the singular `LastNoun` antecedent to the last object a multi-object action handled (matching the original ZIL's `PERFORM` updating `P-IT-OBJECT` on every object processed), so `it` correctly resolves to that one item instead of asking for clarification. `them` still resolves to the whole set, per #248 (`GameEngine/Context.cs`).

## Test plan

- [x] Added a failing-then-passing test (`UnitTests/GlobalCommands/PronounResolutionTests.cs`) that reproduces the bug in the Attic (rope + knife) using a `TestParser` subclass that mimics the production resolver's failure mode, and confirmed it fails without the fix and passes with it.
- [x] Added a regression test confirming `drop them` still drops the whole set taken by `take all` (issue #248 behavior preserved).
- [x] `dotnet test UnitTests/UnitTests.csproj` - 981 passed, 0 failed.
- [x] `dotnet test ZorkOne.Tests/ZorkOne.Tests.csproj` - 1725 passed, 0 failed.
- [x] `dotnet test Planetfall.Tests/Planetfall.Tests.csproj` - 2841 passed, 0 failed.
- [x] `dotnet test EscapeRoom.Tests/EscapeRoom.Tests.csproj` - 7 passed, 0 failed.
- [x] `dotnet build Zork.sln` - full solution builds with no errors.

https://claude.ai/code/session_01LAuWRtGpTH1rsyDjjMCbio

---
_Generated by [Claude Code](https://claude.ai/code/session_01LAuWRtGpTH1rsyDjjMCbio)_