### PR TITLE
Fix #370: opening an empty canteen no longer returns a blank response

### DIFF
--- a/Planetfall.Tests/KitchenAndCanteenTests.cs
+++ b/Planetfall.Tests/KitchenAndCanteenTests.cs
@@ -148,6 +148,28 @@ public class KitchenAndCanteenTests : EngineTestsBase
         Repository.GetItem<Canteen>().Items.Should().NotBeEmpty();
     }
 
+    [Test]
+    public async Task OpenCanteen_Empty()
+    {
+        var target = GetTarget();
+        StartHere<MessCorridor>();
+        Take<Canteen>();
+
+        var response = await target.GetResponse("open canteen");
+        response.Should().Contain("Opened");
+    }
+
+    [Test]
+    public async Task OpenCanteen_WithProteinLiquid()
+    {
+        var target = GetTarget();
+        StartHere<MessCorridor>();
+        Take<Canteen>();
+        GetItem<Canteen>().Items.Add(GetItem<ProteinLiquid>());
+
+        var response = await target.GetResponse("open canteen");
+        response.Should().Contain("Opening the canteen reveals a quantity of protein-rich liquid.");
+    }
 
     // TODO: drink dont have it
     // TODO: put something in canteen

--- a/Planetfall/Item/Kalamontee/Canteen.cs
+++ b/Planetfall/Item/Kalamontee/Canteen.cs
@@ -30,7 +30,10 @@ public class Canteen : OpenAndCloseContainerBase, ICanBeExamined, ICanBeTakenAnd
 
     public override string NowOpen(ILocation currentLocation)
     {
-        return string.Empty;
+        // Empty must fall back to the base "Opened." - OnOpening only supplies text when
+        // there's protein liquid to describe, so returning empty here for both would leave
+        // the player with a blank response (issue #370).
+        return Items.Any() ? string.Empty : base.NowOpen(currentLocation);
     }
 
     public override string OnOpening(IContext context)


### PR DESCRIPTION
## Summary
- `Canteen.NowOpen` unconditionally returned `string.Empty`, which relied on `OnOpening` to supply text. That works when the canteen has protein liquid (`OnOpening` returns the "reveals a quantity of protein-rich liquid" message), but when the canteen is empty, `OnOpening` falls through to the base no-op — leaving both halves of the concatenated response empty, so `open canteen` prints nothing.
- Fixed `Canteen.NowOpen` to delegate to the base `"Opened."` message when the canteen is empty, and keep returning `string.Empty` when it has contents (so `OnOpening`'s custom message isn't duplicated) — the same pattern already used by `SurvivalKit.NowOpen`.

## Test plan
- [x] Added `OpenCanteen_Empty` to `Planetfall.Tests/KitchenAndCanteenTests.cs`, asserting `open canteen` on a freshly-taken, empty canteen returns non-empty text containing "Opened" (red before the fix — previously returned an empty string).
- [x] Added `OpenCanteen_WithProteinLiquid` as a regression guard, asserting the canteen-with-liquid path still returns the "Opening the canteen reveals a quantity of protein-rich liquid." message unchanged.
- [x] `dotnet test Planetfall.Tests` — 2861 passed, 0 failed.
- [x] `dotnet test UnitTests` — 985 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TAwkj1TyRcBY88xG26UXLs

---
_Generated by [Claude Code](https://claude.ai/code/session_01TAwkj1TyRcBY88xG26UXLs)_