### PR TITLE
Fix #376: "get in web" and "enter web" now work in the escape pod

### DIFF
--- a/Planetfall.Tests/ExplosionTests.cs
+++ b/Planetfall.Tests/ExplosionTests.cs
@@ -529,4 +529,44 @@ public class ExplosionTests : EngineTestsBase
         // The web is unharmed, but the pod still stabilizes and looks for a destination.
         response.Should().Contain("autopilot searches for a reasonable destination");
     }
+
+    // Issue #376: "get in web" / "enter web" resolve to an EnterSubLocationIntent whose noun is
+    // looked up via Repository.GetItemInScope - but SafetyWeb was never actually seeded into the
+    // pod's Items list by EscapePod.Init() (only BulkheadDoor was), so the scope lookup always
+    // failed even though the room's own description talks about the webbing. The exact-phrase
+    // shortcuts in EscapePod.RespondToSpecificLocationInteraction ("sit", "get in", "enter webbing")
+    // masked this for those specific strings, but any phrasing that reaches normal noun resolution
+    // - like the bare noun "web" - fell through to a generic "can't go that way" refusal instead of
+    // actually sitting the player down in the webbing.
+    [TestFixture]
+    public class EnterWebTests : EngineTestsBase
+    {
+        [Test]
+        public async Task EnterWeb_PutsPlayerInTheSafetyWeb()
+        {
+            var target = GetTarget();
+            var pod = Repository.GetLocation<EscapePod>();
+            pod.Init(); // place BulkheadDoor and SafetyWeb in the pod's scope
+            target.Context.CurrentLocation = pod;
+
+            var response = await target.GetResponse("enter web");
+
+            response.Should().Contain("You are now safely cushioned within the web.");
+            pod.SubLocation.Should().BeOfType<SafetyWeb>();
+        }
+
+        [Test]
+        public async Task GetInWeb_PutsPlayerInTheSafetyWeb()
+        {
+            var target = GetTarget();
+            var pod = Repository.GetLocation<EscapePod>();
+            pod.Init();
+            target.Context.CurrentLocation = pod;
+
+            var response = await target.GetResponse("get in web");
+
+            response.Should().Contain("You are now safely cushioned within the web.");
+            pod.SubLocation.Should().BeOfType<SafetyWeb>();
+        }
+    }
 }

--- a/Planetfall/Location/Feinstein/EscapePod.cs
+++ b/Planetfall/Location/Feinstein/EscapePod.cs
@@ -346,5 +346,13 @@ internal class EscapePod : LocationBase, ITurnBasedActor
     public override void Init()
     {
         StartWithItem<BulkheadDoor>();
+
+        // Issue #376: SafetyWeb was never actually seeded here, so "enter web"/"get in web" - which
+        // resolve to an EnterSubLocationIntent whose noun is looked up via
+        // Repository.GetItemInScope - could never find it, even though the room's own description
+        // talks about the webbing filling the pod. The raw-text shortcuts in
+        // RespondToSpecificLocationInteraction ("sit", "get in", "enter webbing") masked this for
+        // those exact phrasings only.
+        StartWithItem<SafetyWeb>();
     }
 }

--- a/UnitTests/IntentMappings/base-mappings.json
+++ b/UnitTests/IntentMappings/base-mappings.json
@@ -315,7 +315,9 @@
     { "inputs": ["enter door", "board door"], "noun": "door" },
 
     { "inputs": ["enter elevator", "enter the elevator"], "noun": "elevator" },
-    { "inputs": ["enter the kitchen", "enter kitchen"], "noun": "kitchen" }
+    { "inputs": ["enter the kitchen", "enter kitchen"], "noun": "kitchen" },
+
+    { "inputs": ["enter web", "enter the web", "enter webbing", "enter the webbing", "get in web", "get in the web", "get in webbing", "get in the webbing", "board web", "board webbing"], "noun": "web" }
   ],
 
   "exitSubLocationIntents": [


### PR DESCRIPTION
## Summary

- `SafetyWeb` (the escape pod's safety webbing) was never actually seeded into `EscapePod`'s `Items` list — `Init()` only placed `BulkheadDoor`. Since `Repository.GetItemInScope` requires an item to be reachable from the room/inventory, any command that resolves "web"/"webbing" through normal noun resolution — like the bare noun in `enter web` or `get in web` — failed to find it and fell through to a generic "can't go that way" refusal.
- The raw-text shortcuts in `EscapePod.RespondToSpecificLocationInteraction` (`"sit"`, `"get in"`, `"enter webbing"`) bypass scope resolution entirely, which is why those exact phrasings appeared to work while `"enter web"` / `"get in web"` did not — masking the underlying gap.
- Fix: seed `SafetyWeb` into the pod via `StartWithItem<SafetyWeb>()` in `EscapePod.Init()`, alongside the existing `BulkheadDoor`, so it's properly in scope for normal `EnterSubLocationEngine` resolution.
- Added deterministic test-parser mappings (`enter web`, `get in web`, and related phrasings) to `UnitTests/IntentMappings/base-mappings.json` so the fix is provable without a live AI call.

## Test plan

- [x] Added failing-first tests (`EnterWeb_PutsPlayerInTheSafetyWeb`, `GetInWeb_PutsPlayerInTheSafetyWeb`) to `Planetfall.Tests/ExplosionTests.cs`, confirmed both failed before the fix (empty response — command unrecognized).
- [x] Applied the fix; both tests pass.
- [x] `dotnet test Planetfall.Tests` — 2906/2906 passed, no regressions.
- [x] `dotnet test UnitTests` — 993/994 passed (1 pre-existing skip), no regressions.
- [x] `dotnet test ZorkOne.Tests` — 1752/1752 passed, no regressions.
- [x] `dotnet build` — solution builds cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016pKaC1x8mAxC4BdL5TkXMS

---
_Generated by [Claude Code](https://claude.ai/code/session_016pKaC1x8mAxC4BdL5TkXMS)_