### PR TITLE
Fix #396: "look in <container>" now lists contents in both games

### DIFF
--- a/EscapeRoom.Tests/WalkthroughTests.cs
+++ b/EscapeRoom.Tests/WalkthroughTests.cs
@@ -87,6 +87,23 @@ public class WalkthroughTests : EscapeRoomEngineTestsBase
         engine.Context.Score.Should().Be(100);
     }
 
+    [TestCase("look in desk")]
+    [TestCase("look inside desk")]
+    public async Task LookInDesk_Open_ShowsContents(string command)
+    {
+        // Issue #396 regression guard for a third game: "look in <container>" must list contents in
+        // EscapeRoom too. The fix rewrites the verb to "examine" before parsing, so this exercises the
+        // WelcomeDesk via the base examine processor rather than its ["search","look in","look inside"]
+        // handler — both return the same ExaminationDescription; this locks that equivalence.
+        var engine = GetTarget();
+
+        await engine.GetResponse("open desk");
+        var response = await engine.GetResponse(command);
+
+        response.Should().Contain("leaflet");
+        response.Should().NotContain("cannot go that way");
+    }
+
     [Test]
     public async Task CannotOpenDoor_WhenLocked()
     {

--- a/GameEngine/GameEngine.cs
+++ b/GameEngine/GameEngine.cs
@@ -379,8 +379,9 @@ public class GameEngine<TInfocomGame, TContext> : IGameEngine
             return string.IsNullOrEmpty(atNoun) ? input : "examine " + atNoun;
         }
 
-        // "look in <noun>" / "look inside <noun>" -> "examine <noun>" (issue #396). "look inside " is
-        // matched before "look in " so it is never misread as "look in" + "side ...".
+        // "look in <noun>" / "look inside <noun>" -> "examine <noun>" (issue #396). The trailing space in
+        // "look in " keeps the two prefixes mutually exclusive ("look inside X" never matches "look in "),
+        // so the match order is not load-bearing; longest-first is just a defensive habit.
         string[] lookInPrefixes = ["look inside ", "look in "];
         foreach (var lookInPrefix in lookInPrefixes)
         {

--- a/GameEngine/GameEngine.cs
+++ b/GameEngine/GameEngine.cs
@@ -351,24 +351,56 @@ public class GameEngine<TInfocomGame, TContext> : IGameEngine
     }
 
     /// <summary>
-    ///     Rewrites a leading "look at &lt;noun&gt;" into the canonical "examine &lt;noun&gt;" so it routes
-    ///     through the examine-with-noun path instead of collapsing to the bare-room LOOK command
-    ///     (issues #312 / #283). Only the exact "look at " prefix followed by a noun is rewritten — bare
-    ///     "look"/"look around" and other "look &lt;preposition&gt;" phrases (e.g. "look under the rug",
-    ///     "look in the box") are intentionally left alone.
+    ///     Rewrites a leading "look at &lt;noun&gt;" — and the container-inspection phrasings
+    ///     "look in &lt;noun&gt;" / "look inside &lt;noun&gt;" (issue #396) — into the canonical
+    ///     "examine &lt;noun&gt;" so they route through the examine-with-noun path (which lists an open
+    ///     container's contents) instead of collapsing to the bare-room LOOK command or being handed to
+    ///     the AI parser, which mis-tags the "in" as a movement ("You cannot go that way."). This mirrors
+    ///     the original ZIL, where LOOK IN &lt;object&gt; maps to V-LOOK-INSIDE (issues #312 / #283 for
+    ///     "look at"; issue #396 for "look in"/"look inside"). Left untouched: bare "look"/"look around",
+    ///     genuinely different prepositions ("look under the rug", "look behind the painting", "look
+    ///     through the crack", and "look into ..." — not an original syntax, and it reads as
+    ///     "investigate"), and the "look in inventory" / "look in my inventory" phrasing owned by
+    ///     GlobalCommandFactory's InventoryProcessor (which runs on the literal text after this —
+    ///     rewriting it to "examine inventory" would break the inventory listing).
     /// </summary>
     internal static string? NormalizeLookAt(string? input)
     {
         if (string.IsNullOrWhiteSpace(input))
             return input;
 
-        const string prefix = "look at ";
         var trimmed = input.TrimStart();
-        if (!trimmed.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
-            return input;
 
-        var noun = trimmed[prefix.Length..].Trim();
-        return string.IsNullOrEmpty(noun) ? input : "examine " + noun;
+        // "look at <noun>" -> "examine <noun>" (issues #312 / #283).
+        const string lookAtPrefix = "look at ";
+        if (trimmed.StartsWith(lookAtPrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            var atNoun = trimmed[lookAtPrefix.Length..].Trim();
+            return string.IsNullOrEmpty(atNoun) ? input : "examine " + atNoun;
+        }
+
+        // "look in <noun>" / "look inside <noun>" -> "examine <noun>" (issue #396). "look inside " is
+        // matched before "look in " so it is never misread as "look in" + "side ...".
+        string[] lookInPrefixes = ["look inside ", "look in "];
+        foreach (var lookInPrefix in lookInPrefixes)
+        {
+            if (!trimmed.StartsWith(lookInPrefix, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            var noun = trimmed[lookInPrefix.Length..].Trim();
+            if (string.IsNullOrEmpty(noun))
+                return input;
+
+            // Preserve the "look in inventory" / "look in my inventory" special-case owned by
+            // GlobalCommandFactory (InventoryProcessor); rewriting it to "examine inventory" breaks it.
+            if (noun.Equals("inventory", StringComparison.OrdinalIgnoreCase)
+                || noun.Equals("my inventory", StringComparison.OrdinalIgnoreCase))
+                return input;
+
+            return "examine " + noun;
+        }
+
+        return input;
     }
 
     /// <summary>
@@ -395,12 +427,13 @@ public class GameEngine<TInfocomGame, TContext> : IGameEngine
         if (string.IsNullOrEmpty(playerInput))
             return PostProcessing(await GetGeneratedNoCommandResponse());
 
-        // 2b. ------- "look at <noun>" is an examine synonym, not the bare-room LOOK command. The AI
-        // parser (rule (f) in the system prompt) collapses "look at X" to a noun-less look intent for
-        // single-word nouns, re-describing the room instead of the object (issues #312 / #283). Rewrite
-        // it to the canonical "examine <noun>" here so it routes through the examine-with-noun path,
-        // while leaving the bare forms ("look", "look around") and other "look <prep>" phrases
-        // ("look under the rug", "look in the box") untouched. Note: because this runs before pronoun
+        // 2b. ------- "look at <noun>" — and the "look in/inside <noun>" container-inspection phrasings
+        // (issue #396) — are examine synonyms, not the bare-room LOOK command. The AI parser collapses
+        // "look at X" to a noun-less look intent (issues #312 / #283) and mis-tags "look in X" as an "in"
+        // movement ("You cannot go that way."). Rewrite them to the canonical "examine <noun>" here so
+        // they route through the examine-with-noun path (which lists an open container's contents), while
+        // leaving the bare forms ("look", "look around") and genuinely different prepositions ("look
+        // under the rug", "look behind the painting") untouched. Note: because this runs before pronoun
         // resolution and the LastInput capture below, a subsequent "again"/"g" replays "look at X" as
         // "examine X" — harmless, since both produce the same examination output.
         playerInput = NormalizeLookAt(playerInput);

--- a/Planetfall.Tests/PlanetaryDefenseTests.cs
+++ b/Planetfall.Tests/PlanetaryDefenseTests.cs
@@ -57,6 +57,24 @@ public class PlanetaryDefenseTests : EngineTestsBase
     }
 
     [Test]
+    public async Task LookInPanel_Open_ListsContents()
+    {
+        // Issue #396: "look in <container>" — the exact prod repro — must list the panel's contents,
+        // exactly like "examine panel" (ZIL syntax.zil:201: LOOK IN OBJECT -> V-LOOK-INSIDE). Before
+        // the fix it was mis-parsed as an "in" movement / bare-room LOOK and never showed the boards.
+        var target = GetTarget();
+        StartHere<PlanetaryDefense>();
+        GetItem<FromitzAccessPanel>().IsOpen = true;
+
+        var response = await target.GetResponse("look in panel");
+
+        response.Should().Contain("The access panel contains:");
+        response.Should().Contain("  A first seventeen-centimeter fromitz board");
+        response.Should().Contain("  A second seventeen-centimeter fromitz board");
+        response.Should().NotContain("cannot go that way");
+    }
+
+    [Test]
     [TestCase("first")]
     [TestCase("third")]
     [TestCase("fourth")]

--- a/UnitTests/Engine/NormalizeLookAtTests.cs
+++ b/UnitTests/Engine/NormalizeLookAtTests.cs
@@ -5,11 +5,15 @@ using ZorkOne;
 namespace UnitTests.Engine;
 
 /// <summary>
-///     Pins the conservative contract of <see cref="GameEngine{TInfocomGame,TContext}.NormalizeLookAt" />
-///     (issues #312 / #283). The behavioral <c>ExamineVerbsTests</c> in each game cover the positive
-///     "look at X routes to examine" path end-to-end; these unit tests lock the <em>negative</em> cases
-///     the integration tests leave implicit — bare "look", "look around" and other "look &lt;preposition&gt;"
-///     phrases must NOT be rewritten — so a future broadening of the prefix match is caught immediately.
+///     Pins the contract of <see cref="GameEngine{TInfocomGame,TContext}.NormalizeLookAt" />
+///     (issues #312 / #283 for "look at"; issue #396 for "look in"/"look inside"). The behavioral
+///     <c>ExamineVerbsTests</c> in each game cover the positive "look at X routes to examine" path
+///     end-to-end; these unit tests lock the boundary cases the integration tests leave implicit —
+///     which "look &lt;preposition&gt;" phrases route to examine ("look in"/"look inside", the
+///     container-inspection phrasings that mirror the original ZIL's LOOK IN -> V-LOOK-INSIDE) and
+///     which stay untouched (bare "look"/"look around", "look under"/"look behind"/"look through",
+///     and the "look in inventory" phrasing owned elsewhere) — so a future change to the prefix
+///     matching is caught immediately.
 /// </summary>
 public class NormalizeLookAtTests
 {
@@ -29,13 +33,42 @@ public class NormalizeLookAtTests
         Normalize(input).Should().Be(expected);
     }
 
+    // Issue #396: "look in <container>" / "look inside <container>" — the canonical Infocom phrasing
+    // for inspecting an open container's contents — must route to examine, not be handed to the AI
+    // parser (which mis-tags the "in" as a movement, yielding "You cannot go that way.").
+    [TestCase("look in the box", "examine the box")]
+    [TestCase("look inside the box", "examine the box")]
+    [TestCase("look in panel", "examine panel")]
+    [TestCase("look inside panel", "examine panel")]
+    [TestCase("LOOK IN MAILBOX", "examine MAILBOX")] // case-insensitive prefix, noun case preserved
+    [TestCase("  look in mailbox", "examine mailbox")] // leading whitespace tolerated
+    [TestCase("look inside   sack", "examine sack")] // collapses padding after the prefix
+    public void Rewrites_LookInNoun_ToExamine(string input, string expected)
+    {
+        Normalize(input).Should().Be(expected);
+    }
+
+    // The "look in inventory" / "look in my inventory" phrasing is owned by GlobalCommandFactory's
+    // InventoryProcessor, which runs AFTER NormalizeLookAt on the literal text — rewriting it to
+    // "examine inventory" would break the inventory listing (issue #396). Must be left untouched.
+    [TestCase("look in inventory")]
+    [TestCase("look in my inventory")]
+    [TestCase("LOOK IN INVENTORY")]
+    public void PreservesLookInInventory_ForInventoryProcessor(string input)
+    {
+        Normalize(input).Should().Be(input);
+    }
+
     [TestCase("look")] // bare room-description command
     [TestCase("look around")]
     [TestCase("l")]
-    [TestCase("look under the rug")] // distinct "look <preposition>" interactions
-    [TestCase("look in the box")]
+    [TestCase("look under the rug")] // distinct "look <preposition>" interactions, left alone
     [TestCase("look through the crack")]
     [TestCase("look behind the painting")]
+    // "look into" is deliberately NOT rewritten: it is not an original ZIL syntax, it carries an
+    // "investigate" reading, and the existing "look into relay" Planetfall path depends on it being
+    // left alone. Issue #396 marks it explicitly optional.
+    [TestCase("look into the box")]
     [TestCase("examine mailbox")] // already canonical — untouched
     [TestCase("take lamp")]
     [TestCase("quickly look at the lamp")] // only a leading prefix is rewritten, not a mid-sentence one
@@ -47,7 +80,11 @@ public class NormalizeLookAtTests
     [TestCase("look at")] // verb phrase with no noun — nothing to examine, leave alone
     [TestCase("look at ")]
     [TestCase("look at   ")]
-    public void LeavesNounlessLookAt_Untouched(string input)
+    [TestCase("look in")]
+    [TestCase("look in ")]
+    [TestCase("look inside")]
+    [TestCase("look inside ")]
+    public void LeavesNounlessLookPhrase_Untouched(string input)
     {
         Normalize(input).Should().Be(input);
     }

--- a/ZorkOne.Tests/Things/MailboxTests.cs
+++ b/ZorkOne.Tests/Things/MailboxTests.cs
@@ -20,6 +20,22 @@ public class MailboxTests : EngineTestsBase
     }
 
     [Test]
+    public async Task Should_ListContents_When_LookingInOpenMailbox()
+    {
+        // Issue #396: "look in <container>" is the canonical Infocom phrasing for inspecting an open
+        // container's contents (ZIL: LOOK IN OBJECT -> V-LOOK-INSIDE). It must list the contents, not
+        // be mis-parsed as an "in" movement ("You cannot go that way.") or collapse to the room LOOK.
+        var target = GetTarget();
+        target.Context.CurrentLocation = Repository.GetLocation<WestOfHouse>();
+
+        await target.GetResponse("open mailbox");
+        var response = await target.GetResponse("look in mailbox");
+
+        response.Should().Contain("leaflet");
+        response.Should().NotContain("cannot go that way");
+    }
+
+    [Test]
     public async Task Should_SayEmpty_When_ExaminingOpenEmptyMailbox()
     {
         var target = GetTarget();


### PR DESCRIPTION
Fixes #396.

## The bug

`look in <container>` — the canonical Infocom phrasing for inspecting an open container — never showed the contents. It was misclassified as an `in` **movement** (`"You cannot go that way."`) or collapsed to the bare-room `LOOK` (room re-described). `examine <container>` and `look at <container>` both work, so the contents *are* reachable — just not via the natural "look in" phrasing. Affected **both Zork I and Planetfall**, since the normalization is shared engine code.

**Prod repro (Planetfall, Planetary Defense, panel opened):**
```
> examine panel        → The access panel contains: ...fromitz boards...
> look at panel         → The access panel contains: ...
> look in panel         → You cannot go that way.        (never the contents)
> look inside panel     → <room description>
```

## Root cause

`NormalizeLookAt` in `GameEngine/GameEngine.cs` rewrote only `"look at <noun>"` → `"examine <noun>"` and **intentionally** left `"look in <noun>"` to the AI intent parser — which mis-tags the `in` as a movement intent or the bare-room `LOOK`. The examine processor already lists `"look in"` among its verbs, so a parse that reached it with the noun attached would work — but it never got there.

## Original behavior (ZIL — ground truth)

`LOOK IN <object>` maps to `V-LOOK-INSIDE`, which lists the object's contents:
- Planetfall — `planetfall-source/syntax.zil:201`: `<SYNTAX LOOK IN OBJECT (HELD CARRIED ON-GROUND IN-ROOM MANY) = V-LOOK-INSIDE>`
- Zork I — `zork1/gsyntax.zil:200-201`: `<SYNTAX EXAMINE IN OBJECT (...) = V-LOOK-INSIDE>` (LOOK is a synonym of EXAMINE)

Neither game defines `LOOK INTO` as a syntax.

## The fix

Extend `NormalizeLookAt` to also rewrite leading `"look in <noun>"` / `"look inside <noun>"` → `"examine <noun>"`, routing through the examine path that already lists an open container's contents.

Guardrails:
- **`look in inventory` / `look in my inventory` left untouched** — owned by `GlobalCommandFactory`'s `InventoryProcessor`, which runs on the literal text *after* this step; rewriting to `examine inventory` would break the inventory listing.
- **`look inside ` matched before `look in `** so it's never misread as `look in` + `side …`.
- **`look into` deliberately excluded** — not an original ZIL syntax, carries an "investigate" reading, and the existing `look into relay` Planetfall path depends on it being left alone. (The issue marks it explicitly optional.)
- **`look at` behavior unchanged.**

## Tests (TDD — red before, green after)

- `UnitTests/Engine/NormalizeLookAtTests.cs` (game-agnostic, pins the fix): `look in`/`look inside` → examine rewrites, the `look in inventory` and `look into` exclusions, and nounless forms.
- `ZorkOne.Tests/Things/MailboxTests.cs`: `open mailbox; look in mailbox` now lists the leaflet.
- `Planetfall.Tests/PlanetaryDefenseTests.cs`: the exact prod repro — `look in panel` now lists the fromitz boards.

## Regression results (each project run separately)

| Suite | Result |
|---|---|
| UnitTests | 1012 passed, 0 failed |
| ZorkOne.Tests | 1771 passed, 0 failed |
| Planetfall.Tests | 2998 passed, 0 failed (incl. the `look into relay` tests) |
| EscapeRoom.Tests | 7 passed, 0 failed |

`Lambda.Tests` / `Planetfall-Lambda.Tests` fail to **restore** with a pre-existing `NU1605` package-downgrade conflict (`Amazon.Lambda.APIGatewayEvents` 2.7.3→2.7.0, `Amazon.Lambda.Core` 2.8.0→2.2.0). This is unrelated to this change — no `.csproj`/package references were touched, and those projects can't restore regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
