### PR TITLE
Fix the ambassador's celery being unreachable: take/eat now hit the authored responses

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -365,9 +365,9 @@ This Lambda integration demonstrates how the core game engine's excellent archit
 - **Examples**: See `Laser.cs`, `Floyd.cs`, `SleepEngine.cs` for usage patterns
 - **Known violations to fix when touched**: a few classes still `new Random()` directly instead of the
   injected `Chooser` — `Planetfall/Location/Feinstein/BlatherLocation.cs` (`RandomBlatherBlock()`),
-  `ZorkOne/Location/ForestLocation/ForestPath.cs`, `ZorkOne/Location/UpATree.cs`,
-  `Planetfall/Item/Feinstein/Ambassador.cs`. These make their randomness untestable; refactor to
-  `Chooser` (and mock it) when modifying them.
+  `ZorkOne/Location/ForestLocation/ForestPath.cs`, `ZorkOne/Location/UpATree.cs`. These make their
+  randomness untestable; refactor to `Chooser` (and mock it) when modifying them.
+  (`Planetfall/Item/Feinstein/Ambassador.cs` was converted in PR #384.)
 
 ### AI Integration Guidelines  
 - **Hierarchical parsing**: Try simple pattern matching first, then fall back to expensive AI calls

--- a/Planetfall.Tests/DeckNineTests.cs
+++ b/Planetfall.Tests/DeckNineTests.cs
@@ -135,6 +135,44 @@ public class DeckNineTests : EngineTestsBase
         }
 
         [Test]
+        public async Task TakeAll_WhileAmbassadorIsPresent_ReportsTheCeleryRefusalAndDoesNotTakeIt()
+        {
+            // Pins the "take all" behavior for the now-room-level celery: the engine's convention
+            // is to report non-takeable items with their CannotBeTakenDescription (a deliberate,
+            // player-friendly divergence from the original's TAKE ALL, which skips non-TAKEBIT
+            // objects entirely).
+            var engine = GetTarget();
+            var deckNine = StartHere<DeckNine>();
+            GetItem<Ambassador>().JoinsTheScene(engine.Context, deckNine);
+
+            var response = await engine.GetResponse("take all");
+
+            response.Should().Contain("The ambassador seems perturbed by your lack of normal protocol.");
+            engine.Context.Items.Should().NotContain(GetItem<Celery>());
+        }
+
+        [Test]
+        public async Task AmbassadorRandomDeparture_TakesTheCeleryWithHim()
+        {
+            // The random-departure branch of Ambassador.Act, forced deterministically via the
+            // injected IRandomChooser (RollDice(10): <=2 idle, <=4 leave, else quirky speech).
+            var engine = GetTarget();
+            var deckNine = StartHere<DeckNine>();
+            var ambassador = GetItem<Ambassador>();
+            ambassador.JoinsTheScene(engine.Context, deckNine);
+
+            var mockChooser = new Mock<IRandomChooser>();
+            mockChooser.Setup(c => c.RollDice(10)).Returns(3); // force the "leaves" branch
+            ambassador.Chooser = mockChooser.Object;
+
+            var response = await engine.GetResponse("wait");
+
+            response.Should().Contain("grunts a polite farewell");
+            deckNine.Items.Should().NotContain(ambassador);
+            deckNine.Items.Should().NotContain(GetItem<Celery>());
+        }
+
+        [Test]
         public void Celery_ArrivesAndLeavesWithTheAmbassador()
         {
             // Mirrors the original: MOVE CELERY,HERE on arrival (globals.zil:825) and
@@ -154,6 +192,10 @@ public class DeckNineTests : EngineTestsBase
         public async Task Celery_IsNotListedInTheRoomDescription()
         {
             // NDESCBIT in the original: the celery is present and interactable but never listed.
+            // The word-level assertion is deliberately strict: neither the item list nor any
+            // authored description currently mentions celery outside the arrival text. If a future
+            // change adds "celery" to the ambassador's or slime's LOOK-visible description on
+            // purpose, scope this assertion to the item list (e.g. "There is a celery") instead.
             var engine = GetTarget();
             var deckNine = StartHere<DeckNine>();
             GetItem<Ambassador>().JoinsTheScene(engine.Context, deckNine);

--- a/Planetfall.Tests/DeckNineTests.cs
+++ b/Planetfall.Tests/DeckNineTests.cs
@@ -1,4 +1,8 @@
 using FluentAssertions;
+using GameEngine.Item.ItemProcessor;
+using Model.AIGeneration;
+using Model.AIParsing;
+using Model.Intent;
 using Model.Interface;
 using Moq;
 using Planetfall.Item.Feinstein;
@@ -67,5 +71,96 @@ public class DeckNineTests : EngineTestsBase
         await engine.GetResponse("wait");
 
         deckNine.Items.Should().Contain(GetItem<Ambassador>());
+    }
+
+    /// <summary>
+    /// The ambassador's celery must be in the player's scope while he is present. In the original,
+    /// the celery is moved into the room alongside him (globals.zil:825) so its authored TAKE and
+    /// EAT responses can fire. Sealing it inside the ambassador (a closed, opaque container) put it
+    /// out of GetItemInScope's reach, so a live AI-tagged "take the celery" (a TakeIntent) fell
+    /// through to the "take something that is not portable" AI narrator instead.
+    /// </summary>
+    [TestFixture]
+    public class CeleryTests : EngineTestsBase
+    {
+        [Test]
+        public async Task TakeCelery_ViaTakeIntent_WhileAmbassadorIsPresent_YieldsProtocolRefusal()
+        {
+            // Production's real AI parser tags "take the celery" as a TakeIntent, which GameEngine
+            // dispatches straight to TakeOrDropInteractionProcessor.Process(TakeIntent, ...). That
+            // path resolves the noun with Repository.GetItemInScope, which rejects anything nested
+            // in a closed, opaque container - so the TakeIntent overload must be invoked directly,
+            // exactly as GameEngine.cs does (same technique as the issue #342 tests).
+            var engine = GetTarget();
+            var deckNine = StartHere<DeckNine>();
+            GetItem<Ambassador>().JoinsTheScene(engine.Context, deckNine);
+
+            var takeAndDropParser = new Mock<IAITakeAndAndDropParser>();
+            takeAndDropParser.Setup(s => s.GetListOfItemsToTake(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(["celery"]);
+            var processor = new TakeOrDropInteractionProcessor(takeAndDropParser.Object);
+
+            var (_, message) = await processor.Process(
+                new TakeIntent { Noun = "celery", OriginalInput = "take the celery" },
+                engine.Context, Mock.Of<IGenerationClient>());
+
+            message.Should().Contain("The ambassador seems perturbed by your lack of normal protocol.");
+            engine.Context.Items.Should().NotContain(GetItem<Celery>());
+        }
+
+        [Test]
+        public async Task TakeCelery_WhileAmbassadorIsPresent_YieldsProtocolRefusal()
+        {
+            var engine = GetTarget();
+            var deckNine = StartHere<DeckNine>();
+            GetItem<Ambassador>().JoinsTheScene(engine.Context, deckNine);
+
+            var response = await engine.GetResponse("take celery");
+
+            response.Should().Contain("The ambassador seems perturbed by your lack of normal protocol.");
+            engine.Context.Items.Should().NotContain(GetItem<Celery>());
+        }
+
+        [Test]
+        public async Task EatCelery_WhileAmbassadorIsPresent_KillsThePlayer()
+        {
+            var engine = GetTarget();
+            var deckNine = StartHere<DeckNine>();
+            GetItem<Ambassador>().JoinsTheScene(engine.Context, deckNine);
+
+            var response = await engine.GetResponse("eat celery");
+
+            response.Should().Contain("Blow'k-Bibben-Gordoan metabolism is not compatible with our own");
+            response.Should().Contain("You die of all sorts of convulsions");
+        }
+
+        [Test]
+        public void Celery_ArrivesAndLeavesWithTheAmbassador()
+        {
+            // Mirrors the original: MOVE CELERY,HERE on arrival (globals.zil:825) and
+            // REMOVE CELERY when he goes (globals.zil:806).
+            var engine = GetTarget();
+            var deckNine = StartHere<DeckNine>();
+            var ambassador = GetItem<Ambassador>();
+
+            ambassador.JoinsTheScene(engine.Context, deckNine);
+            deckNine.Items.Should().Contain(GetItem<Celery>());
+
+            ambassador.LeavesTheScene(engine.Context);
+            deckNine.Items.Should().NotContain(GetItem<Celery>());
+        }
+
+        [Test]
+        public async Task Celery_IsNotListedInTheRoomDescription()
+        {
+            // NDESCBIT in the original: the celery is present and interactable but never listed.
+            var engine = GetTarget();
+            var deckNine = StartHere<DeckNine>();
+            GetItem<Ambassador>().JoinsTheScene(engine.Context, deckNine);
+
+            var response = await engine.GetResponse("look");
+
+            response.Should().NotContain("celery");
+        }
     }
 }

--- a/Planetfall/Item/Feinstein/Ambassador.cs
+++ b/Planetfall/Item/Feinstein/Ambassador.cs
@@ -75,6 +75,10 @@ internal class Ambassador : QuirkyCompanion, ICanBeExamined, ICanBeTalkedTo
     {
         location.ItemPlacedHere(this);
         location.ItemPlacedHere<Slime>();
+        // The celery goes in the ROOM alongside the ambassador (globals.zil:825), not inside him:
+        // a closed, opaque container puts its contents out of GetItemInScope's reach, which sent a
+        // live AI-tagged "take the celery" to the narrator instead of its authored refusal.
+        location.ItemPlacedHere<Celery>();
         context.ItemPlacedHere<Brochure>();
 
         context.RegisterActor(this);
@@ -89,6 +93,11 @@ internal class Ambassador : QuirkyCompanion, ICanBeExamined, ICanBeTalkedTo
 
     internal string LeavesTheScene(IContext context, string? partingText = null)
     {
+        // The celery travels with him (REMOVE CELERY, globals.zil:806).
+        var celery = Repository.GetItem<Celery>();
+        celery.CurrentLocation?.RemoveItem(celery);
+        celery.CurrentLocation = null;
+
         CurrentLocation?.RemoveItem(this);
         CurrentLocation = null;
         context.RemoveActor(this);
@@ -99,7 +108,8 @@ internal class Ambassador : QuirkyCompanion, ICanBeExamined, ICanBeTalkedTo
 
     public override void Init()
     {
-        StartWithItemInside<Celery>();
+        // Deliberately empty: the celery is placed in the room when the ambassador arrives
+        // (JoinsTheScene) and removed when he goes (LeavesTheScene) - never inside him.
     }
 
     public async Task<string> OnBeingTalkedTo(string text, IContext context, IGenerationClient client)

--- a/Planetfall/Item/Feinstein/Ambassador.cs
+++ b/Planetfall/Item/Feinstein/Ambassador.cs
@@ -1,13 +1,17 @@
 ﻿using ChatLambda;
 using Model.AIGeneration;
 using Model.Item;
+using Newtonsoft.Json;
 
 namespace Planetfall.Item.Feinstein;
 
 internal class Ambassador : QuirkyCompanion, ICanBeExamined, ICanBeTalkedTo
 {
     private readonly ChatWithAmbassador _chatWithAmbassador = new(null);
-    
+
+    [UsedImplicitly] [JsonIgnore]
+    public IRandomChooser Chooser { get; set; } = new RandomChooser();
+
     public override string[] NounsForMatching => ["ambassador", "alien"];
 
     public override string GenericDescription(ILocation? currentLocation)
@@ -33,7 +37,7 @@ internal class Ambassador : QuirkyCompanion, ICanBeExamined, ICanBeTalkedTo
             return Task.FromResult(LeavesTheScene(context,
                 "The ambassador squawks frantically, evacuates a massive load of gooey slime, and rushes away. "));
 
-        Func<Task<string>> action = new Random().Next(1, 10) switch
+        Func<Task<string>> action = Chooser.RollDice(10) switch
         {
             // 20% chance the Ambassador does nothing at all.
             <= 2 => (Func<Task<string>>)(async () => await Task.FromResult(String.Empty)),
@@ -93,6 +97,9 @@ internal class Ambassador : QuirkyCompanion, ICanBeExamined, ICanBeTalkedTo
 
     internal string LeavesTheScene(IContext context, string? partingText = null)
     {
+        // Called unconditionally from DeckNine.OnLeaveLocation even when the ambassador never
+        // joined; everything below is a safe no-op in that case (the celery lookup lazily creates
+        // an unplaced singleton, and the removals are null-guarded).
         // The celery travels with him (REMOVE CELERY, globals.zil:806).
         var celery = Repository.GetItem<Celery>();
         celery.CurrentLocation?.RemoveItem(celery);

--- a/Planetfall/Item/Feinstein/Celery.cs
+++ b/Planetfall/Item/Feinstein/Celery.cs
@@ -2,9 +2,11 @@
 
 namespace Planetfall.Item.Feinstein;
 
-public class Celery : ItemBase, ICanBeEaten
+// IDoNotAppearInItemLists is the original's NDESCBIT: the celery sits in the room with the
+// ambassador so it is in scope, but it is never listed in the room description.
+public class Celery : ItemBase, ICanBeEaten, IDoNotAppearInItemLists
 {
-    public override string[] NounsForMatching => ["celery"];
+    public override string[] NounsForMatching => ["celery", "stalk", "stalk of celery"];
 
     public override string? CannotBeTakenDescription =>
         "The ambassador seems perturbed by your lack of normal protocol. ";


### PR DESCRIPTION
## The bug

On Deck Nine, with the ambassador present and visibly "munching on something resembling an enormous stalk of celery":

```
> take the celery
Ah, the elusive celery of immobility—truly the most mysterious of all vegetable phenomena.
```

An improvised AI-narrator line — instead of the authored refusal. The famous `eat celery` convulsions death was equally unreachable through the live take path.

## Root cause

The celery was seeded **inside** the ambassador (`StartWithItemInside<Celery>()`), and the ambassador is a closed, opaque `ContainerBase` — so `Repository.GetItemInScope` rejects the celery (closed-container accessibility walk).

The live AI parser tags "take the celery" as a `TakeIntent`, which `GameEngine` dispatches straight to `TakeOrDropInteractionProcessor`. That path resolves nouns via `GetItemInScope`; finding nothing, it falls through to the `TakeSomethingThatIsNotPortable` generated narration — hence "celery of *immobility*". (The `SimpleIntent` path happened to work because `ContainerBase.RespondToSimpleInteraction` forwards to contained items unconditionally — which is why the bug only bit the AI-parsed take route, same family as #342/#345.)

## Original behavior (ZIL evidence)

The original never puts the celery in the ambassador. It moves it into the **room** alongside him and removes it when he leaves, invisible in room descriptions but fully in scope:

- Arrival: `<MOVE ,CELERY ,HERE>` — `globals.zil:825`
- Departure: `<REMOVE ,CELERY>` — `globals.zil:806`
- `NDESCBIT` + synonyms `CELERY PIECE STALK` — `globals.zil:785-789`
- `CELERY-F`: TAKE → "The ambassador seems perturbed by your lack of normal protocol."; EAT → the convulsions death — `globals.zil:791-798`

## The fix (mirrors the original)

- `Ambassador.JoinsTheScene` places the celery in the room; `LeavesTheScene` removes it (covers the random departure, the explosion departure, and the leave-Deck-Nine cleanup).
- `Celery` implements `IDoNotAppearInItemLists` (NDESCBIT) and gains the original's "stalk" synonyms.
- `Ambassador.Init` no longer seeds the celery inside him.

## TDD

`TakeCelery_ViaTakeIntent_WhileAmbassadorIsPresent_YieldsProtocolRefusal` invokes the `TakeIntent` overload directly, exactly as `GameEngine.cs` does for a live AI-tagged take (the #342 technique). Red before the fix (generated fallback instead of the authored line), green after. Additional pins: SimpleIntent take, eat-celery death, celery arriving/leaving with the ambassador, and no celery in room descriptions.

Full `Planetfall.Tests` suite: 2987 passed. (`Planetfall-Lambda.Tests` currently fails to *restore* on main due to pre-existing NU1605 `Amazon.Lambda.*` package downgrades — unrelated; this change touches only Planetfall `.cs` files.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)