### PR TITLE
Fix #398: examining an open container now lists its contents

### DIFF
--- a/GameEngine/Item/OpenAndCloseContainerBase.cs
+++ b/GameEngine/Item/OpenAndCloseContainerBase.cs
@@ -8,9 +8,25 @@ namespace GameEngine.Item;
 /// <summary>
 ///     Represents a base class for containers that can be opened and closed.
 /// </summary>
-public abstract class OpenAndCloseContainerBase : ContainerBase, IOpenAndClose
+public abstract class OpenAndCloseContainerBase : ContainerBase, IOpenAndClose, ICanBeExamined
 {
     public bool HasEverBeenOpened { get; set; }
+
+    /// <summary>
+    ///     Default examine behavior for an open/close container: when closed, report it is closed;
+    ///     when open, list the contents (or that it is empty). This closes the recurring gap
+    ///     (issue #398) where a subclass hand-wrote an <c>ExaminationDescription</c> that reported
+    ///     only "is open" and hid what was inside.
+    ///     <para>
+    ///     Implemented as an <b>explicit</b> interface member on purpose: subclasses that need
+    ///     special examine text simply re-list <see cref="ICanBeExamined" /> and declare their own
+    ///     public <c>ExaminationDescription</c> - that re-implementation wins for their type with no
+    ///     member-hiding warning. Subclasses that want the correct default just leave it off and
+    ///     inherit this.
+    ///     </para>
+    /// </summary>
+    string ICanBeExamined.ExaminationDescription =>
+        IsOpen ? ItemListDescription(Name, null) : $"The {Name} is closed. ";
 
     public virtual string? CannotBeOpenedDescription(IContext context)
     {

--- a/GameEngine/Item/OpenAndCloseContainerBase.cs
+++ b/GameEngine/Item/OpenAndCloseContainerBase.cs
@@ -13,10 +13,12 @@ public abstract class OpenAndCloseContainerBase : ContainerBase, IOpenAndClose, 
     public bool HasEverBeenOpened { get; set; }
 
     /// <summary>
-    ///     Default examine behavior for an open/close container: when closed, report it is closed;
-    ///     when open, list the contents (or that it is empty). This closes the recurring gap
-    ///     (issue #398) where a subclass hand-wrote an <c>ExaminationDescription</c> that reported
-    ///     only "is open" and hid what was inside.
+    ///     Default examine behavior for an open/close container: report it is closed only when it is
+    ///     actually closed AND opaque; otherwise (open, or transparent) list the contents (or that it
+    ///     is empty). This closes the recurring gap (issue #398) where a subclass hand-wrote an
+    ///     <c>ExaminationDescription</c> that reported only "is open" and hid what was inside. The
+    ///     transparency check keeps this consistent with <see cref="ContainerBase.ItemListDescription" />,
+    ///     which shows the contents of a transparent container even while it is closed.
     ///     <para>
     ///     Implemented as an <b>explicit</b> interface member on purpose: subclasses that need
     ///     special examine text simply re-list <see cref="ICanBeExamined" /> and declare their own
@@ -26,7 +28,7 @@ public abstract class OpenAndCloseContainerBase : ContainerBase, IOpenAndClose, 
     ///     </para>
     /// </summary>
     string ICanBeExamined.ExaminationDescription =>
-        IsOpen ? ItemListDescription(Name, null) : $"The {Name} is closed. ";
+        !IsOpen && !IsTransparent ? $"The {Name} is closed. " : ItemListDescription(Name, null);
 
     public virtual string? CannotBeOpenedDescription(IContext context)
     {

--- a/Planetfall.Tests/AdminOfficeTests.cs
+++ b/Planetfall.Tests/AdminOfficeTests.cs
@@ -1,0 +1,52 @@
+using FluentAssertions;
+using GameEngine;
+using Planetfall.Item.Kalamontee.Admin;
+using Planetfall.Location.Kalamontee.Admin;
+
+namespace Planetfall.Tests;
+
+/// <summary>
+/// Issue #398: examining an OPEN open/close container must list its contents instead of
+/// reporting only that the drawer is "open" - which hid the access cards inside the desks.
+/// </summary>
+public class AdminOfficeTests : EngineTestsBase
+{
+    [Test]
+    public async Task ExamineSmallDesk_WhenOpen_ListsContents()
+    {
+        var target = GetTarget();
+        StartHere<SmallOffice>();
+        GetItem<SmallDesk>().IsOpen = true;
+
+        var response = await target.GetResponse("examine desk");
+
+        response.Should().Contain("kitchen access card");
+        response.Should().NotContain("currently open");
+    }
+
+    [Test]
+    public async Task ExamineSmallDesk_WhenClosed_ReportsClosed()
+    {
+        var target = GetTarget();
+        StartHere<SmallOffice>();
+        GetItem<SmallDesk>().IsOpen = false;
+
+        var response = await target.GetResponse("examine desk");
+
+        response.Should().Contain("closed");
+        response.Should().NotContain("kitchen access card");
+    }
+
+    [Test]
+    public async Task ExamineLargeDesk_WhenOpen_ListsContents()
+    {
+        var target = GetTarget();
+        StartHere<LargeOffice>();
+        GetItem<LargeDesk>().IsOpen = true;
+
+        var response = await target.GetResponse("examine desk");
+
+        response.Should().Contain("shuttle access card");
+        response.Should().NotContain("currently open");
+    }
+}

--- a/Planetfall.Tests/CourseControlTests.cs
+++ b/Planetfall.Tests/CourseControlTests.cs
@@ -160,7 +160,7 @@ public class CourseControlTests : EngineTestsBase
     }
 
     [Test]
-    public async Task ExamineCube_WhenOpen()
+    public async Task ExamineCube_WhenOpen_ListsContents()
     {
         var target = GetTarget();
         StartHere<CourseControl>();
@@ -168,7 +168,10 @@ public class CourseControlTests : EngineTestsBase
 
         var response = await target.GetResponse("examine cube");
 
-        response.Should().Contain("The large metal cube is open");
+        // Issue #398: examining an OPEN container must list its contents (the fused bedistor
+        // central to the Course Control puzzle), not just report "is open" and hide them.
+        response.Should().Contain("bedistor");
+        response.Should().NotContain("The large metal cube is open");
     }
 
     [Test]

--- a/Planetfall/Item/Kalamontee/Admin/LargeDesk.cs
+++ b/Planetfall/Item/Kalamontee/Admin/LargeDesk.cs
@@ -1,11 +1,12 @@
 namespace Planetfall.Item.Kalamontee.Admin;
 
-public class LargeDesk : OpenAndCloseContainerBase, ICanBeExamined
+public class LargeDesk : OpenAndCloseContainerBase
 {
-    public override string[] NounsForMatching => ["lsrge desk", "desk"];
+    public override string[] NounsForMatching => ["large desk", "desk"];
 
-    public string ExaminationDescription =>
-        $"The desk has a drawer which is currently {(IsOpen ? "open" : "closed")}. ";
+    // Examine is inherited from OpenAndCloseContainerBase (issue #398): open -> lists the shuttle
+    // access card in the drawer; closed -> "The large desk is closed." The old override reported
+    // only that the drawer was "currently open" and hid its contents.
 
     public override void Init()
     {

--- a/Planetfall/Item/Kalamontee/Admin/SmallDesk.cs
+++ b/Planetfall/Item/Kalamontee/Admin/SmallDesk.cs
@@ -1,11 +1,12 @@
 ﻿namespace Planetfall.Item.Kalamontee.Admin;
 
-public class SmallDesk : OpenAndCloseContainerBase, ICanBeExamined
+public class SmallDesk : OpenAndCloseContainerBase
 {
     public override string[] NounsForMatching => ["small desk", "desk"];
 
-    public string ExaminationDescription =>
-        $"The desk has a drawer which is currently {(IsOpen ? "open" : "closed")}. ";
+    // Examine is inherited from OpenAndCloseContainerBase (issue #398): open -> lists the access
+    // cards in the drawer; closed -> "The small desk is closed." The old override reported only
+    // that the drawer was "currently open" and hid its contents.
 
     public override void Init()
     {

--- a/Planetfall/Item/Lawanda/LargeMetalCube.cs
+++ b/Planetfall/Item/Lawanda/LargeMetalCube.cs
@@ -3,12 +3,13 @@ using Planetfall.Location.Lawanda;
 
 namespace Planetfall.Item.Lawanda;
 
-public class LargeMetalCube : OpenAndCloseContainerBase, ICanBeExamined
+public class LargeMetalCube : OpenAndCloseContainerBase
 {
     public override string[] NounsForMatching => ["large metal cube", "metal cube", "cube", "lid"];
 
-    public string ExaminationDescription => $"The large metal cube is {(IsOpen ? "open" : "closed")}. ";
-    
+    // Examine is inherited from OpenAndCloseContainerBase (issue #398): open -> lists the fused
+    // bedistor inside; closed -> "The large metal cube is closed." The old override reported only
+    // "is open" and hid the contents.
     public override Type[] CanOnlyHoldTheseTypes => [typeof(BedistorBase)];
 
     public override int Size => 1;

--- a/UnitTests/OpenAndCloseContainerExamineTests.cs
+++ b/UnitTests/OpenAndCloseContainerExamineTests.cs
@@ -1,0 +1,101 @@
+using FluentAssertions;
+using GameEngine;
+using GameEngine.Item;
+using Model.Item;
+using Model.Location;
+using NUnit.Framework;
+
+namespace UnitTests;
+
+/// <summary>
+/// Exercises the default <see cref="ICanBeExamined.ExaminationDescription" /> that
+/// <see cref="OpenAndCloseContainerBase" /> provides (issue #398). Uses minimal test doubles so
+/// the base behavior is verified independently of any single game item.
+/// </summary>
+public class OpenAndCloseContainerExamineTests
+{
+    private class ShinyWidget : ItemBase
+    {
+        public override string[] NounsForMatching => ["widget"];
+
+        public override string GenericDescription(ILocation? currentLocation) => "a shiny widget";
+    }
+
+    /// <summary>An opaque (non-transparent) openable container that inherits the default examine.</summary>
+    private class OpaqueBox : OpenAndCloseContainerBase
+    {
+        public override string[] NounsForMatching => ["box"];
+
+        public override void Init()
+        {
+        }
+    }
+
+    /// <summary>A transparent openable container that inherits the default examine.</summary>
+    private class GlassBox : OpenAndCloseContainerBase
+    {
+        public override string[] NounsForMatching => ["glass box"];
+
+        public override bool IsTransparent => true;
+
+        public override void Init()
+        {
+        }
+    }
+
+    private static string Examine(OpenAndCloseContainerBase container) =>
+        ((ICanBeExamined)container).ExaminationDescription;
+
+    [Test]
+    public void OpaqueClosed_ReportsClosed_AndHidesContents()
+    {
+        var box = new OpaqueBox();
+        box.ItemPlacedHere(new ShinyWidget());
+        box.IsOpen = false;
+
+        var text = Examine(box);
+
+        text.Should().Contain("The box is closed");
+        text.Should().NotContain("shiny widget");
+    }
+
+    [Test]
+    public void OpaqueOpen_ListsContents()
+    {
+        var box = new OpaqueBox();
+        box.ItemPlacedHere(new ShinyWidget());
+        box.IsOpen = true;
+
+        var text = Examine(box);
+
+        text.Should().Contain("shiny widget");
+        text.Should().NotContain("is closed");
+    }
+
+    [Test]
+    public void OpaqueOpenEmpty_ReportsEmpty()
+    {
+        var box = new OpaqueBox();
+        box.IsOpen = true;
+
+        var text = Examine(box);
+
+        text.Should().Contain("The box is empty");
+    }
+
+    // Hardening (issue #398 review): a transparent container reveals its contents even when
+    // closed, matching ItemListDescription's own transparency handling. Before the fix the
+    // default short-circuited to "The glass box is closed." and hid the widget.
+    [Test]
+    public void TransparentClosed_StillListsContents()
+    {
+        var box = new GlassBox();
+        box.ItemPlacedHere(new ShinyWidget());
+        box.IsOpen = false;
+
+        var text = Examine(box);
+
+        text.Should().Contain("shiny widget");
+        text.Should().NotContain("is closed");
+    }
+}


### PR DESCRIPTION
## Summary

Examining an **open** `OpenAndCloseContainerBase` should list what's inside, but there was no shared default — each subclass hand-wrote its `ExaminationDescription` and several omitted the contents listing, so `examine` reported only "is open" and hid the contents. The player was then told a container was open with no idea what was in it, and had to know a different verb.

This matches the original ZIL, where `V-EXAMINE` on an open container defers to `V-LOOK-INSIDE` (`planetfall-source/verbs.zil:52-62`).

## Root cause & fix

There was no default, so correctness depended on every subclass remembering to call `ItemListDescription`. `OpenAndCloseContainerBase` now implements `ICanBeExamined` with a default:

- **closed** → "The `<name>` is closed."
- **open, non-empty** → the `ItemListDescription(...)` contents listing
- **open, empty** → "The `<name>` is empty."

It's an **explicit** interface member on purpose: the subclasses that need special examine text already re-list `ICanBeExamined` and declare their own public `ExaminationDescription`, so their re-implementation still wins for their type — **no member-hiding (CS0108) warnings and zero churn** to those 19 files. Offenders simply drop their broken override and inherit the default.

## Offenders fixed (full audit of all subclasses)

| Container | Old (open) examine | Was hiding |
|---|---|---|
| `LargeMetalCube` (Course Control) | "The large metal cube is open." | the fused bedistor |
| `SmallDesk` (Small Office) | "…drawer which is currently open." | kitchen + upper-elevator access cards |
| `LargeDesk` (Large Office) | "…drawer which is currently open." | shuttle access card |

Also fixed `LargeDesk`'s `"lsrge desk"` noun typo, surfaced now that the default uses `Name`.

`Mailbox` (#331) was already fixed; every other `OpenAndCloseContainerBase` subclass was already correct or has genuinely special examine text (e.g. `Tube`/`MedicineBottle` show a label, `LabUniform` describes the garment) and is untouched. This closes #398 and #331.

## TDD

- **Red:** flipped `CourseControlTests.ExamineCube_WhenOpen` (which *encoded* the bug) to assert the bedistor is listed, and added `AdminOfficeTests` for both desks. Confirmed all three failed for the right reason (e.g. *Expected "The large metal cube is open." to contain "bedistor"*).
- **Green, no regressions** (each suite run separately):

| Suite | Result |
|---|---|
| Planetfall.Tests | 3000 passed |
| ZorkOne.Tests | 1770 passed |
| UnitTests | 998 passed |
| EscapeRoom.Tests | 7 passed |

Tests drive the real `GetResponse("examine …")` pipeline, so behavior is verified end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)