### PR TITLE
Disarm Planetfall's explosion clock on god-mode teleport

### DIFF
--- a/GameEngine/StaticCommand/Implementation/GodModeProcessor.cs
+++ b/GameEngine/StaticCommand/Implementation/GodModeProcessor.cs
@@ -108,6 +108,14 @@ public class GodModeProcessor : IGlobalCommand
         // StartWithItem<T> (a bare Items.Add with no dedupe) would end up with their starting items
         // duplicated in the room.
         context.CurrentLocation = location;
+
+        // Issue #356 follow-up: this is a raw location swap, not a real move - it skips
+        // OnLeaveLocation/AfterEnterLocation, so a game-specific location-blind death clock (e.g.
+        // Planetfall's Feinstein explosion) never gets the chance to disarm itself. Let the context
+        // do that explicitly for a god-mode teleport.
+        if (context is IGodModeTeleportAware teleportAware)
+            teleportAware.OnGodModeTeleport();
+
         return $"Welcome to {location.Name}";
     }
 

--- a/Model/Interface/IGodModeTeleportAware.cs
+++ b/Model/Interface/IGodModeTeleportAware.cs
@@ -1,0 +1,17 @@
+namespace Model.Interface;
+
+/// <summary>
+///     Marker interface for game contexts that run early-game, location-blind timed-death mechanics
+///     (e.g. Planetfall's Feinstein explosion clock) which only check where the player currently is,
+///     not how they got there. "god mode go &lt;place&gt;" is a raw location swap for testing/debugging -
+///     it does not run the normal OnLeaveLocation/AfterEnterLocation hooks - so a tester who teleports
+///     away from the danger zone never trips the hook that would otherwise disarm the clock. It keeps
+///     counting turns in the background and can silently kill the tester once the move count rolls
+///     into its death window, far from whatever they were actually testing. Games that implement this
+///     get a chance to disarm those clocks when a god-mode teleport happens. Games without such
+///     mechanics do not implement this.
+/// </summary>
+public interface IGodModeTeleportAware
+{
+    void OnGodModeTeleport();
+}

--- a/Planetfall.Tests/ExplosionTests.cs
+++ b/Planetfall.Tests/ExplosionTests.cs
@@ -80,6 +80,28 @@ public class ExplosionTests : EngineTestsBase
         target.Context.DeathCounter.Should().Be(1);
     }
 
+    // Review follow-up on this PR: the previous fix left ExplosionCoordinator armed whenever the
+    // teleport destination was EscapePod, mirroring the DeckNine exception. But unlike DeckNine,
+    // EscapePod's move-14 case in ExplosionCoordinator has NO location check at all - under normal
+    // play that's safe because actually boarding the pod always disarms the coordinator first (via
+    // EscapePod.AfterEnterLocation), so the "still armed while genuinely inside the pod" state never
+    // occurs. "god mode go escape pod" skipped that hook and the old fix deliberately kept the clock
+    // armed for this destination, so a tester who teleported into the pod and waited out the clock
+    // was killed by their own ship's explosion while standing in the one place meant to be safe.
+    [Test]
+    public async Task GodModeGo_IntoEscapePod_DoesNotGetKilledByExplosionClock()
+    {
+        var target = GetTarget();
+        target.Context.CurrentLocation = Repository.GetLocation<MessHall>();
+
+        await target.GetResponse("god mode go escape pod");
+
+        for (var i = 0; i < 13; i++)
+            await target.GetResponse("wait");
+
+        target.Context.DeathCounter.Should().Be(0);
+    }
+
     [Test]
     [Explicit("Requires ZorkAI.OpenAI API key - tests pronoun resolution fix")]
     public async Task PronounResolution_OpenIt_ResolvesToBulkhead()

--- a/Planetfall.Tests/ExplosionTests.cs
+++ b/Planetfall.Tests/ExplosionTests.cs
@@ -38,6 +38,48 @@ public class ExplosionTests : EngineTestsBase
         target.Context.CurrentLocation.Should().BeOfType<MessHall>();
     }
 
+    // Code review follow-up on #356: OnGodModeTeleport only disarmed ExplosionCoordinator, leaving
+    // EscapePod's own post-landing sinking timer (YerSinking/TurnsAfterStanding) armed - it has the
+    // exact same location-blind death bug (no CurrentLocation check) that ExplosionCoordinator had.
+    // A tester who stands out of the safety web then teleports away to check something else could
+    // still be silently killed by the sinking pod several turns later, far from the pod.
+    [Test]
+    public async Task GodModeGo_DisarmsEscapePodSinkingClock_SoTeleportedTesterSurvives()
+    {
+        var target = GetTarget();
+        var pod = Repository.GetLocation<EscapePod>();
+        target.Context.CurrentLocation = pod;
+        pod.TurnsAfterStanding = 1; // already standing - sinking countdown underway
+        target.Context.RegisterActor(pod);
+
+        // A tester jumps straight to later content, unrelated to the sinking pod.
+        await target.GetResponse("god mode go mess hall");
+
+        for (var i = 0; i < 5; i++)
+            await target.GetResponse("wait");
+
+        target.Context.DeathCounter.Should().Be(0);
+        target.Context.CurrentLocation.Should().BeOfType<MessHall>();
+    }
+
+    // Code review follow-up on #356: OnGodModeTeleport originally disarmed ExplosionCoordinator
+    // unconditionally, even when the god-mode destination was Deck Nine itself - meaning a developer
+    // who teleported in specifically to test the Feinstein-explosion sequence found it permanently
+    // defused on arrival, with no way to observe it short of restarting the whole engine.
+    [Test]
+    public async Task GodModeGo_IntoDeckNine_DoesNotDisarmExplosionClock()
+    {
+        var target = GetTarget();
+        target.Context.CurrentLocation = Repository.GetLocation<MessHall>();
+
+        await target.GetResponse("god mode go deck nine");
+
+        for (var i = 0; i < 13; i++)
+            await target.GetResponse("wait");
+
+        target.Context.DeathCounter.Should().Be(1);
+    }
+
     [Test]
     [Explicit("Requires ZorkAI.OpenAI API key - tests pronoun resolution fix")]
     public async Task PronounResolution_OpenIt_ResolvesToBulkhead()

--- a/Planetfall.Tests/ExplosionTests.cs
+++ b/Planetfall.Tests/ExplosionTests.cs
@@ -6,11 +6,38 @@ using Moq;
 using OpenAI;
 using Planetfall.Item.Feinstein;
 using Planetfall.Location.Feinstein;
+using Planetfall.Location.Kalamontee;
 
 namespace Planetfall.Tests;
 
 public class ExplosionTests : EngineTestsBase
 {
+    // Issue #356 follow-up: "god mode go <place>" is a raw CurrentLocation swap for testing - it
+    // doesn't run DeckNine.OnLeaveLocation or EscapePod.AfterEnterLocation, so a tester who teleports
+    // away from Deck Nine to check on later content never unregisters ExplosionCoordinator. It keeps
+    // counting turns in the background and can unconditionally kill the tester (wiping their god-mode
+    // session via RestartAfterDeath) once Moves rolls into the 10-14 death window, nowhere near the
+    // ship. The clock is only meaningful while actually navigating the Deck Nine escape sequence, so
+    // a god-mode teleport should disarm it.
+    [Test]
+    public async Task GodModeGo_DisarmsExplosionClock_SoTeleportedTesterSurvives()
+    {
+        var target = GetTarget();
+        target.Context.CurrentLocation = Repository.GetLocation<DeckNine>();
+
+        // A tester jumps straight to later content, unrelated to the Deck Nine escape sequence.
+        await target.GetResponse("god mode go mess hall");
+
+        // Wait through the Feinstein-explosion window (moves 10-14), far from the ship.
+        for (var i = 0; i < 14; i++)
+            await target.GetResponse("wait");
+
+        // If the explosion clock had still fired, death would reset the game via
+        // RestartAfterDeath - snapping the player back to Deck Nine and bumping DeathCounter.
+        target.Context.DeathCounter.Should().Be(0);
+        target.Context.CurrentLocation.Should().BeOfType<MessHall>();
+    }
+
     [Test]
     [Explicit("Requires ZorkAI.OpenAI API key - tests pronoun resolution fix")]
     public async Task PronounResolution_OpenIt_ResolvesToBulkhead()

--- a/Planetfall/PlanetfallContext.cs
+++ b/Planetfall/PlanetfallContext.cs
@@ -255,15 +255,21 @@ public class PlanetfallContext : Context<PlanetfallGame>, ITimeBasedContext, ISu
     /// <summary>
     ///     Issue #356 follow-up: "god mode go &lt;place&gt;" is a raw CurrentLocation swap - it never runs
     ///     DeckNine.OnLeaveLocation or EscapePod.AfterEnterLocation, so ExplosionCoordinator (registered
-    ///     unconditionally from game start) stays armed even after a tester teleports away from the
-    ///     ship. It only checks CurrentLocation, not how the player got there, so it would otherwise
-    ///     unconditionally kill the tester once Moves rolls into its 10-14 death window, wherever they
-    ///     happened to be testing. Disarm it here; it's only meaningful while actually navigating the
-    ///     Deck Nine escape sequence.
+    ///     unconditionally from game start) and EscapePod's own post-landing sinking timer (armed once
+    ///     the player stands out of the safety web) stay armed even after a tester teleports away.
+    ///     Both only check CurrentLocation, not how the player got there, so either would otherwise
+    ///     unconditionally kill the tester once their move count rolls into its death window, wherever
+    ///     they happened to be testing. Disarm each - unless the teleport destination is the location
+    ///     it actually governs, so "god mode go deck nine" (or "... escape pod") still lets a tester
+    ///     observe the sequence instead of always defusing it on arrival.
     /// </summary>
     public void OnGodModeTeleport()
     {
-        RemoveActor<ExplosionCoordinator>();
+        if (CurrentLocation is not DeckNine && CurrentLocation is not EscapePod)
+            RemoveActor<ExplosionCoordinator>();
+
+        if (CurrentLocation is not EscapePod)
+            RemoveActor<EscapePod>();
     }
 
     /// <summary>

--- a/Planetfall/PlanetfallContext.cs
+++ b/Planetfall/PlanetfallContext.cs
@@ -259,13 +259,20 @@ public class PlanetfallContext : Context<PlanetfallGame>, ITimeBasedContext, ISu
     ///     the player stands out of the safety web) stay armed even after a tester teleports away.
     ///     Both only check CurrentLocation, not how the player got there, so either would otherwise
     ///     unconditionally kill the tester once their move count rolls into its death window, wherever
-    ///     they happened to be testing. Disarm each - unless the teleport destination is the location
-    ///     it actually governs, so "god mode go deck nine" (or "... escape pod") still lets a tester
-    ///     observe the sequence instead of always defusing it on arrival.
+    ///     they happened to be testing.
+    ///     ExplosionCoordinator is disarmed unless the destination is DeckNine specifically - staying
+    ///     armed there is intentional (mirrors normal play: staying put without reaching the pod is
+    ///     still fatal at move 14). EscapePod does NOT get the same exception: its move-14 case in
+    ///     ExplosionCoordinator has no location check at all, relying on EscapePod.AfterEnterLocation
+    ///     always disarming the coordinator before a real player is ever standing in the pod at that
+    ///     point - a god-mode teleport straight into the pod must disarm it the same way, or the
+    ///     tester gets killed by their own ship's explosion in the one place meant to be safe.
+    ///     EscapePod's own sinking timer is disarmed unless the destination is EscapePod itself, so a
+    ///     tester can still teleport in to observe that sequence.
     /// </summary>
     public void OnGodModeTeleport()
     {
-        if (CurrentLocation is not DeckNine && CurrentLocation is not EscapePod)
+        if (CurrentLocation is not DeckNine)
             RemoveActor<ExplosionCoordinator>();
 
         if (CurrentLocation is not EscapePod)

--- a/Planetfall/PlanetfallContext.cs
+++ b/Planetfall/PlanetfallContext.cs
@@ -6,7 +6,8 @@ using Utilities;
 
 namespace Planetfall;
 
-public class PlanetfallContext : Context<PlanetfallGame>, ITimeBasedContext, ISurvivalClockContext, IResettableClockContext
+public class PlanetfallContext : Context<PlanetfallGame>, ITimeBasedContext, ISurvivalClockContext,
+    IResettableClockContext, IGodModeTeleportAware
 {
     private const int TurnTimeIncrement = 54;
 
@@ -249,6 +250,20 @@ public class PlanetfallContext : Context<PlanetfallGame>, ITimeBasedContext, ISu
     {
         // God-mode commands still take a Planetfall turn, so compensate for the end-of-turn tick.
         Repository.GetItem<Chronometer>().CurrentTime = targetTime - TurnTimeIncrement;
+    }
+
+    /// <summary>
+    ///     Issue #356 follow-up: "god mode go &lt;place&gt;" is a raw CurrentLocation swap - it never runs
+    ///     DeckNine.OnLeaveLocation or EscapePod.AfterEnterLocation, so ExplosionCoordinator (registered
+    ///     unconditionally from game start) stays armed even after a tester teleports away from the
+    ///     ship. It only checks CurrentLocation, not how the player got there, so it would otherwise
+    ///     unconditionally kill the tester once Moves rolls into its 10-14 death window, wherever they
+    ///     happened to be testing. Disarm it here; it's only meaningful while actually navigating the
+    ///     Deck Nine escape sequence.
+    /// </summary>
+    public void OnGodModeTeleport()
+    {
+        RemoveActor<ExplosionCoordinator>();
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Investigation of #356 found the reported "unconditional death at move 14 silently wipes session progress" is **not a bug** — it's Planetfall's intentional, already-tested escape-pod timed puzzle. `Planetfall.Tests/ExplosionTests.cs` already has `Experience_StayOnDeckNine` (and four sibling tests) asserting that a player who never reaches the escape pod dies exactly as described — faithfully recreating the original Feinstein-explosion sequence. The issue's suggested fix (treat Deck Nine as permanently safe past move 12) would have broken that existing, deliberate mechanic and let players camp indefinitely at the very start of the game.

However, digging into the reproduction turned up a real, narrower problem: **`god mode go <place>`** — the dev/testing teleport command — is a raw `CurrentLocation` swap. It skips `DeckNine.OnLeaveLocation` and `EscapePod.AfterEnterLocation`, so a tester who teleports away from Deck Nine (e.g. to check on later-game content) never trips the hook that would normally unregister `ExplosionCoordinator`. The clock keeps counting turns in the background and can unconditionally kill the tester — wiping their god-mode session via `RestartAfterDeath` — once `Moves` rolls into its move-10-to-14 death window, regardless of what they're actually testing.

## Changes

- Added `Model/Interface/IGodModeTeleportAware`, a game-agnostic marker interface (mirroring the existing `IResettableClockContext` / `ISurvivalClockContext` god-mode affordances) with a single `OnGodModeTeleport()` hook.
- `GodModeProcessor.Go()` now calls this hook after relocating the player via `god mode go`.
- `PlanetfallContext` implements it to remove `ExplosionCoordinator` from the actor list. Games without a comparable location-blind death clock (Zork I) don't implement the interface and are unaffected.

## Test plan

- [x] Added `GodModeGo_DisarmsExplosionClock_SoTeleportedTesterSurvives` to `Planetfall.Tests/ExplosionTests.cs`, following TDD: confirmed red first (`DeathCounter` became 1 — the tester was killed and the session reset), then green after the fix.
- [x] `dotnet test Planetfall.Tests` — 2842 passed, 0 failed (including all existing explosion/death-sequence tests, confirming the intentional Deck-Nine death mechanic itself is untouched).
- [x] `dotnet test UnitTests` — 985 passed, 0 failed (game-agnostic `GodModeProcessor` change, ZorkOne's context doesn't implement the new interface).
- [x] `dotnet test ZorkOne.Tests` — 1750 passed, 0 failed.

https://claude.ai/code/session_01NRyG8MF31eey55kCyYrLjQ


---
_Generated by [Claude Code](https://claude.ai/code/session_01NRyG8MF31eey55kCyYrLjQ)_