### PR TITLE
Fix #373: shuttle arrival consequence dodged by leaving on the arrival turn

### DIFF
--- a/Planetfall.Tests/ShuttleTests.cs
+++ b/Planetfall.Tests/ShuttleTests.cs
@@ -551,6 +551,39 @@ public class ShuttleTests : EngineTestsBase
     }
 
     [Test]
+    public async Task LeaveImmediatelyAfterArrivalLandmark_SpeedConsequenceStillApplies()
+    {
+        // Regression test for issue #373: a player who never decelerates (pushes the lever
+        // once and never touches it again) and then leaves the control cabin on the very turn
+        // the arrival landmark text appears must still suffer the speed-based consequence.
+        // Previously, OnLeaveLocation deregistered the shuttle control as an actor before the
+        // deferred Arrived() computation could run on the next Act() cycle, letting the player
+        // dodge the crash/death penalty just by choosing "leave" as their next command.
+        var target = GetTarget();
+        Take<ShuttleAccessCard>();
+        StartHere<AlfieControlEast>();
+        var controls = GetLocation<AlfieControlEast>();
+
+        await target.GetResponse("slide shuttle access card through slot");
+
+        var response = await target.GetResponse("push lever"); // never touch the lever again
+
+        for (var i = 0; i < 23; i++)
+            response = await target.GetResponse("wait");
+
+        response.Should().Contain(
+            "The shuttle car is approaching a brightly lit area. As you near it, you make out the concrete platforms of a shuttle station");
+        controls.TunnelPosition.Should().Be(24);
+        controls.Activated.Should().BeTrue();
+        controls.DoorIsClosed.Should().BeFalse();
+
+        var leaveResponse = await target.GetResponse("W");
+
+        leaveResponse.Should().Contain("You have died");
+        controls.Activated.Should().BeFalse();
+    }
+
+    [Test]
     public async Task FullTrip_ConstantSpeed_PerfectLanding()
     {
         var target = GetTarget();

--- a/Planetfall/Location/Shuttle/ShuttleControl.cs
+++ b/Planetfall/Location/Shuttle/ShuttleControl.cs
@@ -89,6 +89,16 @@ public abstract class ShuttleControl<TCabin, TControl> : LocationWithNoStartingI
 
     public override void OnLeaveLocation(IContext context, ILocation newLocation, ILocation previousLocation)
     {
+        // Issue #373: the car reaches the platform (TunnelPosition == EndOfTunnel) and the door
+        // opens a full turn before the speed-based arrival consequence (Arrived()) is computed -
+        // that computation is deferred to this turn's end-of-turn actor processing. If we
+        // deregister here unconditionally, a player who leaves on that exact turn escapes the
+        // pending crash/death consequence entirely. Skip the deregistration in that case so
+        // Act() still runs after the player exits, letting Move() -> Arrived() apply the
+        // consequence; Arrived() itself deregisters and resets state once it runs.
+        if (Activated && TunnelPosition == EndOfTunnel)
+            return;
+
         context.RemoveActor(this);
         Activated = false;
         TurnsSinceActivated = 0;


### PR DESCRIPTION
## Summary

Fixes #373 — a player who never decelerates the shuttle (pushes the lever once and never touches it again) could dodge the speed-based crash/death consequence entirely by leaving the control cabin on the exact turn the arrival landmark text appears, regardless of how fast they were going.

**Root cause:** `ShuttleControl<TCabin, TControl>.Move()` prints the arrival landmark text and advances `TunnelPosition` to `EndOfTunnel` in one `Act()` cycle, but defers the actual speed-based consequence (`Arrived()`) to the *next* `Act()` cycle. Meanwhile the door opens (`DoorIsClosed` becomes `false`) the instant `TunnelPosition` hits `EndOfTunnel`, so the player can leave immediately. `OnLeaveLocation` unconditionally deregistered the shuttle control as a turn-based actor, which permanently prevented the pending `Arrived()` call — and its crash/death consequence — from ever running.

**Fix:** `OnLeaveLocation` now checks whether there's a still-pending, unresolved arrival (`Activated && TunnelPosition == EndOfTunnel`) and, if so, skips the deregistration for that turn instead of unconditionally tearing down actor state. This lets the normal end-of-turn actor processing still call `Act() -> Move() -> Arrived()` after the player has already left the cabin, so the crash/death consequence is applied in the same response as the "leave" command. `Arrived()` itself performs the deregistration/reset once it runs, so cleanup still happens exactly once. Both shuttle lines (Alfie and Betty) share this base class, so the fix covers both.

This preserves the existing two-turn landmark/consequence pacing (used by other passing tests like `FullTrip_ConstantSpeed_NoDeceleration` and `FullTrip_ConstantSpeed_PerfectLanding`) — it only changes what happens when the player's very next command is to leave.

## TDD

Followed the repo's mandatory TDD process:
1. Added `LeaveImmediatelyAfterArrivalLandmark_SpeedConsequenceStillApplies` to `Planetfall.Tests/ShuttleTests.cs`, reproducing the exact exploit from the issue (push lever once, wait through the tunnel until the arrival landmark appears, then leave as the very next command).
2. Confirmed it failed for the right reason: the "W" response was a clean cabin description with no crash/death text.
3. Applied the minimal fix in `Planetfall/Location/Shuttle/ShuttleControl.cs`.
4. Confirmed the new test passes, and re-ran the full `Planetfall.Tests` suite (2907 tests) with no regressions.

## Test plan

- [x] New regression test `LeaveImmediatelyAfterArrivalLandmark_SpeedConsequenceStillApplies` fails before the fix and passes after it
- [x] Full `Planetfall.Tests` suite passes (2907 passed, 0 failed)
- [x] Solution builds cleanly (`dotnet build`)

https://claude.ai/code/session_01XK4z2ETXEhfDiaiarBVhSv


---
_Generated by [Claude Code](https://claude.ai/code/session_01XK4z2ETXEhfDiaiarBVhSv)_