### PR TITLE
Fix PR330 Zork e2e header assertions for new stat-chip markup

### DIFF
--- a/zorkweb.client/tests/gameState.spec.ts
+++ b/zorkweb.client/tests/gameState.spec.ts
@@ -92,7 +92,8 @@ test.describe('Game State', () => {
         await waitForGameResponse(page);
 
         // Verify that the score in the header has changed to "10"
-        await expect(headerScore).toHaveText('Score:  10');
+        await expect(headerScore).toContainText('Score');
+        await expect(headerScore).toContainText('10');
     });
 
     test('Moves - when API returns moves, those moves are displayed in the header', async ({page}) => {
@@ -118,7 +119,8 @@ test.describe('Game State', () => {
         await waitForGameResponse(page);
 
         // Verify that the moves in the header has changed to "1"
-        await expect(headerMoves).toHaveText('Moves:  1');
+        await expect(headerMoves).toContainText('Moves');
+        await expect(headerMoves).toContainText('1');
     });
 
 });


### PR DESCRIPTION
## Summary
- PR #330's Zork header redesign (`zorkweb.client/src/components/Header.tsx`) renders the "Score"/"Moves" label and the `CountUp` value as separate sibling elements with no literal `": "` text node between them, so the container's rendered text is now `Score10` / `Moves1` instead of the old `Score:  10` / `Moves:  1`.
- The Jest unit test (`Header.test.tsx`) was already updated for this in PR #330 (uses substring `toHaveTextContent` checks), but the Playwright e2e spec `zorkweb.client/tests/gameState.spec.ts` still asserted the old exact text via `toHaveText`, causing 6 CI failures across chromium/firefox/webkit on the `zork-tests` check.
- Updated the two assertions to `toContainText('Score')` / `toContainText('10')` and `toContainText('Moves')` / `toContainText('1')`, matching the substring-based style already used in `Header.test.tsx` for this same markup.

This is a test-only fix — no production code changed.

## Test plan
- [x] `npx playwright test tests/gameState.spec.ts --project=chromium` — 3/3 pass
- [x] `npx playwright test --project=chromium` (full zorkweb.client e2e suite) — 29/29 pass
- [x] `npx jest` (zorkweb.client unit suite) — 102/102 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SDgegjurhYf5p8WCmxDHpd

---
_Generated by [Claude Code](https://claude.ai/code/session_01SDgegjurhYf5p8WCmxDHpd)_