### PR TITLE
Fix #365: stop Floyd from teleporting back into the room mid Bio Lab fight

### DIFF
--- a/Planetfall.Tests/BioLockEastTests.cs
+++ b/Planetfall.Tests/BioLockEastTests.cs
@@ -398,6 +398,41 @@ public class BioLockEastTests : EngineTestsBase
     }
 
     [Test]
+    public async Task AbandoningSequence_ByWalkingAway_ShouldNotPermanentlySoftlockFloyd()
+    {
+        // Issue #365 follow-up: IsAwayOnScriptedSequence is only ever set true (never cleared) by the
+        // Bio Lab sequence. If the player walks away instead of closing the door, BioLockEast unregisters
+        // itself as an actor (OnLeaveLocation) and the state machine freezes forever - so without an
+        // explicit recovery, Floyd would stay CurrentLocation=null and IsAwayOnScriptedSequence=true for
+        // the rest of the game, with no in-game way to get him back. BioLockEast.OnLeaveLocation must
+        // release the flag when the sequence is abandoned mid-flight, letting Floyd's normal following
+        // behavior resume.
+        var target = GetTarget();
+        var floyd = GetItem<Floyd>();
+        floyd.IsOn = true;
+        floyd.TurnOnCountdown = 0;
+        floyd.HasEverBeenOn = true;
+        var mockChooser = new Mock<IRandomChooser>();
+        mockChooser.Setup(r => r.RollDiceSuccess(5)).Returns(false); // deterministic: always the "follow" branch
+        floyd.Chooser = mockChooser.Object;
+        var bioLockEast = StartHere<BioLockEast>();
+        bioLockEast.ItemPlacedHere(floyd);
+        bioLockEast.StateMachine.HasWaitedOneTurnInBioLockEast = true;
+        bioLockEast.StateMachine.FloydHasSaidNeedToGetCard = true;
+        target.Context.RegisterActor(floyd);
+        target.Context.RegisterActor(bioLockEast);
+
+        await target.GetResponse("open door"); // Floyd rushes in: CurrentLocation=null, IsAwayOnScriptedSequence=true
+        floyd.IsAwayOnScriptedSequence.Should().BeTrue();
+
+        var response = await target.GetResponse("west"); // Abandon the sequence instead of closing the door
+
+        floyd.IsAwayOnScriptedSequence.Should().BeFalse("leaving mid-sequence must release Floyd, not strand him forever");
+        response.Should().Contain("Floyd follows you");
+        floyd.CurrentLocation.Should().NotBeNull("Floyd must be recoverable, not permanently stuck with no location");
+    }
+
+    [Test]
     public async Task FloydFighting_Turn1_ShouldShowInTheLabTwo()
     {
         var target = GetTarget();
@@ -467,6 +502,28 @@ public class BioLockEastTests : EngineTestsBase
         await target.GetResponse("open door");
 
         bioLockEast.StateMachine.LabSequenceState.Should().Be(FloydLabSequenceState.DoorReopenedNeedToCloseAgain);
+    }
+
+    [Test]
+    public async Task ReopenDoor_AfterInTheLabFour_FloydShouldActuallyBeBackInTheRoom()
+    {
+        // The narration ("Floyd stumbles out of the Bio Lab, clutching the mini-booth card") says he's
+        // back, but earlier in the sequence he was correctly given CurrentLocation = null while fighting
+        // (unlike sibling tests here, which pre-seed ItemPlacedHere and so never exercise this transition
+        // starting from the real null-location state). Reopening the door must actually restore his
+        // presence, not just narrate it.
+        var target = GetTarget();
+        var floyd = GetItem<Floyd>();
+        floyd.IsOn = true;
+        floyd.CurrentLocation = null;
+        var bioLockEast = StartHere<BioLockEast>();
+        bioLockEast.StateMachine.LabSequenceState = FloydLabSequenceState.NeedToReopenDoor;
+        target.Context.RegisterActor(bioLockEast);
+
+        await target.GetResponse("open door");
+
+        floyd.CurrentLocation.Should().Be(bioLockEast);
+        bioLockEast.Items.Should().Contain(floyd);
     }
 
     [Test]

--- a/Planetfall.Tests/BioLockEastTests.cs
+++ b/Planetfall.Tests/BioLockEastTests.cs
@@ -1,4 +1,6 @@
 ﻿using FluentAssertions;
+using Model.Interface;
+using Moq;
 using Planetfall.Item.Kalamontee.Mech.FloydPart;
 using Planetfall.Item.Lawanda.Lab;
 using Planetfall.Location.Lawanda;
@@ -356,6 +358,43 @@ public class BioLockEastTests : EngineTestsBase
 
         response.Should().Contain("And not a moment too soon!");
         bioLockEast.StateMachine.LabSequenceState.Should().Be(FloydLabSequenceState.DoorClosedFloydFighting);
+    }
+
+    [Test]
+    public async Task CloseDoor_WithFloydRegisteredAsRealActor_FloydShouldRemainAbsentWhileFighting()
+    {
+        // Issue #365: in real gameplay, Floyd is registered as an actor via FloydPowerManager.Activate()
+        // long before the player reaches BioLockEast, so both Floyd and BioLockEast act every turn. Every
+        // other test in this file only registers BioLockEast, so Floyd's own Act() never runs here and this
+        // gap was never exercised. Floyd is always added to Context.Actors before BioLockEast (he's
+        // activated earlier in the game), so his Act() always runs first in ProcessActors()'s loop - which
+        // means BioLockEast's floyd.SkipActingThisTurn(context) calls (meant to keep Floyd quiet while he's
+        // "in the lab") always arrive one actor-turn too late to stop this same turn's Floyd.Act(). Once
+        // HandleDoorOpening sets floyd.CurrentLocation = null to represent Floyd being absent (fighting
+        // in the lab), Floyd's own FloydMovementManager.HandleFollowingPlayer sees a location mismatch and
+        // "helpfully" teleports him straight back into the room, announcing "Floyd follows you." while the
+        // narration simultaneously says he's trapped behind the door fighting mutants.
+        var target = GetTarget();
+        var floyd = GetItem<Floyd>();
+        floyd.IsOn = true;
+        floyd.TurnOnCountdown = 0; // He's been on for a while by the time he reaches BioLockEast, same as real play
+        floyd.HasEverBeenOn = true;
+        var mockChooser = new Mock<IRandomChooser>();
+        mockChooser.Setup(r => r.RollDiceSuccess(5)).Returns(false); // deterministic: always the "follow" branch
+        floyd.Chooser = mockChooser.Object;
+        var bioLockEast = StartHere<BioLockEast>();
+        bioLockEast.ItemPlacedHere(floyd);
+        bioLockEast.StateMachine.HasWaitedOneTurnInBioLockEast = true; // Skip the one-turn delay
+        bioLockEast.StateMachine.FloydHasSaidNeedToGetCard = true;
+        target.Context.RegisterActor(floyd);
+        target.Context.RegisterActor(bioLockEast);
+
+        await target.GetResponse("open door");
+        var response = await target.GetResponse("close door");
+
+        response.Should().NotContain("Floyd follows you");
+        floyd.CurrentLocation.Should().BeNull("Floyd is trapped in the Bio Lab fighting mutants, not following the player");
+        bioLockEast.Items.Should().NotContain(floyd);
     }
 
     [Test]

--- a/Planetfall/Item/Kalamontee/Mech/FloydPart/Floyd.cs
+++ b/Planetfall/Item/Kalamontee/Mech/FloydPart/Floyd.cs
@@ -42,6 +42,13 @@ public class Floyd : QuirkyCompanion, IAmANamedPerson, ICanHoldItems, ICanBeGive
 
     [UsedImplicitly] public int WanderingTurnsRemaining { get; set; }
 
+    // Set by a scripted sequence (e.g. the Bio Lab fight in BioLockStateMachineManager) that has
+    // deliberately given Floyd CurrentLocation = null to represent him being absent/busy elsewhere.
+    // Without this, FloydMovementManager.HandleFollowingPlayer sees the location mismatch on Floyd's
+    // very next Act() and "helpfully" teleports him straight back into the player's room, undoing the
+    // sequence's own bookkeeping (issue #365).
+    [UsedImplicitly] public bool IsAwayOnScriptedSequence { get; set; }
+
     [UsedImplicitly] public bool HasEverBeenOn { get; set; }
 
     // Tracks whether the one-time +2 award for turning Floyd on has already been granted. We can't

--- a/Planetfall/Item/Kalamontee/Mech/FloydPart/FloydMovementManager.cs
+++ b/Planetfall/Item/Kalamontee/Mech/FloydPart/FloydMovementManager.cs
@@ -32,8 +32,9 @@ public class FloydMovementManager(Floyd floyd)
     /// </summary>
     public async Task<string> HandleFollowingPlayer(IContext context, IGenerationClient client)
     {
-        // Don't follow if already wandering
-        if (floyd.IsOffWandering)
+        // Don't follow if already wandering, or deliberately parked elsewhere by a scripted sequence
+        // (e.g. the Bio Lab fight, which sets CurrentLocation = null to represent Floyd being absent).
+        if (floyd.IsOffWandering || floyd.IsAwayOnScriptedSequence)
             return string.Empty;
 
         bool isInTheRoom = floyd.CurrentLocation == context.CurrentLocation;

--- a/Planetfall/Location/Lawanda/Lab/BioLockEast.cs
+++ b/Planetfall/Location/Lawanda/Lab/BioLockEast.cs
@@ -58,6 +58,13 @@ internal class BioLockEast : LocationBase, ITurnBasedActor, IFloydDoesNotTalkHer
 
     public override void OnLeaveLocation(IContext context, ILocation newLocation, ILocation previousLocation)
     {
+        // Issue #365 follow-up: if the player abandons the Bio Lab sequence mid-flight (walks away
+        // instead of closing the door), this actor stops running and never gets another turn to progress
+        // the state machine. Without releasing Floyd here, IsAwayOnScriptedSequence would stay true
+        // forever with no other code path to clear it, permanently blocking his normal following behavior.
+        if (StateMachine.IsFloydInLabFighting)
+            Repository.GetItem<Floyd>().IsAwayOnScriptedSequence = false;
+
         context.RemoveActor(this);
     }
 

--- a/Planetfall/Location/Lawanda/Lab/BioLockStateMachineManager.cs
+++ b/Planetfall/Location/Lawanda/Lab/BioLockStateMachineManager.cs
@@ -168,6 +168,7 @@ public class BioLockStateMachineManager
             // Remove Floyd from the room - he's now in the lab fighting!
             bioLockEast.RemoveItem(floyd);
             floyd.CurrentLocation = null; // Floyd has no location while in the lab
+            floyd.IsAwayOnScriptedSequence = true; // Stop his own Act() from following him back in early
             floyd.SkipActingThisTurn(context);
 
             return FloydConstants.InTheLabOne;

--- a/Planetfall/Location/Lawanda/Lab/BioLockStateMachineManager.cs
+++ b/Planetfall/Location/Lawanda/Lab/BioLockStateMachineManager.cs
@@ -179,6 +179,7 @@ public class BioLockStateMachineManager
         {
             LabSequenceState = FloydLabSequenceState.DoorReopenedNeedToCloseAgain;
             TurnsAfterDoorReopened = 0; // Reset the turn counter
+            bioLockEast.ItemPlacedHere(floyd); // He's stumbled back into the room, clutching the card
             floyd.SkipActingThisTurn(context);
             return FloydConstants.FloydReturnsWithCard;
         }

--- a/Planetfall/Location/Lawanda/Lab/BioLockStateMachineManager.cs
+++ b/Planetfall/Location/Lawanda/Lab/BioLockStateMachineManager.cs
@@ -180,6 +180,11 @@ public class BioLockStateMachineManager
             LabSequenceState = FloydLabSequenceState.DoorReopenedNeedToCloseAgain;
             TurnsAfterDoorReopened = 0; // Reset the turn counter
             bioLockEast.ItemPlacedHere(floyd); // He's stumbled back into the room, clutching the card
+
+            // IsAwayOnScriptedSequence is deliberately left true here, unlike the abandon path in
+            // BioLockEast.OnLeaveLocation - every exit from here still ends in floyd.HasDied = true
+            // (EndSequence or the trapped-death branch), which already short-circuits Floyd.Act() before
+            // HandleFollowingPlayer would ever read the flag again.
             floyd.SkipActingThisTurn(context);
             return FloydConstants.FloydReturnsWithCard;
         }


### PR DESCRIPTION
## Summary

Fixes #365. The bug report's own hypothesis - "no test ever registers Floyd as a real actor alongside `BioLockEast`" - turned out to be the exact right lead, but the actual defect it exposes is more specific than "the dialogue never fires."

- In real play, Floyd is registered as an `ITurnBasedActor` via `FloydPowerManager.Activate()` long before the player ever reaches Bio Lock East. Because he's added to `Context.Actors` first, his own `Act()` always runs *before* `BioLockEast.Act()` in `ProcessActors()`'s loop each turn.
- `BioLockStateMachineManager.HandleTurnAction` calls `floyd.SkipActingThisTurn(context)` from several branches, intending to keep Floyd quiet while he's "in the lab" - but since `BioLockEast.Act()` always runs *after* Floyd's own `Act()` in the same turn, that call always arrives one actor-turn too late to do anything (and `ProcessBeginningOfTurn` resets the flag again before Floyd's next turn regardless).
- When `HandleDoorOpening` sets `floyd.CurrentLocation = null` to represent Floyd being absent (fighting mutants behind the closed door), Floyd's own `FloydMovementManager.HandleFollowingPlayer` sees the location mismatch on his very next `Act()` and "helpfully" teleports him straight back into the room, printing `"Floyd follows you."` - while the narration in the same breath says he's trapped fighting for his life on the other side of the door. This also puts him back in `BioLockEast.Items`, contradicting the sequence's own invariant (checked elsewhere by `WhileFloydFighting_FloydNotInRoomItems`).

Every existing `BioLockEastTests`/`WalkthroughBioLock` test only ever calls `Context.RegisterActor(bioLockEast)`, never `Context.RegisterActor(floyd)`, so Floyd's `Act()` never actually ran and this gap was invisible to the suite - exactly as the issue predicted.

### Fix

- Added `Floyd.IsAwayOnScriptedSequence`, mirroring the existing `IsOffWandering` guard.
- `BioLockStateMachineManager` sets it when Floyd rushes into the lab (alongside the existing `CurrentLocation = null`).
- `FloydMovementManager.HandleFollowingPlayer` now treats it the same as `IsOffWandering`: don't try to reposition Floyd back into the room.

### Follow-up fixes (from a recall-focused `/code-review` of the original fix)

The initial fix introduced two regressions of its own, both now fixed with regression tests:

1. **Floyd could be permanently softlocked.** `IsAwayOnScriptedSequence` was set `true` but never reset. If the player abandons the sequence mid-fight by walking away instead of closing the door, `BioLockEast` stops acting (the state machine freezes) but Floyd stays parked with no location - forever, since nothing else ever clears the flag. `examine floyd` returned a blank response, with no in-game recovery. Fixed by releasing the flag in `BioLockEast.OnLeaveLocation` when the sequence is abandoned mid-flight - this also fixes a "ghost talk" case where Floyd could narrate being active in a room he couldn't physically be in.
2. **Door-reopen didn't actually place Floyd back in the room.** `HandleDoorOpening`'s `NeedToReopenDoor` branch narrates "Floyd stumbles out of the Bio Lab, clutching the mini-booth card" but never called `ItemPlacedHere` - a pre-existing bug, but the original fix made it 100% reproducible instead of ~80% accidentally masked by the old buggy auto-follow it removed.

The review also surfaced two more severe but genuinely pre-existing and unrelated bugs in the same state machine (confirmed present with or without this PR's changes): opening the door and then simply walking out and back in leaves a turn counter un-reset, causing an instant unavoidable player death on re-entry; and a god-mode teleport away during the same window causes an unrelated death later regardless of player location. Left out of this PR's scope since they're a different root cause (state never resets when the sequence is abandoned via normal movement, independent of the actor-registration bug this PR fixes) - worth a follow-up issue.

## Test plan

- [x] `Planetfall.Tests/BioLockEastTests.cs`: `CloseDoor_WithFloydRegisteredAsRealActor_FloydShouldRemainAbsentWhileFighting` - registers both Floyd and `BioLockEast` as real actors (matching production), verified failing before the fix and passing after.
- [x] `AbandoningSequence_ByWalkingAway_ShouldNotPermanentlySoftlockFloyd` - proves the softlock regression and its fix.
- [x] `ReopenDoor_AfterInTheLabFour_FloydShouldActuallyBeBackInTheRoom` - proves the missing-placement bug and its fix.
- [x] `dotnet test Planetfall.Tests` - 2859 passed, 0 failed.
- [x] `dotnet test UnitTests` - 985 passed, 0 failed.
- [x] `dotnet test ZorkOne.Tests` - 1750 passed, 0 failed.
- [x] Manually re-verified the full `WalkthroughBioLock` 48-scenario matrix with Floyd genuinely registered as an actor (temporary local edit, not committed) to confirm the whole sequence - waiting, opening/closing the door, Floyd rushing in, fighting, dying, and the successful sacrifice ending - still narrates correctly end-to-end.