### PR TITLE
Fix #399: card-activated booths now expire their activation after 30 turns

### DIFF
--- a/Planetfall.Tests/BoothTests.cs
+++ b/Planetfall.Tests/BoothTests.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using FluentAssertions;
 using Planetfall.Item.Kalamontee.Admin;
 using Planetfall.Item.Kalamontee.Mech;
@@ -269,12 +270,91 @@ public class BoothTests : EngineTestsBase
         StartHere<BoothThree>();
         Take<TeleportationAccessCard>();
         GetItem<Floyd>().CurrentLocation = GetLocation<BoothThree>();
-        
+
         await target.GetResponse("slide teleportation access card through slot");
         var response = await target.GetResponse("press one");
         response.Should().Contain("You experience a strange feeling in the pit of your stomach");
         response.Should().Contain("Floyd gives a terrified squeal, and clutches at his guidance mechanism");
         target.Context.CurrentLocation.Should().BeOfType<BoothOne>();
         GetItem<Floyd>().CurrentLocation.Should().BeOfType<BoothOne>();
+    }
+
+    // Issue #399: sliding the card activates the booth for only 30 turns in the original
+    // (<ENABLE <QUEUE I-TURNOFF-TELEPORTATION 30>>, globals.zil:1414). The port used to leave it
+    // "Redee" forever. After the window lapses, pressing a button must report the booth is not
+    // activated and must NOT teleport.
+    [Test]
+    public async Task Activation_Expires_AfterThirtyTurns()
+    {
+        var target = GetTarget();
+        StartHere<BoothThree>();
+        Take<TeleportationAccessCard>();
+
+        await target.GetResponse("slide teleportation access card through slot");
+        for (var i = 0; i < 31; i++)
+            await target.GetResponse("wait");
+
+        var response = await target.GetResponse("press 1");
+        response.Should().Contain("not aktivaatid");
+        target.Context.CurrentLocation.Should().BeOfType<BoothThree>();
+    }
+
+    // Complements the expiry test: a normal player slides then presses within a couple of turns,
+    // so activation must still be live well inside the 30-turn window.
+    [Test]
+    public async Task Activation_StillLive_WithinThirtyTurns()
+    {
+        var target = GetTarget();
+        StartHere<BoothThree>();
+        Take<TeleportationAccessCard>();
+
+        await target.GetResponse("slide teleportation access card through slot");
+        for (var i = 0; i < 5; i++)
+            await target.GetResponse("wait");
+
+        var response = await target.GetResponse("press 1");
+        response.Should().Contain("You experience a strange feeling in the pit of your stomach");
+        target.Context.CurrentLocation.Should().BeOfType<BoothOne>();
+    }
+
+    // When the timer lapses while the player is standing in the booth, the original announces it
+    // ("The ready light goes dark.", I-TURNOFF-TELEPORTATION, globals.zil:1538-1542).
+    [Test]
+    public async Task Activation_AnnouncesExpiry_WhenPlayerInBooth()
+    {
+        var target = GetTarget();
+        StartHere<BoothThree>();
+        Take<TeleportationAccessCard>();
+
+        await target.GetResponse("slide teleportation access card through slot");
+
+        var everything = new StringBuilder();
+        for (var i = 0; i < 32; i++)
+            everything.Append(await target.GetResponse("wait"));
+
+        everything.ToString().Should().Contain("The ready light goes dark");
+    }
+
+    // Re-sliding the card restarts the countdown (the original re-QUEUEs the turn-off daemon).
+    [Test]
+    public async Task Activation_ReslidingCard_RestartsCountdown()
+    {
+        var target = GetTarget();
+        StartHere<BoothThree>();
+        Take<TeleportationAccessCard>();
+
+        await target.GetResponse("slide teleportation access card through slot");
+        for (var i = 0; i < 25; i++)
+            await target.GetResponse("wait");
+
+        // Re-slide well before expiry, then wait past the ORIGINAL window - the fresh countdown
+        // should keep the booth live.
+        await target.GetResponse("slide teleportation access card through slot");
+        for (var i = 0; i < 10; i++)
+            await target.GetResponse("wait");
+
+        var response = await target.GetResponse("press 1");
+        response.Should().Contain("You experience a strange feeling in the pit of your stomach");
+        target.Context.CurrentLocation.Should().BeOfType<BoothOne>();
     }
 }

--- a/Planetfall.Tests/BoothTests.cs
+++ b/Planetfall.Tests/BoothTests.cs
@@ -335,6 +335,36 @@ public class BoothTests : EngineTestsBase
         everything.ToString().Should().Contain("The ready light goes dark");
     }
 
+    // The flip side of the announcement: when the window lapses while the player has wandered off, the
+    // original stays silent (I-TURNOFF-TELEPORTATION only tells if HERE is a booth, globals.zil:1540) -
+    // no phantom "ready light goes dark" should leak into an unrelated room. The booth still deactivates.
+    [Test]
+    public async Task Activation_ExpiresSilently_WhenPlayerHasLeftTheBooth()
+    {
+        var target = GetTarget();
+        StartHere<BoothThree>();
+        Take<TeleportationAccessCard>();
+
+        await target.GetResponse("slide teleportation access card through slot");
+        await target.GetResponse("west");
+        target.Context.CurrentLocation.Should().BeOfType<LibraryLobby>();
+
+        var everything = new StringBuilder();
+        for (var i = 0; i < 32; i++)
+            everything.Append(await target.GetResponse("wait"));
+
+        // Fired silently: no announcement while the player is elsewhere...
+        everything.ToString().Should().NotContain("ready light goes dark");
+        // ...but the activation still lapsed.
+        GetLocation<BoothThree>().IsEnabled.Should().BeFalse();
+
+        // And it is genuinely off: returning to the booth and pressing a button is rebuffed.
+        await target.GetResponse("east");
+        var response = await target.GetResponse("press 1");
+        response.Should().Contain("not aktivaatid");
+        target.Context.CurrentLocation.Should().BeOfType<BoothThree>();
+    }
+
     // Re-sliding the card restarts the countdown (the original re-QUEUEs the turn-off daemon).
     [Test]
     public async Task Activation_ReslidingCard_RestartsCountdown()

--- a/Planetfall.Tests/MiniaturizationBoothTests.cs
+++ b/Planetfall.Tests/MiniaturizationBoothTests.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using FluentAssertions;
 using Planetfall.Item.Kalamontee.Admin;
 using Planetfall.Item.Kalamontee.Mech.FloydPart;
@@ -176,5 +177,59 @@ public class MiniaturizationBoothTests : EngineTestsBase
         response.Should().Contain("Ooops! You seem to have transported yourself into an active sector of the computer");
         response.Should().Contain("fried by powerful electric currents");
         response.Should().Contain("You have died");
+    }
+
+    // Issue #399: sliding the card activates the booth for only 30 turns in the original
+    // (<ENABLE <QUEUE I-TURNOFF-MINI 30>>, globals.zil:1424). The port used to leave it activated
+    // forever. After the window lapses, keying the sector number must report the booth is not
+    // activated and must NOT teleport.
+    [Test]
+    public async Task Activation_Expires_AfterThirtyTurns()
+    {
+        var target = GetTarget();
+        StartHere<MiniaturizationBooth>();
+        Take<MiniaturizationAccessCard>();
+
+        await target.GetResponse("slide miniaturization card through slot");
+        for (var i = 0; i < 31; i++)
+            await target.GetResponse("wait");
+
+        var response = await target.GetResponse("type 384");
+        response.Should().Contain("Internal computer repair booth not activated");
+        target.Context.CurrentLocation.Should().BeOfType<MiniaturizationBooth>();
+    }
+
+    [Test]
+    public async Task Activation_StillLive_WithinThirtyTurns()
+    {
+        var target = GetTarget();
+        StartHere<MiniaturizationBooth>();
+        Take<MiniaturizationAccessCard>();
+
+        await target.GetResponse("slide miniaturization card through slot");
+        for (var i = 0; i < 5; i++)
+            await target.GetResponse("wait");
+
+        var response = await target.GetResponse("type 384");
+        response.Should().Contain("walls of the booth sliding away in all directions");
+        target.Context.CurrentLocation.Should().BeOfType<Station384>();
+    }
+
+    // When the timer lapses while the player is standing in the booth, the original announces it
+    // ("...Miniaturization booth de-activated.", I-TURNOFF-MINI, comptwo.zil:2390-2394).
+    [Test]
+    public async Task Activation_AnnouncesExpiry_WhenPlayerInBooth()
+    {
+        var target = GetTarget();
+        StartHere<MiniaturizationBooth>();
+        Take<MiniaturizationAccessCard>();
+
+        await target.GetResponse("slide miniaturization card through slot");
+
+        var everything = new StringBuilder();
+        for (var i = 0; i < 32; i++)
+            everything.Append(await target.GetResponse("wait"));
+
+        everything.ToString().Should().Contain("Miniaturization booth de-activated");
     }
 }

--- a/Planetfall/Item/Lawanda/MiniaturizationSlot.cs
+++ b/Planetfall/Item/Lawanda/MiniaturizationSlot.cs
@@ -1,5 +1,6 @@
 using Planetfall.Item.Kalamontee.Admin;
 using Planetfall.Item.Lawanda.Lab;
+using Planetfall.Location;
 using Planetfall.Location.Lawanda;
 
 namespace Planetfall.Item.Lawanda;
@@ -11,7 +12,9 @@ internal class MiniaturizationSlot : SlotBase<MiniaturizationAccessCard, Miniatu
 
     protected override InteractionResult OnSuccessfulSlide(IContext context, string? afterMessage)
     {
-        Repository.GetLocation<MiniaturizationBooth>().IsEnabled = true;
+        // Activate the booth AND start its 30-turn expiry countdown (issue #399). Previously this only
+        // set IsEnabled, so the activation never lapsed.
+        CardActivationTimer.Enable(Repository.GetLocation<MiniaturizationBooth>(), context);
         return new PositiveInteractionResult(
             "A melodic high-pitched voice says \"Miniaturization and teleportation booth activated. Please type in damaged sector number.\"" + afterMessage);
     }

--- a/Planetfall/Item/TeleportationSlot.cs
+++ b/Planetfall/Item/TeleportationSlot.cs
@@ -22,7 +22,9 @@ internal class TeleportationSlot<TBooth> : SlotBase<TeleportationAccessCard, Tel
     
     protected override InteractionResult OnSuccessfulSlide(IContext context, string? afterMessage)
     {
-        Repository.GetLocation<TBooth>().IsEnabled = true;
+        // Activate the booth AND start its 30-turn expiry countdown (issue #399). Previously this only
+        // set IsEnabled, so the activation never lapsed.
+        CardActivationTimer.Enable(Repository.GetLocation<TBooth>(), context);
         return new PositiveInteractionResult("Nothing happens for a moment. Then a light flashes \"Redee.\"" + afterMessage);
     }
 }

--- a/Planetfall/Location/BoothBase.cs
+++ b/Planetfall/Location/BoothBase.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using GameEngine.Location;
+using Model.AIGeneration;
 using Planetfall.Item.Kalamontee.Mech;
 using Planetfall.Item.Kalamontee.Mech.FloydPart;
 using Planetfall.Location.Lawanda;
@@ -11,9 +12,23 @@ namespace Planetfall.Location;
 /// inheriting properties and behaviors from <see cref="LocationBase"/>.
 /// Provides shared functionality for interacting with specific types of teleportation booth locations.
 /// </summary>
-internal abstract class BoothBase : LocationBase
+internal abstract class BoothBase : LocationBase, ICardActivatedDevice
 {
     public bool IsEnabled { get; set; }
+
+    // Issue #399: sliding the teleportation card activates the booth for only 30 turns in the original
+    // (<QUEUE I-TURNOFF-TELEPORTATION 30>, globals.zil:1414). CardActivationTimer counts this down and
+    // clears IsEnabled; without it the booth stayed "Redee" forever.
+    [UsedImplicitly] public int ActivationTurnsRemaining { get; set; }
+
+    // Shown when the window lapses while the player is in the booth (I-TURNOFF-TELEPORTATION,
+    // globals.zil:1538-1542); silent otherwise.
+    public string DeactivationAnnouncement => "The ready light goes dark. ";
+
+    public Task<string> Act(IContext context, IGenerationClient client)
+    {
+        return Task.FromResult(CardActivationTimer.Tick(this, context));
+    }
 
     protected PositiveInteractionResult GoOne(IContext context)
     {
@@ -43,7 +58,9 @@ internal abstract class BoothBase : LocationBase
             Repository.GetItem<Floyd>().CurrentLocation = Repository.GetLocation<T>();
         }
         
-        IsEnabled = false;
+        // Using the booth consumes the activation and cancels its expiry countdown, mirroring
+        // <DISABLE <INT I-TURNOFF-TELEPORTATION>> on a successful teleport (globals.zil:1522).
+        CardActivationTimer.Cancel(this, context);
         context.CurrentLocation = Repository.GetLocation<T>();
 
         sb.AppendLine("You experience a strange feeling in the pit of your stomach. ");

--- a/Planetfall/Location/CardActivationTimer.cs
+++ b/Planetfall/Location/CardActivationTimer.cs
@@ -1,0 +1,69 @@
+namespace Planetfall.Location;
+
+/// <summary>
+/// Shared turn-based expiry for card-activated devices (the teleportation booths and the
+/// miniaturization booth). Sliding a valid card calls <see cref="Enable" />, which activates the device
+/// and registers it as an actor; <see cref="Tick" /> (invoked from each device's <c>Act</c>) counts the
+/// window down and clears the activation when it elapses. This reproduces the original's turn-off
+/// daemons — both booths expire after 30 turns (<c>&lt;QUEUE I-TURNOFF-TELEPORTATION 30&gt;</c>,
+/// globals.zil:1414; <c>&lt;QUEUE I-TURNOFF-MINI 30&gt;</c>, globals.zil:1424) — instead of the port's
+/// former behaviour of staying activated forever (issue #399).
+///
+/// The lower/upper elevators are deliberately NOT routed through here: they already carry an equivalent
+/// self-timer in <see cref="Kalamontee.ElevatorBase" />, entangled with their movement-reset counter.
+/// </summary>
+internal static class CardActivationTimer
+{
+    /// <summary>The original's activation window for both the teleportation and miniaturization booths.</summary>
+    public const int DefaultWindow = 30;
+
+    /// <summary>
+    /// Activates the device and starts (or, on a re-slide, restarts) its expiry countdown.
+    /// </summary>
+    public static void Enable(ICardActivatedDevice device, IContext context, int window = DefaultWindow)
+    {
+        device.IsEnabled = true;
+        device.ActivationTurnsRemaining = window;
+        // RegisterActor de-dupes by type, so re-sliding the card simply restarts the countdown here.
+        context.RegisterActor(device);
+    }
+
+    /// <summary>
+    /// Advances the countdown by one turn. Returns the deactivation announcement on the turn the window
+    /// lapses (and only when the player is standing in the device, matching the original); otherwise
+    /// returns an empty string.
+    /// </summary>
+    public static string Tick(ICardActivatedDevice device, IContext context)
+    {
+        // Defensive: if something already cleared the activation (e.g. a teleport that used the booth),
+        // there is nothing left to count down - just stop acting.
+        if (!device.IsEnabled)
+        {
+            context.RemoveActor(device);
+            return string.Empty;
+        }
+
+        if (device.ActivationTurnsRemaining > 0)
+        {
+            device.ActivationTurnsRemaining--;
+            return string.Empty;
+        }
+
+        // The window has elapsed - deactivate. The original announces the lapse only if you are standing
+        // in the device when it fires (I-TURNOFF-TELEPORTATION / I-TURNOFF-MINI); elsewhere it is silent.
+        device.IsEnabled = false;
+        context.RemoveActor(device);
+        return context.CurrentLocation == device ? device.DeactivationAnnouncement : string.Empty;
+    }
+
+    /// <summary>
+    /// Cancels an active countdown because the device was used before it lapsed (mirrors
+    /// <c>&lt;DISABLE &lt;INT I-TURNOFF-TELEPORTATION&gt;&gt;</c> on a successful teleport, globals.zil:1522).
+    /// </summary>
+    public static void Cancel(ICardActivatedDevice device, IContext context)
+    {
+        device.IsEnabled = false;
+        device.ActivationTurnsRemaining = 0;
+        context.RemoveActor(device);
+    }
+}

--- a/Planetfall/Location/ICardActivatedDevice.cs
+++ b/Planetfall/Location/ICardActivatedDevice.cs
@@ -1,0 +1,26 @@
+namespace Planetfall.Location;
+
+/// <summary>
+/// A device that a player activates by sliding an access card through a slot, and whose activation
+/// lapses after a fixed number of turns unless the device is used first. Implemented by the
+/// teleportation booths (<see cref="BoothBase" />) and the
+/// <see cref="Planetfall.Location.Lawanda.MiniaturizationBooth" />. The shared countdown lives in
+/// <see cref="CardActivationTimer" />, reproducing the original's I-TURNOFF-* turn-off daemons
+/// (planetfall/globals.zil) that the port originally omitted (issue #399).
+/// </summary>
+internal interface ICardActivatedDevice : ILocation, ITurnBasedActor
+{
+    /// <summary>Whether the device is currently activated (its button / keys will work).</summary>
+    bool IsEnabled { get; set; }
+
+    /// <summary>
+    /// Turns left before the activation lapses. Counted down each turn by <see cref="CardActivationTimer.Tick" />.
+    /// </summary>
+    int ActivationTurnsRemaining { get; set; }
+
+    /// <summary>
+    /// The message shown when the activation lapses while the player is standing in the device. The
+    /// original stays silent when the timer fires while the player is elsewhere.
+    /// </summary>
+    string DeactivationAnnouncement { get; }
+}

--- a/Planetfall/Location/Lawanda/MiniaturizationBooth.cs
+++ b/Planetfall/Location/Lawanda/MiniaturizationBooth.cs
@@ -8,13 +8,27 @@ using Utilities;
 
 namespace Planetfall.Location.Lawanda;
 
-internal class MiniaturizationBooth : LocationBase
+internal class MiniaturizationBooth : LocationBase, ICardActivatedDevice
 {
     public override string Name => "Miniaturization Booth";
 
     public override string[] NounsForMatching => ["shrink booth", "miniaturizer"];
 
     public bool IsEnabled { get; set; }
+
+    // Issue #399: sliding the miniaturization card activates the booth for only 30 turns in the original
+    // (<QUEUE I-TURNOFF-MINI 30>, globals.zil:1424). CardActivationTimer counts this down and clears
+    // IsEnabled; without it the booth stayed activated forever.
+    [UsedImplicitly] public int ActivationTurnsRemaining { get; set; }
+
+    // Shown when the window lapses while the player is in the booth (I-TURNOFF-MINI,
+    // comptwo.zil:2390-2394); silent otherwise.
+    public string DeactivationAnnouncement => "A recorded voice says \"Miniaturization booth de-activated.\" ";
+
+    public Task<string> Act(IContext context, IGenerationClient client)
+    {
+        return Task.FromResult(CardActivationTimer.Tick(this, context));
+    }
 
     public override void Init()
     {
@@ -60,8 +74,9 @@ internal class MiniaturizationBooth : LocationBase
             {
                 if (keyPress.Value == 384)
                 {
-                    // Teleport to Station 384
-                    IsEnabled = false;
+                    // Teleport to Station 384. Using the booth consumes the activation and cancels its
+                    // expiry countdown (mirrors the original disabling I-TURNOFF-MINI once used).
+                    CardActivationTimer.Cancel(this, context);
                     context.CurrentLocation = Repository.GetLocation<Station384>();
 
                     var message = "You notice the walls of the booth sliding away in all directions, followed by a momentary queasiness in the pit of your stomach...\n\n" +


### PR DESCRIPTION
## Bug

Sliding the teleportation (or miniaturization) access card through a booth's slot activated it **permanently** — the activation never expired. In the original, activation lapses after 30 turns, so a dawdling player must re-slide the card. The port kept the booth `Redee`/activated indefinitely (until an actual teleport, which already deactivated it correctly).

Repro: slide the teleportation card in Booth 3, `wait` 30+ times, `press 1` → still teleported (should report `not aktivaatid`).

## Original behavior (ZIL — ground truth)

Sliding a card enables the device **and queues a turn-off daemon**:
- teleport booths: `<ENABLE <QUEUE I-TURNOFF-TELEPORTATION 30>>` (`globals.zil:1414`)
- miniaturization booth: `<ENABLE <QUEUE I-TURNOFF-MINI 30>>` (`globals.zil:1424`)

The daemons clear the flag after the window and announce the lapse **only if the player is standing in the device** when it fires:
- `I-TURNOFF-TELEPORTATION` (`globals.zil:1538`) → `"The ready light goes dark."`
- `I-TURNOFF-MINI` (`comptwo.zil:2390`) → `"...Miniaturization booth de-activated."`

Using the booth also cancels the daemon (`<DISABLE <INT I-TURNOFF-TELEPORTATION>>`, `globals.zil:1522`).

## Fix

Introduce a shared `ICardActivatedDevice` + `CardActivationTimer` (an `ITurnBasedActor` self-timer, mirroring the existing `ElevatorBase` pattern; serialization-safe, no delegates/refs). `BoothBase` and `MiniaturizationBooth` now:

- activate for 30 turns and clear `IsEnabled` when the window lapses;
- announce the lapse only when the player is in the device (silent otherwise), matching the original;
- cancel the timer when the device is used (teleport), and restart it on a re-slide.

### Scope note — the lower elevator

The issue also listed the lower elevator, but it **already expires** via `ElevatorBase.ElevatorIsEnabled` (see the existing `DisablesAfterFiveTurns_Lower` test). Its countdown is deliberately entangled with the elevator's post-move door-reset counter, so retrofitting the original's 200-turn value would break that mechanic and its tests for no real-world benefit. Left untouched and documented in the `CardActivationTimer` doc comment.

## TDD

Red first: 4 of the new expiry/announce tests failed for the right reason (booth still teleported after 31 turns). Added 8 tests across `BoothTests` / `MiniaturizationBoothTests`:

- **expiry** — pressing a button after 31 turns is rebuffed and does not teleport (both booths);
- **still-live-within-window** — pressing a few turns after the slide still works (both booths);
- **in-booth announcement** — the lapse announces `"The ready light goes dark."` / `"...Miniaturization booth de-activated."` when the player is present (both booths);
- **silent expiry when away** — when the window lapses after the player has left the booth, no phantom `"ready light goes dark"` leaks into the adjacent room, the booth still deactivates, and pressing a button on return is rebuffed (covers the `CurrentLocation != device` branch);
- **re-slide restart** — re-sliding the card restarts the countdown.

## Verification

- Full `Planetfall.Tests` suite green: **3005 passed**, 0 failed.
- Full solution builds with 0 errors.
- Walkthroughs (which slide-then-press immediately, incl. `type 384`) confirm the 30-turn window never clips the real solution path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)