### PR TITLE
Fix #390: squeeze tube now extracts the viscous material

### DIFF
--- a/Model/Verbs.cs
+++ b/Model/Verbs.cs
@@ -61,6 +61,13 @@ public static class Verbs
         ["touch", "rub", "feel", "press", "stroke", "pat", "tap", "poke", "brush", "caress", "prod", "nudge"];
 
     /// <summary>
+    ///     The "squeeze" family. Used by the toothpaste Tube to extract its viscous material, mirroring
+    ///     the original's SQUEEZE handling in TUBE-FUNCTION (zork1/1actions.zil). Deliberately excludes
+    ///     "press" (a push/button synonym) so squeezing the tube never collides with pressing a button.
+    /// </summary>
+    public static readonly string[] SqueezeVerbs = ["squeeze", "squish", "compress"];
+
+    /// <summary>
     ///     The "look at / examine" family. Distinct from <see cref="LookVerbs" /> (which is about
     ///     glancing/observing and is used for things like "look through the crack"). These are the
     ///     synonyms a player reaches for when they want to inspect a specific object. Always pair this

--- a/UnitTests/TestParser.cs
+++ b/UnitTests/TestParser.cs
@@ -28,7 +28,7 @@ public class TestParser : IntentParser
             "drink", "use", "count", "touch", "read", "turn", "wave", "move", "ring", "activate", "search",
             "smell", "turn on", "turn off", "throw", "light", "rub", "kiss", "wind", "kick", "deflate",
             "lower", "raise", "get", "inflate", "leave", "unlock", "lock", "climb", "extend", "lift", "shake",
-            "oil", "lubricate", "cross", "through", "go", "break", "smash"
+            "oil", "lubricate", "cross", "through", "go", "break", "smash", "squeeze"
         ];
 
         _allNouns = Repository.GetNouns(gameName);

--- a/ZorkOne.Tests/Places/DamTests.cs
+++ b/ZorkOne.Tests/Places/DamTests.cs
@@ -340,8 +340,57 @@ public class DamTests : EngineTestsBase
         await target.GetResponse("take material");
         var response = await target.GetResponse("i");
 
-        // Unbelievably, we can take and hold the gunk. 
+        // Unbelievably, we can take and hold the gunk.
         response.Should().Contain("viscous material");
+    }
+
+    // Issue #390: squeezing an open, full tube of toothpaste is the natural way to extract the
+    // viscous material, and the original handles it in TUBE-FUNCTION (zork1/1actions.zil:1386-1398).
+    // The material should ooze into the player's hand.
+    [Test]
+    public async Task SqueezeOpenTube_MovesMaterialToHand()
+    {
+        var target = GetTarget();
+        Take<Torch>();
+        StartHere<MaintenanceRoom>();
+
+        await target.GetResponse("open tube");
+        var response = await target.GetResponse("squeeze tube");
+
+        response.Should().Contain("oozes into your hand");
+        target.Context.HasItem<ViscousMaterial>().Should().BeTrue();
+    }
+
+    // Issue #390: squeezing an open but empty tube reports that it is empty (TUBE-FUNCTION's
+    // "The tube is apparently empty." branch), and must not conjure a second blob of material.
+    [Test]
+    public async Task SqueezeOpenEmptyTube_SaysEmpty()
+    {
+        var target = GetTarget();
+        Take<Torch>();
+        StartHere<MaintenanceRoom>();
+
+        await target.GetResponse("open tube");
+        await target.GetResponse("take material"); // empty the tube
+
+        var response = await target.GetResponse("squeeze tube");
+
+        response.Should().Contain("apparently empty");
+    }
+
+    // Issue #390: squeezing a closed tube reports that it is closed (TUBE-FUNCTION's
+    // "The tube is closed." branch) rather than extracting anything.
+    [Test]
+    public async Task SqueezeClosedTube_SaysClosed()
+    {
+        var target = GetTarget();
+        Take<Torch>();
+        StartHere<MaintenanceRoom>();
+
+        var response = await target.GetResponse("squeeze tube");
+
+        response.Should().Contain("The tube is closed");
+        target.Context.HasItem<ViscousMaterial>().Should().BeFalse();
     }
 
     [Test]

--- a/ZorkOne/Item/Tube.cs
+++ b/ZorkOne/Item/Tube.cs
@@ -1,4 +1,8 @@
+using GameEngine;
 using GameEngine.Item;
+using Model.AIGeneration;
+using Model.Intent;
+using Model.Interface;
 
 namespace ZorkOne.Item;
 
@@ -53,5 +57,33 @@ public class Tube : OpenAndCloseContainerBase, ICanBeExamined, ICanBeTakenAndDro
     public override void Init()
     {
         StartWithItemInside<ViscousMaterial>();
+    }
+
+    /// <summary>
+    ///     Mirrors TUBE-FUNCTION (zork1/1actions.zil:1386-1398): SQUEEZE is the canonical way to get the
+    ///     viscous material out of the toothpaste tube. When the tube is open and still holds the material
+    ///     it oozes into the player's hand (the ZIL's <c>&lt;MOVE ,PUTTY ,WINNER&gt;</c>); open but empty
+    ///     reports "apparently empty"; closed reports "closed". Without this handler SQUEEZE fell through
+    ///     to the AI narrator and never extracted the material (issue #390).
+    /// </summary>
+    public override async Task<InteractionResult?> RespondToSimpleInteraction(SimpleIntent action,
+        IContext context, IGenerationClient client, IItemProcessorFactory itemProcessorFactory)
+    {
+        if (!action.Match(Verbs.SqueezeVerbs, NounsForMatching))
+            return await base.RespondToSimpleInteraction(action, context, client, itemProcessorFactory);
+
+        // Closed → the material is sealed away and can't be reached.
+        if (!IsOpen)
+            return new PositiveInteractionResult("The tube is closed. ");
+
+        // Open and still holding the material → it oozes into your hand.
+        if (HasItem<ViscousMaterial>())
+        {
+            context.Take(Repository.GetItem<ViscousMaterial>());
+            return new PositiveInteractionResult("The viscous material oozes into your hand. ");
+        }
+
+        // Open but already emptied → nothing left to squeeze out.
+        return new PositiveInteractionResult("The tube is apparently empty. ");
     }
 }


### PR DESCRIPTION
## Summary

Fixes #390. The tube of toothpaste in the Maintenance Room did not respond to `squeeze` — the natural, canonical way to get the viscous material (gunk) out of a toothpaste tube. `squeeze tube` fell through to the AI narrator ("You decide against squeezing the tube…") and never extracted the material, forcing the workaround `open tube` + `take gunk`.

`Tube` now handles the SQUEEZE verb in `RespondToSimpleInteraction`, mirroring the original `TUBE-FUNCTION` (`zork1/1actions.zil:1386-1398`):

| Tube state | Response |
|---|---|
| Open, material inside | Material oozes into your hand (moved to inventory) — *"The viscous material oozes into your hand."* |
| Open, empty | *"The tube is apparently empty."* |
| Closed | *"The tube is closed."* |

The handler gates on the tube's **state** (open/closed, material present) rather than the command phrasing, so a second squeeze on an already-emptied tube reports it empty instead of conjuring a duplicate blob.

## Changes

- **`ZorkOne/Item/Tube.cs`** — override `RespondToSimpleInteraction` to handle `squeeze`, moving `ViscousMaterial` to the player's hands when the open tube still holds it, or reporting empty/closed otherwise. Non-squeeze verbs and other nouns fall through to the base handler unchanged.
- **`Model/Verbs.cs`** — add `SqueezeVerbs` (`squeeze`, `squish`, `compress`), deliberately excluding `press` so it never collides with pressing the Maintenance Room buttons.
- **`UnitTests/TestParser.cs`** — teach the deterministic test parser the `squeeze` verb so the intent parses without the live AI (same pattern used for the bottle's shake/break/smash in #388).

## Testing (TDD)

Added three tests in `ZorkOne.Tests/Places/DamTests.cs`, next to the existing tube tests, following the established `Take<Torch>()` (for light) + `StartHere<MaintenanceRoom>()` pattern:

- `SqueezeOpenTube_MovesMaterialToHand` — material oozes into hand and lands in inventory
- `SqueezeOpenEmptyTube_SaysEmpty` — reports empty, no duplicate material
- `SqueezeClosedTube_SaysClosed` — reports closed, no material extracted

All three failed before the fix (response was the empty narrator no-op) and pass after. No regressions:

- `ZorkOne.Tests`: 1773 passed, 0 failed
- `UnitTests`: 998 passed, 0 failed

Found via the AdventureBreaker harness (AB-055).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012b6X1Fc6Wa5Pv9WCLcpTnX

---
_Generated by [Claude Code](https://claude.ai/code/session_012b6X1Fc6Wa5Pv9WCLcpTnX)_