### PR TITLE
Fix #337: wire up Shore/Sandy Beach local-global water and river objects

### DIFF
--- a/Model/Verbs.cs
+++ b/Model/Verbs.cs
@@ -18,6 +18,12 @@ public static class Verbs
     public static readonly string[] DropVerbs = ["drop"];
 
     public static readonly string[] DrinkVerbs = ["swallow", "sip", "drink", "consume", "gulp", "guzzle", "slurp"];
+
+    /// <summary>
+    ///     The "go for a swim" family (ZIL: <c>SYNONYM SWIM BATHE WADE</c>). Used by the river-bank
+    ///     locations (Shore, Sandy Beach) that expose the local-global river/water objects.
+    /// </summary>
+    public static readonly string[] SwimVerbs = ["swim", "bathe", "wade"];
     public static readonly string[] FixVerbs = ["fix", "repair", "seal", "patch", "stop", "block", "mend", "plug"];
     public static readonly string[] ApplyVerbs = ["use", "apply", "stick", "put", "place", "spread", "smear", "press"];
     public static readonly string[] PushVerbs = ["push", "press", "activate", "toggle", "click", "flip", "switch", "depress"];

--- a/UnitTests/TestParser.cs
+++ b/UnitTests/TestParser.cs
@@ -38,7 +38,7 @@ public class TestParser : IntentParser
         [
             "one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "zero", "dial", "shelves", "pocket",
             "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "dude", "hello", "17", "seventeen", "slot", "lever", "label",
-            "tree", "branches", "house", "lettering", "mirror", "match", "yellow button", "red button", "button", "medicine",
+            "tree", "branches", "house", "lettering", "mirror", "match", "river", "yellow button", "red button", "button", "medicine",
             "blue button", "brown button", "bolt", "bubble", "bodies", "gate", "lid", "switch", "slag", "engravings",
             "fromitz board", "board", "fromitz", "second fromitz board", "second board", "second",
             "second board", "second fromitz board", "second fromitz", "384",

--- a/ZorkOne.Tests/Places/ShoreTests.cs
+++ b/ZorkOne.Tests/Places/ShoreTests.cs
@@ -1,0 +1,88 @@
+using FluentAssertions;
+using GameEngine;
+using ZorkOne.Item;
+using ZorkOne.Location;
+
+namespace ZorkOne.Tests.Places;
+
+// Issue #337: Shore and Sandy Beach both expose the river in their room descriptions, but neither
+// location wired up the original ZIL "local-global" water/river objects
+// (zork1/1dungeon.zil: both SHORE and SANDY-BEACH declare `(GLOBAL GLOBAL-WATER RIVER)`), so
+// swim/drink/take fell through to the engine's generic no-op responses instead of the original
+// handlers.
+public class ShoreTests : EngineTestsBase
+{
+    [TestCase("swim")]
+    [TestCase("swim in river")]
+    [TestCase("swim in water")]
+    [TestCase("bathe")]
+    public async Task Swim_AtShore_GivesTheOriginalRefusal(string input)
+    {
+        var target = GetTarget();
+        StartHere<Shore>();
+
+        var response = await target.GetResponse(input);
+
+        response.Should().Contain("Swimming isn't usually allowed in the dungeon.");
+    }
+
+    [Test]
+    public async Task DrinkWater_AtShore_QuenchesThirst()
+    {
+        var target = GetTarget();
+        StartHere<Shore>();
+
+        var response = await target.GetResponse("drink water");
+
+        response.Should().Contain("Thank you very much. I was rather thirsty (from all this talking, probably).");
+    }
+
+    [Test]
+    public async Task TakeWater_AtShore_SlipsThroughFingers()
+    {
+        var target = GetTarget();
+        StartHere<Shore>();
+
+        var response = await target.GetResponse("take water");
+
+        response.Should().Contain("The water slips through your fingers.");
+    }
+
+    [Test]
+    public async Task ExamineRiver_AtShore_DescribesIt()
+    {
+        var target = GetTarget();
+        StartHere<Shore>();
+
+        var response = await target.GetResponse("examine river");
+
+        response.Should().Contain("The river is wide, swift, and cold.");
+    }
+
+    [Test]
+    public async Task Swim_AtSandyBeach_GivesTheOriginalRefusal_EvenInTheDark()
+    {
+        // Sandy Beach is a DarkLocation, but RespondToSpecificLocationInteraction (like the
+        // existing "launch" handling here) runs before any darkness gate, so this must work
+        // without a light source too.
+        var target = GetTarget();
+        StartHere<SandyBeach>();
+
+        var response = await target.GetResponse("swim in river");
+
+        response.Should().Contain("Swimming isn't usually allowed in the dungeon.");
+    }
+
+    [Test]
+    public async Task DrinkWater_AtSandyBeach_QuenchesThirst()
+    {
+        var target = GetTarget();
+        StartHere<SandyBeach>();
+        Take<Lantern>();
+        GetItem<Lantern>().IsOn = true;
+
+        var response = await target.GetResponse("drink water");
+
+        response.Should().Contain("Thank you very much. I was rather thirsty (from all this talking, probably).");
+    }
+}

--- a/ZorkOne/Item/Water.cs
+++ b/ZorkOne/Item/Water.cs
@@ -7,13 +7,13 @@ public class Water : ItemBase, IAmADrink
 {
     public override string[] NounsForMatching => ["water", "quantity of water"];
 
-    public override string CannotBeTakenDescription => "It would just slip through your fingers";
+    public override string CannotBeTakenDescription => "The water slips through your fingers.";
 
     public override int Size => 2;
 
     (string Message, bool WasConsumed) IAmADrink.OnDrinking(IContext context)
     {
-        return ("Thank you very much -- I was very thirsty (probably from all this talking).", true);
+        return ("Thank you very much. I was rather thirsty (from all this talking, probably).", true);
     }
 
     public override string GenericDescription(ILocation? currentLocation)

--- a/ZorkOne/Location/RiverBankGlobalObjects.cs
+++ b/ZorkOne/Location/RiverBankGlobalObjects.cs
@@ -1,0 +1,59 @@
+using GameEngine;
+using GameEngine.Location;
+using Model.AIGeneration;
+using Model.Intent;
+using Model.Interface;
+
+namespace ZorkOne.Location;
+
+/// <summary>
+///     Shared "local-global" river/water responses for the river-bank rooms whose descriptions
+///     expose the river directly. In the original ZIL, both Shore and Sandy Beach declare
+///     <c>(GLOBAL GLOBAL-WATER RIVER)</c>, which makes the water/river objects respond to commands
+///     there even though neither object is ever actually carried or placed in the room's inventory.
+///     Without this, "swim"/"drink water"/"take water" fell through to the engine's generic no-op
+///     responses instead of the original water/river handlers (issue #337).
+/// </summary>
+internal static class RiverBankGlobalObjects
+{
+    public const string SwimmingMessage = "Swimming isn't usually allowed in the dungeon. ";
+
+    /// <summary>
+    ///     Prose-only "river" scenery: examinable and un-takeable, like the ZIL RIVER object
+    ///     (FLAGS NDESCBIT, no TAKEBIT).
+    /// </summary>
+    public static readonly SceneryItem River = new(
+        ["river"],
+        "The river is wide, swift, and cold. ",
+        "You can't take the river. ");
+
+    /// <summary>
+    ///     True for "swim", "swim in river", "swim across river", "bathe", "wade", etc. Checked
+    ///     against the raw input (rather than a parsed noun) because, like "pray" at the Altar, swim
+    ///     is meaningful with or without an object.
+    /// </summary>
+    public static bool IsSwimAttempt(string? input)
+    {
+        if (string.IsNullOrEmpty(input))
+            return false;
+
+        var trimmed = input.Trim();
+        return Verbs.SwimVerbs.Any(verb => trimmed.StartsWith(verb, StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
+    ///     Delegates any "water" noun interaction (drink, take, examine, ...) to the single global
+    ///     <see cref="Water" /> item, without ever placing it in this room's <c>Items</c> - doing so
+    ///     would fight over its singleton <c>CurrentLocation</c> with wherever else it's seeded (e.g.
+    ///     inside the Bottle). Returns null when the action's noun isn't water at all, so the caller
+    ///     can fall through to its normal handling.
+    /// </summary>
+    public static async Task<InteractionResult?> RespondToWater(SimpleIntent action, IContext context,
+        IGenerationClient client, IItemProcessorFactory itemProcessorFactory)
+    {
+        var result = await Repository.GetItem<Water>()
+            .RespondToSimpleInteraction(action, context, client, itemProcessorFactory);
+
+        return result is NoNounMatchInteractionResult ? null : result;
+    }
+}

--- a/ZorkOne/Location/SandyBeach.cs
+++ b/ZorkOne/Location/SandyBeach.cs
@@ -1,13 +1,14 @@
 using GameEngine;
 using GameEngine.Location;
 using Model.AIGeneration;
+using Model.Intent;
 using Model.Interface;
 using Model.Movement;
 using ZorkOne.Location.RiverLocation;
 
 namespace ZorkOne.Location;
 
-public class SandyBeach : DarkLocation // Explain to me how a beach can be a dark location? Well, it is. 
+public class SandyBeach : DarkLocation // Explain to me how a beach can be a dark location? Well, it is.
 {
     public override string Name => "Sandy Beach";
 
@@ -25,12 +26,17 @@ public class SandyBeach : DarkLocation // Explain to me how a beach can be a dar
         return "You are on a large sandy beach on the east shore of the river, which is flowing quickly by. " +
                "A path runs beside the river to the south here, and a passage is partially buried in sand to the northeast. ";
     }
-    
+
+    protected override IReadOnlyList<SceneryItem> Scenery => [RiverBankGlobalObjects.River];
+
     public override async Task<InteractionResult> RespondToSpecificLocationInteraction(string? input, IContext context,
         IGenerationClient client)
     {
         if (string.IsNullOrEmpty(input))
             return await base.RespondToSpecificLocationInteraction(input, context, client);
+
+        if (RiverBankGlobalObjects.IsSwimAttempt(input))
+            return new PositiveInteractionResult(RiverBankGlobalObjects.SwimmingMessage);
 
         var preppedInput = input.ToLowerInvariant().Trim();
 
@@ -39,7 +45,7 @@ public class SandyBeach : DarkLocation // Explain to me how a beach can be a dar
 
         if (preppedInput.StartsWith("launch"))
         {
-            // TODO: move some of this logic to the move engine, but only after tests are passing. 
+            // TODO: move some of this logic to the move engine, but only after tests are passing.
             context.CurrentLocation.SubLocation = null;
             context.CurrentLocation = Repository.GetLocation<FrigidRiverThree>();
             await context.CurrentLocation.AfterEnterLocation(context, this, null!);
@@ -50,6 +56,16 @@ public class SandyBeach : DarkLocation // Explain to me how a beach can be a dar
         }
 
         return await base.RespondToSpecificLocationInteraction(input, context, client);
+    }
+
+    public override async Task<InteractionResult> RespondToSimpleInteraction(SimpleIntent action, IContext context,
+        IGenerationClient client, IItemProcessorFactory itemProcessorFactory)
+    {
+        var waterResult = await RiverBankGlobalObjects.RespondToWater(action, context, client, itemProcessorFactory);
+        if (waterResult is not null)
+            return waterResult;
+
+        return await base.RespondToSimpleInteraction(action, context, client, itemProcessorFactory);
     }
 
     public override void Init()

--- a/ZorkOne/Location/Shore.cs
+++ b/ZorkOne/Location/Shore.cs
@@ -1,4 +1,6 @@
 using GameEngine.Location;
+using Model.AIGeneration;
+using Model.Intent;
 using Model.Interface;
 using Model.Movement;
 
@@ -22,5 +24,25 @@ public class Shore : LocationWithNoStartingItems
         return
             "You are on the east shore of the river. The water here seems somewhat treacherous. A path travels from north " +
             "to south here, the south end quickly turning around a sharp corner. ";
+    }
+
+    protected override IReadOnlyList<SceneryItem> Scenery => [RiverBankGlobalObjects.River];
+
+    public override Task<InteractionResult> RespondToSpecificLocationInteraction(string? input, IContext context,
+        IGenerationClient client)
+    {
+        return RiverBankGlobalObjects.IsSwimAttempt(input)
+            ? Task.FromResult<InteractionResult>(new PositiveInteractionResult(RiverBankGlobalObjects.SwimmingMessage))
+            : base.RespondToSpecificLocationInteraction(input, context, client);
+    }
+
+    public override async Task<InteractionResult> RespondToSimpleInteraction(SimpleIntent action, IContext context,
+        IGenerationClient client, IItemProcessorFactory itemProcessorFactory)
+    {
+        var waterResult = await RiverBankGlobalObjects.RespondToWater(action, context, client, itemProcessorFactory);
+        if (waterResult is not null)
+            return waterResult;
+
+        return await base.RespondToSimpleInteraction(action, context, client, itemProcessorFactory);
     }
 }


### PR DESCRIPTION
## Summary

Fixes #337. `zork1/1dungeon.zil` declares both `SHORE` and `SANDY-BEACH` with `(GLOBAL GLOBAL-WATER RIVER)` — a ZIL "local-global" object binding that makes the river/water objects respond to commands in those two rooms even though neither object is ever actually carried or placed in the room's inventory. Neither `Shore.cs` nor `SandyBeach.cs` wired this up, so `swim`, `drink water`, and `take water` fell through to the engine's generic no-op / "can't get there" responses instead of the original handlers.

- Added `Verbs.SwimVerbs` (ZIL: `SYNONYM SWIM BATHE WADE`) and handled it as a raw, object-optional command via `RespondToSpecificLocationInteraction`, mirroring the existing "pray"-at-the-Altar pattern (swim is meaningful with or without a following noun, e.g. `swim`, `swim in river`).
- Added `RiverBankGlobalObjects`, a small helper shared by both rooms:
  - a `river` `Scenery` entry (examinable, un-takeable, matching the ZIL `RIVER` object's `NDESCBIT`/no-`TAKEBIT` flags)
  - a `RespondToWater` helper that delegates any `water`-noun interaction straight to the existing singleton `Water` item's normal processor pipeline (drink/take/examine), without ever placing that item in either room's `Items` — this sidesteps the documented shared-instance `CurrentLocation` pitfall (the same `Water` instance is also seeded inside the `Bottle`).
- Fixed `Water`'s drink/take message text to match the ZIL ground truth (`V-EAT`/`HIT-SPOT` and `WATER-F`), a divergence this issue also called out (`"Thank you very much. I was rather thirsty (from all this talking, probably)."` / `"The water slips through your fingers."`).
- Added `river` to the test parser's noun list so it resolves like other scenery-only nouns in tests.

## Test plan

- [x] Added `ZorkOne.Tests/Places/ShoreTests.cs`, covering: `swim` / `swim in river` / `swim in water` / `bathe` at Shore, `drink water` and `take water` at Shore, `examine river` at Shore, and swim/drink at Sandy Beach (including confirming swim still works while the beach is dark, matching the existing "launch" handling there).
- [x] Confirmed each new test fails against the pre-fix code (reproducing the reported blank/no-op responses) before the fix, and passes after.
- [x] `dotnet test ZorkOne.Tests` — 1734 passed, 0 failed.
- [x] `dotnet test UnitTests` — 979 passed, 0 failed.
- [x] `dotnet test Planetfall.Tests` — 2841 passed, 0 failed (shared `Verbs.cs` change).
- [x] `dotnet build Zork.sln` — succeeds with no errors.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_013XfJiY8YENeFKckeNpbfMn)_