### PR TITLE
Fix #369: jumping into the rift now triggers the written death scene

### DIFF
--- a/Planetfall.Tests/AdminCorridorTests.cs
+++ b/Planetfall.Tests/AdminCorridorTests.cs
@@ -97,6 +97,81 @@ public class AdminCorridorTests : EngineTestsBase
         Context.CurrentLocation.Should().BeOfType<AdminCorridor>();
     }
 
+    // Issue #369: "jump rift"/"jump into rift"/"jump over rift" were being misrouted to the
+    // Direction.N movement failure ("too wide to jump across") instead of reaching the deliberate
+    // death scene already written in RiftLocationBase.RespondToSimpleInteraction. A bare "jump" with
+    // no rift noun must still fall through to normal (non-fatal) handling.
+    [TestFixture]
+    public class JumpIntoRift : AdminCorridorTests
+    {
+        [Test]
+        public async Task JumpRift_TheBareNoun_DiesInTheRift()
+        {
+            var target = GetTarget();
+            StartHere<AdminCorridor>();
+
+            var response = await target.GetResponse("jump rift");
+
+            response.Should().Contain("You have died");
+            response.Should().Contain("sharp and nasty rocks");
+        }
+
+        [Test]
+        public async Task JumpIntoRift_DiesInTheRift()
+        {
+            var target = GetTarget();
+            StartHere<AdminCorridor>();
+
+            var response = await target.GetResponse("jump into rift");
+
+            response.Should().Contain("You have died");
+        }
+
+        [Test]
+        public async Task JumpOverRift_DiesInTheRift()
+        {
+            var target = GetTarget();
+            StartHere<AdminCorridor>();
+
+            var response = await target.GetResponse("jump over rift");
+
+            response.Should().Contain("You have died");
+        }
+
+        [Test]
+        public async Task JumpIntoTheChasm_SynonymNounDiesInTheRift()
+        {
+            var target = GetTarget();
+            StartHere<AdminCorridor>();
+
+            var response = await target.GetResponse("jump into the chasm");
+
+            response.Should().Contain("You have died");
+        }
+
+        [Test]
+        public async Task JumpFromAdminCorridorNorth_DiesInTheRift()
+        {
+            var target = GetTarget();
+            StartHere<AdminCorridorNorth>();
+
+            var response = await target.GetResponse("jump into rift");
+
+            response.Should().Contain("You have died");
+        }
+
+        [Test]
+        public async Task BareJump_NoRiftNoun_DoesNotDie()
+        {
+            var target = GetTarget();
+            StartHere<AdminCorridor>();
+
+            var response = await target.GetResponse("jump");
+
+            response.Should().NotContain("You have died");
+        }
+    }
+
     // Issue #297, Divergence A: once the ladder has plunged into the rift it is out of scope
     // entirely (not carried, not in any room, not spanning). The handler used to match on the
     // command text alone and still narrate destroying a ladder that no longer exists.

--- a/Planetfall/Location/Kalamontee/Admin/RiftLocationBase.cs
+++ b/Planetfall/Location/Kalamontee/Admin/RiftLocationBase.cs
@@ -39,4 +39,37 @@ internal abstract class RiftLocationBase : LocationWithNoStartingItems
 
         return await base.RespondToSimpleInteraction(action, context, client, itemProcessorFactory);
     }
+
+    // Issue #369: "jump rift" / "jump into rift" / "jump over rift" never reached the death branch
+    // above. The AI complex-intent parser reads the rift as "the thing to the north" and misclassifies
+    // these as a MoveIntent toward Direction.N, which only ever produces the mundane "too wide to jump
+    // across" movement-failure message from AdminCorridor/AdminCorridorNorth's Map(). Catching the raw
+    // input here - RespondToSpecificLocationInteraction runs before any parser (deterministic or AI)
+    // gets a chance to claim it - lets the already-correct death scene above actually fire.
+    public override async Task<InteractionResult> RespondToSpecificLocationInteraction(string? input,
+        IContext context, IGenerationClient client)
+    {
+        if (IsJumpingIntoTheRift(input))
+            return new DeathProcessor().Process(
+                "You get a brief (but much closer) view of the sharp and nasty rocks at the bottom of the rift. ",
+                context);
+
+        return await base.RespondToSpecificLocationInteraction(input, context, client);
+    }
+
+    private static bool IsJumpingIntoTheRift(string? input)
+    {
+        var words = input?.ToLowerInvariant().Trim().Split(' ', StringSplitOptions.RemoveEmptyEntries).ToList();
+        if (words is null || words.Count == 0 || !Verbs.JumpVerbs.Contains(words[0]))
+            return false;
+
+        words.RemoveAt(0);
+
+        // Drop the filler prepositions/articles a player might naturally insert - "jump into the
+        // rift" and "jump over rift" mean the same thing as the bare "jump rift".
+        string[] filler = ["into", "in", "over", "across", "through", "the"];
+        words.RemoveAll(filler.Contains);
+
+        return RiftNouns.Contains(string.Join(' ', words));
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #369. Jumping into the Admin Corridor rift (Planetfall) has a deliberately-written death scene in `RiftLocationBase.RespondToSimpleInteraction`, but it was unreachable in live play: "jump rift", "jump into rift", and "jump over rift" were all misclassified by the complex-intent (AI) parser as movement toward the rift's `Direction.N` exit, so they only ever produced the mundane "The rift is too wide to jump across." movement-failure message from `AdminCorridor`/`AdminCorridorNorth`'s `Map()` instead of the death text.

- `RiftLocationBase` now overrides `RespondToSpecificLocationInteraction` to recognize jump-verb + rift-noun phrasing (with optional filler prepositions/articles: "into", "in", "over", "across", "through", "the") directly from the raw player input. This runs *before* any parser — deterministic or AI — gets a chance to claim the input, so the existing death branch actually fires, in both tests and production.
- The original `RespondToSimpleInteraction` death branch is left untouched as a fallback for any `SimpleIntent` that reaches it through another path.

## Test plan (TDD)

- [x] Added failing-first tests in `Planetfall.Tests/AdminCorridorTests.cs` (`JumpIntoRift` nested fixture) covering: bare "jump rift", "jump into rift", "jump over rift", a rift-noun synonym ("jump into the chasm"), the same fix from `AdminCorridorNorth`, and a regression guard that bare "jump" (no noun) still does not kill the player.
- [x] Confirmed all 5 new death-scene tests failed for the right reason (empty response, no death text) before the fix.
- [x] Confirmed all tests pass after the fix.
- [x] Ran `dotnet test Planetfall.Tests` (2922 passed, 0 failed) — no regressions.
- [x] Ran `dotnet test UnitTests` (993 passed, 0 failed) — no regressions.
- [x] Ran `dotnet test ZorkOne.Tests` (1752 passed, 0 failed) — no regressions.
- [x] Full solution build succeeds with 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CREk8m265rZVK6dNt9vrYP

---
_Generated by [Claude Code](https://claude.ai/code/session_01CREk8m265rZVK6dNt9vrYP)_