### PR TITLE
Fix #360: gate fromitz board grant on HasGottenTheFromitzBoard

### DIFF
--- a/Planetfall.Tests/FloydTests.cs
+++ b/Planetfall.Tests/FloydTests.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using ChatLambda;
 using FluentAssertions;
 using Model.AIGeneration;
 using Model.AIGeneration.Requests;
@@ -11,6 +12,7 @@ using Planetfall.Item.Feinstein;
 using Planetfall.Item.Kalamontee.Admin;
 using Planetfall.Item.Kalamontee.Mech;
 using Planetfall.Item.Kalamontee.Mech.FloydPart;
+using Planetfall.Item.Lawanda.PlanetaryDefense;
 using Planetfall.Location.Kalamontee;
 using Planetfall.Location.Kalamontee.Mech;
 using Planetfall.Location.Lawanda;
@@ -2303,6 +2305,81 @@ public class FloydTests : EngineTestsBase
         floyd.Chooser = mockChooser.Object;
 
         floyd.OffersLowerElevatorCard(target.Context).Should().NotBeNull();
+    }
+
+    #endregion
+
+    #region Fromitz Board Retrieval Tests (issue #360)
+
+    private static Mock<IChatWithFloyd> FloydAnsweringPickUpBoard()
+    {
+        var mock = new Mock<IChatWithFloyd>();
+        mock.Setup(s => s.AskFloydAsync("take board")).ReturnsAsync(new CompanionResponse(
+            "Floyd's response",
+            new CompanionMetadata("PickUp", new Dictionary<string, object> { { "object", "board" } })));
+        return mock;
+    }
+
+    [Test]
+    public async Task FromitzBoardRetrieval_AlreadyRetrieved_DroppedElsewhere_DoesNotReacquire()
+    {
+        var target = GetTarget();
+        StartHere<RepairRoom>();
+        var floyd = GetItem<Floyd>();
+        floyd.IsOn = true;
+        floyd.HasGottenTheFromitzBoard = true;
+        floyd.ChatWithFloyd = FloydAnsweringPickUpBoard().Object;
+        GetLocation<RepairRoom>().ItemPlacedHere(floyd);
+
+        // The board was retrieved once already and dropped in a different room - not carried by the
+        // player and not installed anywhere.
+        var otherRoom = GetLocation<SystemsCorridorWest>();
+        otherRoom.ItemPlacedHere(GetItem<ShinyFromitzBoard>());
+
+        var response = await target.GetResponse("floyd, take board");
+
+        response.Should().Contain("already did that");
+        target.Context.Items.Should().NotContain(GetItem<ShinyFromitzBoard>());
+        GetItem<ShinyFromitzBoard>().CurrentLocation.Should().Be(otherRoom);
+    }
+
+    [Test]
+    public async Task FromitzBoardRetrieval_AlreadyInstalledInPanel_DoesNotUninstall()
+    {
+        var target = GetTarget();
+        StartHere<RepairRoom>();
+        var floyd = GetItem<Floyd>();
+        floyd.IsOn = true;
+        floyd.HasGottenTheFromitzBoard = true;
+        floyd.ChatWithFloyd = FloydAnsweringPickUpBoard().Object;
+        GetLocation<RepairRoom>().ItemPlacedHere(floyd);
+
+        // The board has already been installed in the panel, solving the planetary-defense puzzle.
+        var panel = GetItem<FromitzAccessPanel>();
+        panel.ItemPlacedHere(GetItem<ShinyFromitzBoard>());
+
+        var response = await target.GetResponse("floyd, take board");
+
+        response.Should().Contain("already did that");
+        target.Context.Items.Should().NotContain(GetItem<ShinyFromitzBoard>());
+        GetItem<ShinyFromitzBoard>().CurrentLocation.Should().Be(panel);
+    }
+
+    [Test]
+    public async Task FromitzBoardRetrieval_FirstTime_StillGivesBoard()
+    {
+        var target = GetTarget();
+        StartHere<RepairRoom>();
+        var floyd = GetItem<Floyd>();
+        floyd.IsOn = true;
+        floyd.ChatWithFloyd = FloydAnsweringPickUpBoard().Object;
+        GetLocation<RepairRoom>().ItemPlacedHere(floyd);
+
+        var response = await target.GetResponse("floyd, take board");
+
+        response.Should().Contain("If you say so");
+        target.Context.Items.Should().Contain(GetItem<ShinyFromitzBoard>());
+        floyd.HasGottenTheFromitzBoard.Should().BeTrue();
     }
 
     #endregion

--- a/Planetfall/Item/Kalamontee/Mech/FloydPart/FloydConstants.cs
+++ b/Planetfall/Item/Kalamontee/Mech/FloydPart/FloydConstants.cs
@@ -74,6 +74,9 @@ public static class FloydConstants
         "Floyd shrugs. \"If you say so.\" He vanishes for a few minutes, and returns holding the fromitz board. " +
         "It seems to be in good shape. He tosses it toward you, and you just manage to catch it before it smashes.";
 
+    internal const string AlreadyGotTheFromitzBoard =
+        "Floyd looks half-bored and half-annoyed. Floyd already did that. How about some leap-frogger?\"";
+
     internal const string GoNorth =
         "Floyd squeezes through the opening and is gone for quite a while. You hear thudding noises and squeals " +
         "of enjoyment. After a while the noise stops, and Floyd emerges, looking downcast. \"Floyd found a rubber " +

--- a/Planetfall/Item/Kalamontee/Mech/FloydPart/FloydConstants.cs
+++ b/Planetfall/Item/Kalamontee/Mech/FloydPart/FloydConstants.cs
@@ -75,7 +75,7 @@ public static class FloydConstants
         "It seems to be in good shape. He tosses it toward you, and you just manage to catch it before it smashes.";
 
     internal const string AlreadyGotTheFromitzBoard =
-        "Floyd looks half-bored and half-annoyed. Floyd already did that. How about some leap-frogger?\"";
+        "Floyd looks half-bored and half-annoyed. \"Floyd already did that. How about some leap-frogger?\"";
 
     internal const string GoNorth =
         "Floyd squeezes through the opening and is gone for quite a while. You hear thudding noises and squeals " +

--- a/Planetfall/Item/Kalamontee/Mech/FloydPart/FloydLocationBehaviors.cs
+++ b/Planetfall/Item/Kalamontee/Mech/FloydPart/FloydLocationBehaviors.cs
@@ -26,19 +26,16 @@ public class FloydLocationBehaviors(Floyd floyd)
 
     private string HandleFromitzBoardRetrieval(IContext context)
     {
+        floyd.SkipActingThisTurn(context);
+
         // Only actually (re-)grant the board the first time. On repeat visits, the board may already
         // be in another room, or - worse - installed and doing puzzle duty in the FromitzAccessPanel;
         // context.ItemPlacedHere() would silently rip it out of wherever it currently is (issue #360).
         if (floyd.HasGottenTheFromitzBoard)
-        {
-            floyd.SkipActingThisTurn(context);
             return FloydConstants.AlreadyGotTheFromitzBoard;
-        }
 
         context.ItemPlacedHere<ShinyFromitzBoard>();
-
         floyd.HasGottenTheFromitzBoard = true;
-        floyd.SkipActingThisTurn(context);
         return FloydConstants.GetTheFromitzBoard;
     }
 

--- a/Planetfall/Item/Kalamontee/Mech/FloydPart/FloydLocationBehaviors.cs
+++ b/Planetfall/Item/Kalamontee/Mech/FloydPart/FloydLocationBehaviors.cs
@@ -32,7 +32,7 @@ public class FloydLocationBehaviors(Floyd floyd)
         if (floyd.HasGottenTheFromitzBoard)
         {
             floyd.SkipActingThisTurn(context);
-            return "Floyd looks half-bored and half-annoyed. Floyd already did that. How about some leap-frogger?\"";
+            return FloydConstants.AlreadyGotTheFromitzBoard;
         }
 
         context.ItemPlacedHere<ShinyFromitzBoard>();

--- a/Planetfall/Item/Kalamontee/Mech/FloydPart/FloydLocationBehaviors.cs
+++ b/Planetfall/Item/Kalamontee/Mech/FloydPart/FloydLocationBehaviors.cs
@@ -26,15 +26,20 @@ public class FloydLocationBehaviors(Floyd floyd)
 
     private string HandleFromitzBoardRetrieval(IContext context)
     {
-        var returnString = floyd.HasGottenTheFromitzBoard
-            ? "Floyd looks half-bored and half-annoyed. Floyd already did that. How about some leap-frogger?\""
-            : FloydConstants.GetTheFromitzBoard;
+        // Only actually (re-)grant the board the first time. On repeat visits, the board may already
+        // be in another room, or - worse - installed and doing puzzle duty in the FromitzAccessPanel;
+        // context.ItemPlacedHere() would silently rip it out of wherever it currently is (issue #360).
+        if (floyd.HasGottenTheFromitzBoard)
+        {
+            floyd.SkipActingThisTurn(context);
+            return "Floyd looks half-bored and half-annoyed. Floyd already did that. How about some leap-frogger?\"";
+        }
 
         context.ItemPlacedHere<ShinyFromitzBoard>();
 
         floyd.HasGottenTheFromitzBoard = true;
         floyd.SkipActingThisTurn(context);
-        return returnString;
+        return FloydConstants.GetTheFromitzBoard;
     }
 
     private string HandleSmallDoorExploration(IContext context)


### PR DESCRIPTION
## Summary

- `FloydLocationBehaviors.HandleFromitzBoardRetrieval` only used `floyd.HasGottenTheFromitzBoard` to pick which string to return; `context.ItemPlacedHere<ShinyFromitzBoard>()` ran **unconditionally** on every call.
- This meant asking Floyd to fetch the board a second time silently teleported it back into the player's inventory from wherever it currently was — including yanking it out of the `FromitzAccessPanel` after the planetary-defense puzzle had already been solved, un-solving a completed, scored puzzle step with no narration explaining it.
- Fix: gate the `context.ItemPlacedHere<ShinyFromitzBoard>()` call on `!floyd.HasGottenTheFromitzBoard`. Repeat requests now just return the "already did that" line with no state mutation.
- Incidental fix while extracting that line into `FloydConstants.AlreadyGotTheFromitzBoard`: the original inline string had a stray trailing `\"` with no matching opening quote. Added the opening quote so Floyd's spoken line reads correctly - a small, visible change to the rendered text.

## Test plan (TDD, per CLAUDE.md)

Added three tests to `Planetfall.Tests/FloydTests.cs` (real `Repository`, `Repository.Reset()`, mocked `IChatWithFloyd`/`IRandomChooser` where needed):

- `FromitzBoardRetrieval_AlreadyRetrieved_DroppedElsewhere_DoesNotReacquire` — board previously retrieved and dropped in another room; asking again returns "already did that" and leaves the board where it was. Fails before the fix (board teleports into inventory).
- `FromitzBoardRetrieval_AlreadyInstalledInPanel_DoesNotUninstall` — the confirmed puzzle-breaking case: board already installed in `FromitzAccessPanel`; asking again must not rip it back out. Fails before the fix.
- `FromitzBoardRetrieval_FirstTime_StillGivesBoard` — first-time grant behavior is unchanged (still gives the board and sets the flag).

- [x] New tests fail before the fix and pass after
- [x] `dotnet test Planetfall.Tests` — 2849 passed, 0 failed
- [x] `dotnet test UnitTests` — 985 passed, 0 failed (1 pre-existing skip, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N5jx79SBb97zXg1nfsFRck