### PR TITLE
Fix #344: route object-based kitchen window entry through movement

### DIFF
--- a/ZorkOne.Tests/KitchenWindowTests.cs
+++ b/ZorkOne.Tests/KitchenWindowTests.cs
@@ -47,17 +47,6 @@ public class KitchenWindowTests : EngineTestsBase
         }
 
         [Test]
-        public async Task GoThroughWindow()
-        {
-            var target = GetTarget();
-            target.Context.CurrentLocation = Repository.GetLocation<BehindHouse>();
-
-            var response = await target.GetResponse("go through window");
-
-            response.Should().Contain("The window is slightly ajar, but not enough to permit entry.");
-        }
-
-        [Test]
         public async Task JumpThroughWindow()
         {
             var target = GetTarget();
@@ -146,18 +135,6 @@ public class KitchenWindowTests : EngineTestsBase
             Repository.GetItem<KitchenWindow>().IsOpen = true;
 
             var response = await target.GetResponse("look through window");
-
-            response.Should().Contain("The window is open. If you want to enter the house, just say so.");
-        }
-
-        [Test]
-        public async Task GoThroughWindow()
-        {
-            var target = GetTarget();
-            target.Context.CurrentLocation = Repository.GetLocation<BehindHouse>();
-            Repository.GetItem<KitchenWindow>().IsOpen = true;
-
-            var response = await target.GetResponse("go through window");
 
             response.Should().Contain("The window is open. If you want to enter the house, just say so.");
         }
@@ -440,6 +417,59 @@ public class KitchenWindowTests : EngineTestsBase
             target.Context.CurrentLocation.Should().BeOfType<BehindHouse>();
         }
 
+        /// <summary>
+        /// issue #344: bare "through window" (no leading verb) was intercepted by BehindHouse's raw
+        /// input check and given only advisory text ("...just say so"), never actually moving the
+        /// player, even though the window was open. It must move like "in"/"west" do.
+        /// </summary>
+        [Test]
+        public async Task ThroughWindow_ActuallyEnters_WhenWindowOpen()
+        {
+            var target = GetTarget();
+            target.Context.CurrentLocation = Repository.GetLocation<BehindHouse>();
+            Repository.GetItem<KitchenWindow>().IsOpen = true;
+
+            await target.GetResponse("through window");
+
+            target.Context.CurrentLocation.Should().BeOfType<Kitchen>();
+        }
+
+        [Test]
+        public async Task ThroughWindow_Blocked_WhenWindowClosed()
+        {
+            var target = GetTarget();
+            target.Context.CurrentLocation = Repository.GetLocation<BehindHouse>();
+
+            var response = await target.GetResponse("through window");
+
+            response.Should().Contain("The kitchen window is closed.");
+            target.Context.CurrentLocation.Should().BeOfType<BehindHouse>();
+        }
+
+        [Test]
+        public async Task GoThroughWindow_ActuallyEnters_WhenWindowOpen()
+        {
+            var target = GetTarget();
+            target.Context.CurrentLocation = Repository.GetLocation<BehindHouse>();
+            Repository.GetItem<KitchenWindow>().IsOpen = true;
+
+            await target.GetResponse("go through window");
+
+            target.Context.CurrentLocation.Should().BeOfType<Kitchen>();
+        }
+
+        [Test]
+        public async Task GoThroughWindow_Blocked_WhenWindowClosed()
+        {
+            var target = GetTarget();
+            target.Context.CurrentLocation = Repository.GetLocation<BehindHouse>();
+
+            var response = await target.GetResponse("go through window");
+
+            response.Should().Contain("The kitchen window is closed.");
+            target.Context.CurrentLocation.Should().BeOfType<BehindHouse>();
+        }
+
         [Test]
         public async Task ExitWindow_FromKitchen_GoesToBehindHouse_WhenWindowOpen()
         {
@@ -464,6 +494,47 @@ public class KitchenWindowTests : EngineTestsBase
 
             response.Should().Contain("The kitchen window is closed.");
             target.Context.CurrentLocation.Should().BeOfType<Kitchen>();
+        }
+
+        /// <summary>
+        /// issue #344: the same object-based ambiguity that broke entry from Behind House applies
+        /// symmetrically to the outward trip from the Kitchen, so "board window" and "through window"
+        /// must also walk back out when said from inside.
+        /// </summary>
+        [Test]
+        public async Task BoardWindow_FromKitchen_GoesToBehindHouse_WhenWindowOpen()
+        {
+            var target = GetTarget();
+            target.Context.CurrentLocation = Repository.GetLocation<Kitchen>();
+            Repository.GetItem<KitchenWindow>().IsOpen = true;
+
+            await target.GetResponse("board window");
+
+            target.Context.CurrentLocation.Should().BeOfType<BehindHouse>();
+        }
+
+        [Test]
+        public async Task ThroughWindow_FromKitchen_GoesToBehindHouse_WhenWindowOpen()
+        {
+            var target = GetTarget();
+            target.Context.CurrentLocation = Repository.GetLocation<Kitchen>();
+            Repository.GetItem<KitchenWindow>().IsOpen = true;
+
+            await target.GetResponse("through window");
+
+            target.Context.CurrentLocation.Should().BeOfType<BehindHouse>();
+        }
+
+        [Test]
+        public async Task GoThroughWindow_FromKitchen_GoesToBehindHouse_WhenWindowOpen()
+        {
+            var target = GetTarget();
+            target.Context.CurrentLocation = Repository.GetLocation<Kitchen>();
+            Repository.GetItem<KitchenWindow>().IsOpen = true;
+
+            await target.GetResponse("go through window");
+
+            target.Context.CurrentLocation.Should().BeOfType<BehindHouse>();
         }
 
         [Test]

--- a/ZorkOne/Location/BehindHouse.cs
+++ b/ZorkOne/Location/BehindHouse.cs
@@ -1,6 +1,8 @@
 using GameEngine;
+using GameEngine.IntentEngine;
 using GameEngine.Location;
 using Model.AIGeneration;
+using Model.Intent;
 using Model.Interface;
 using Model.Item;
 using Model.Movement;
@@ -22,18 +24,35 @@ public class BehindHouse : LocationBase
     public override async Task<InteractionResult> RespondToSpecificLocationInteraction(string? input, IContext context,
         IGenerationClient client)
     {
-        // Handle any "through window" command
-        if (input != null && input.ToLowerInvariant().Contains("through") &&
-            input.ToLowerInvariant().Contains("window"))
+        if (input != null)
         {
-            var window = Repository.GetItem<KitchenWindow>();
-            if (window.IsOpen)
+            // Issue #344: object-based phrasing for going through the window ("enter window",
+            // "board window", "through window", "go through window") means the same thing as the bare
+            // "in" / "west" commands here, so walk through it via the same gated movement edge instead
+            // of a generic refusal or no-op. This runs on the RAW input, before AI intent
+            // classification, since the AI parser does not reliably tag these short phrasings as a
+            // "board"/movement intent (unlike, say, "go to the kitchen through the window").
+            var normalized = input.ToLowerInvariant().Trim().Replace("the ", "");
+            if (normalized is "enter window" or "board window" or "through window" or "go through window")
             {
-                return new PositiveInteractionResult("The window is open. If you want to enter the house, just say so. ");
+                var (resultObject, resultMessage) =
+                    await new MoveEngine().Process(new MoveIntent { Direction = Direction.In }, context, client);
+                return resultObject ?? new PositiveInteractionResult(resultMessage);
             }
-            else
+
+            // Handle any other "through window" command (e.g. "look/peer/climb/crawl/squeeze/walk/move
+            // through window") - these are exploratory phrasing, not a request to actually go through.
+            if (normalized.Contains("through") && normalized.Contains("window"))
             {
-                return new PositiveInteractionResult("The window is slightly ajar, but not enough to permit entry. ");
+                var window = Repository.GetItem<KitchenWindow>();
+                if (window.IsOpen)
+                {
+                    return new PositiveInteractionResult("The window is open. If you want to enter the house, just say so. ");
+                }
+                else
+                {
+                    return new PositiveInteractionResult("The window is slightly ajar, but not enough to permit entry. ");
+                }
             }
         }
 

--- a/ZorkOne/Location/Kitchen.cs
+++ b/ZorkOne/Location/Kitchen.cs
@@ -1,5 +1,8 @@
 using GameEngine;
+using GameEngine.IntentEngine;
 using GameEngine.Location;
+using Model.AIGeneration;
+using Model.Intent;
 using Model.Interface;
 using Model.Movement;
 
@@ -17,6 +20,27 @@ public class Kitchen : LocationBase
                $"used recently for the preparation of food. A passage leads to the west " +
                $"and a dark staircase can be seen leading upward. A dark chimney leads down " +
                $"and to the east is a small window which is {(GetItem<KitchenWindow>().IsOpen ? "open" : "closed")}. ";
+    }
+
+    public override async Task<InteractionResult> RespondToSpecificLocationInteraction(string? input, IContext context,
+        IGenerationClient client)
+    {
+        if (input != null)
+        {
+            // Issue #344: symmetric to BehindHouse - object-based phrasing for going back out through
+            // the window ("exit window", "board window", "through window", "go through window") means
+            // the same thing as bare "out" / "east" here. See BehindHouse.RespondToSpecificLocationInteraction
+            // for why this is handled on the raw input rather than relying on AI intent classification.
+            var normalized = input.ToLowerInvariant().Trim().Replace("the ", "");
+            if (normalized is "exit window" or "board window" or "through window" or "go through window")
+            {
+                var (resultObject, resultMessage) =
+                    await new MoveEngine().Process(new MoveIntent { Direction = Direction.Out }, context, client);
+                return resultObject ?? new PositiveInteractionResult(resultMessage);
+            }
+        }
+
+        return await base.RespondToSpecificLocationInteraction(input, context, client);
     }
 
     protected override IReadOnlyList<SceneryItem> Scenery =>


### PR DESCRIPTION
## Summary

- Fixes #344 — `enter window`, `board window`, bare `through window`, and `go through window` didn't move the player through the open kitchen window; only the canonical `in`/`west` worked.
- Root cause: `BehindHouse.RespondToSpecificLocationInteraction` runs on the raw player input *before* AI intent classification, so its old `"through"` + `"window"` substring check only ever returned advisory text ("...just say so"). `enter window`/`board window` weren't handled there at all, so they fell through to the AI parser, which does not reliably tag these short, object-based phrasings as a movement/board intent — leading to "You can't get there from here." / "This action or command has no effect on the game." in production.
- Fix: route `enter window`, `board window`, `through window`, and `go through window` through the same gated `MoveEngine` edge that `in`/`west` already use (`BehindHouse.cs`), with a symmetric fix on the `Kitchen` side for `exit window`/`board window`/`through window`/`go through window` going back out (`out`/`east`). Other exploratory "through window" phrasing (`look`/`peer`/`climb`/`crawl`/`squeeze`/`walk`/`move through window`) is left unchanged.
- Verified against the original ZIL (`zork1/gsyntax.zil` `<SYNTAX ENTER OBJECT = V-THROUGH>` and the `KITCHEN-WINDOW-F` routine's `WALK`/`BOARD`/`THROUGH` handling) to confirm these phrasings are meant to actually traverse the window, gated by the destination room's own exit condition — matching the existing `enterKitchen`/`exit` `MovementParameters` gating already in place for `in`/`west`/`out`/`east`.

## Test plan

- [x] Added failing tests first (`ZorkOne.Tests/KitchenWindowTests.cs`), confirmed red against the pre-fix code (stashed the source changes, reran — all 6 new cases failed for the expected reason).
- [x] Implemented the minimal fix, reran the same tests — green.
- [x] Updated two pre-existing tests (`go through window`, open/closed) whose asserted behavior was the bug itself.
- [x] `dotnet test ZorkOne.Tests` — 1750/1750 passing.
- [x] `dotnet test UnitTests` — 985/985 passing (1 pre-existing skip).
- [x] `dotnet test Planetfall.Tests` — 2841/2841 passing (shared engine code path, `MoveEngine`).
- [x] `dotnet build` (full solution) — succeeds, no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011R2VDSByNDCTbpKkMTqjbo


---
_Generated by [Claude Code](https://claude.ai/code/session_011R2VDSByNDCTbpKkMTqjbo)_