### PR TITLE
Fix #191: block White Cliffs Beach paths while the inflated boat is with the player

### DIFF
--- a/ZorkOne.Tests/BoatTests.cs
+++ b/ZorkOne.Tests/BoatTests.cs
@@ -520,4 +520,113 @@ public class BoatTests : EngineTestsBase
         response.Should().Contain("You are now in the magic boat.");
         target.Context.CurrentLocation.SubLocation.Should().NotBeNull();
     }
+
+    [Test]
+    public async Task WhiteCliffsNorth_InInflatedBoat_PathTooNarrow_South()
+    {
+        var target = GetTarget();
+        var boat = Repository.GetItem<PileOfPlastic>();
+        boat.IsInflated = true;
+        target.Context.CurrentLocation = Repository.GetLocation<WhiteCliffsBeachNorth>();
+        target.Context.CurrentLocation.SubLocation = boat;
+
+        var response = await target.GetResponse("south");
+
+        response.Should().Contain("The path is too narrow");
+        target.Context.CurrentLocation.Should().BeOfType<WhiteCliffsBeachNorth>();
+    }
+
+    [Test]
+    public async Task WhiteCliffsNorth_InInflatedBoat_PathTooNarrow_West()
+    {
+        var target = GetTarget();
+        var boat = Repository.GetItem<PileOfPlastic>();
+        boat.IsInflated = true;
+        target.Context.CurrentLocation = Repository.GetLocation<WhiteCliffsBeachNorth>();
+        target.Context.CurrentLocation.SubLocation = boat;
+
+        var response = await target.GetResponse("west");
+
+        response.Should().Contain("The path is too narrow");
+        target.Context.CurrentLocation.Should().BeOfType<WhiteCliffsBeachNorth>();
+    }
+
+    [Test]
+    public async Task WhiteCliffsSouth_InInflatedBoat_PathTooNarrow_North()
+    {
+        var target = GetTarget();
+        var boat = Repository.GetItem<PileOfPlastic>();
+        boat.IsInflated = true;
+        target.Context.CurrentLocation = Repository.GetLocation<WhiteCliffsBeachSouth>();
+        target.Context.CurrentLocation.SubLocation = boat;
+
+        var response = await target.GetResponse("north");
+
+        response.Should().Contain("The path is too narrow");
+        target.Context.CurrentLocation.Should().BeOfType<WhiteCliffsBeachSouth>();
+    }
+
+    [Test]
+    public async Task WhiteCliffsNorth_BoatNotWithPlayer_CanGoSouth()
+    {
+        var target = GetTarget();
+        var boat = Repository.GetItem<PileOfPlastic>();
+        boat.IsInflated = true;
+        target.Context.CurrentLocation = Repository.GetLocation<WhiteCliffsBeachNorth>();
+        target.Context.CurrentLocation.SubLocation = null;
+
+        var response = await target.GetResponse("south");
+
+        response.Should().Contain("White Cliffs Beach");
+        target.Context.CurrentLocation.Should().BeOfType<WhiteCliffsBeachSouth>();
+    }
+
+    [Test]
+    public async Task WhiteCliffsNorth_BoatNotWithPlayer_CanGoWest()
+    {
+        var target = GetTarget();
+        var boat = Repository.GetItem<PileOfPlastic>();
+        boat.IsInflated = true;
+        target.Context.CurrentLocation = Repository.GetLocation<WhiteCliffsBeachNorth>();
+        target.Context.CurrentLocation.SubLocation = null;
+        var lamp = Repository.GetItem<Lantern>();
+        lamp.IsOn = true;
+        target.Context.Take(lamp);
+
+        var response = await target.GetResponse("west");
+
+        response.Should().Contain("Damp Cave");
+        target.Context.CurrentLocation.Should().BeOfType<DampCave>();
+    }
+
+    [Test]
+    public async Task WhiteCliffsSouth_BoatNotWithPlayer_CanGoNorth()
+    {
+        var target = GetTarget();
+        var boat = Repository.GetItem<PileOfPlastic>();
+        boat.IsInflated = true;
+        target.Context.CurrentLocation = Repository.GetLocation<WhiteCliffsBeachSouth>();
+        target.Context.CurrentLocation.SubLocation = null;
+
+        var response = await target.GetResponse("north");
+
+        response.Should().Contain("White Cliffs Beach");
+        target.Context.CurrentLocation.Should().BeOfType<WhiteCliffsBeachNorth>();
+    }
+
+    [Test]
+    public async Task WhiteCliffsNorth_CarryingInflatedBoat_PathTooNarrow()
+    {
+        var target = GetTarget();
+        var boat = Repository.GetItem<PileOfPlastic>();
+        boat.IsInflated = true;
+        target.Context.CurrentLocation = Repository.GetLocation<WhiteCliffsBeachNorth>();
+        target.Context.CurrentLocation.SubLocation = null;
+        target.Context.Items.Add(boat);
+
+        var response = await target.GetResponse("south");
+
+        response.Should().Contain("The path is too narrow");
+        target.Context.CurrentLocation.Should().BeOfType<WhiteCliffsBeachNorth>();
+    }
 }

--- a/ZorkOne/Location/WhiteCliffsBeachNorth.cs
+++ b/ZorkOne/Location/WhiteCliffsBeachNorth.cs
@@ -1,6 +1,8 @@
-﻿using GameEngine.Location;
+﻿using GameEngine;
+using GameEngine.Location;
 using Model.Interface;
 using Model.Movement;
+using ZorkOne.Item;
 
 namespace ZorkOne.Location;
 
@@ -12,9 +14,30 @@ public class WhiteCliffsBeachNorth : LocationWithNoStartingItems
     {
         return new Dictionary<Direction, MovementParameters>
         {
-            { Direction.W, new MovementParameters { Location = GetLocation<DampCave>() } },
-            { Direction.S, new MovementParameters { Location = GetLocation<WhiteCliffsBeachSouth>() } }
+            {
+                Direction.W, new MovementParameters
+                {
+                    Location = GetLocation<DampCave>(), CanGo = ctx => !InflatedBoatIsWithPlayer(ctx),
+                    CustomFailureMessage = "The path is too narrow. "
+                }
+            },
+            {
+                Direction.S, new MovementParameters
+                {
+                    Location = GetLocation<WhiteCliffsBeachSouth>(), CanGo = ctx => !InflatedBoatIsWithPlayer(ctx),
+                    CustomFailureMessage = "The path is too narrow. "
+                }
+            }
         };
+    }
+
+    // Mirrors the ZIL DEFLATE flag (zork1/1actions.zil:2585-2590): the cliff paths are
+    // passable only while the inflated boat isn't with the player, whether seated in it
+    // or simply carrying it.
+    private bool InflatedBoatIsWithPlayer(IContext context)
+    {
+        var boat = Repository.GetItem<PileOfPlastic>();
+        return boat.IsInflated && (SubLocation == boat || context.HasItem<PileOfPlastic>());
     }
 
     protected override string GetContextBasedDescription(IContext context)

--- a/ZorkOne/Location/WhiteCliffsBeachSouth.cs
+++ b/ZorkOne/Location/WhiteCliffsBeachSouth.cs
@@ -1,6 +1,8 @@
-﻿using GameEngine.Location;
+﻿using GameEngine;
+using GameEngine.Location;
 using Model.Interface;
 using Model.Movement;
+using ZorkOne.Item;
 
 namespace ZorkOne.Location;
 
@@ -12,8 +14,23 @@ public class WhiteCliffsBeachSouth : LocationWithNoStartingItems
     {
         return new Dictionary<Direction, MovementParameters>
         {
-            { Direction.N, new MovementParameters { Location = GetLocation<WhiteCliffsBeachNorth>() } }
+            {
+                Direction.N, new MovementParameters
+                {
+                    Location = GetLocation<WhiteCliffsBeachNorth>(), CanGo = ctx => !InflatedBoatIsWithPlayer(ctx),
+                    CustomFailureMessage = "The path is too narrow. "
+                }
+            }
         };
+    }
+
+    // Mirrors the ZIL DEFLATE flag (zork1/1actions.zil:2585-2590): the cliff paths are
+    // passable only while the inflated boat isn't with the player, whether seated in it
+    // or simply carrying it.
+    private bool InflatedBoatIsWithPlayer(IContext context)
+    {
+        var boat = Repository.GetItem<PileOfPlastic>();
+        return boat.IsInflated && (SubLocation == boat || context.HasItem<PileOfPlastic>());
     }
 
     protected override string GetContextBasedDescription(IContext context)


### PR DESCRIPTION
## Summary

- Fixes #191: the three White Cliffs Beach exits (North → South, North → West/Damp Cave, South → North) were unconditional, so a player who sailed the river and landed there — seated in the inflated boat — could just walk off down the narrow paths.
- The original ZIL gates every cliff exit on the `DEFLATE` flag (`zork1/1dungeon.zil:2233-2256`), which is true only when the inflated boat is **not** with the player (`zork1/1actions.zil:2585-2590`). Ported that as a `CanGo` gate on each exit, matching the existing `DamBase`/`SandyBeach` "can't go there in a magic boat" precedent, using the ZIL's own failure text: "The path is too narrow."
- The gate (`InflatedBoatIsWithPlayer`) checks both being seated in the boat (`SubLocation == boat`) and simply carrying it (`context.HasItem<PileOfPlastic>()`), matching the ZIL's `INFLATED-BOAT IN WINNER` test for full fidelity.

## Test plan

Followed TDD per CLAUDE.md: added failing tests to `ZorkOne.Tests/BoatTests.cs` first, confirmed they failed for the right reason (exits succeeded instead of blocking), then made the minimal fix.

- [x] New tests added and passing: blocked case (seated in boat) for all three exits, blocked case (carrying boat while on foot), and passable cases (boat absent) for all three exits
- [x] `dotnet test ZorkOne.Tests` — 1759 passed, 0 failed
- [x] `dotnet test UnitTests` — 993 passed, 0 failed, 1 skipped (pre-existing, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qq8PD6MdsgRSWZT3FG2Uqy

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qq8PD6MdsgRSWZT3FG2Uqy)_