### PR TITLE
Fix #401: microfilm reader is a fixed machine, no longer takeable

### DIFF
--- a/Planetfall.Tests/SpoolReaderTests.cs
+++ b/Planetfall.Tests/SpoolReaderTests.cs
@@ -132,10 +132,24 @@ public class SpoolReaderTests : EngineTestsBase
         var target = GetTarget();
         StartHere<Library>();
         Take<GreenSpool>();
-        
+
         await target.GetResponse("put green spool in reader");
         var response = await target.GetResponse("take green spool");
 
         response.Should().Contain("The screen goes blank as you take the spool");
+    }
+
+    [Test]
+    public async Task TakeReader_IsRefused_NotCarried()
+    {
+        // Issue #401: the microfilm reader is a machine fixed on the desk (ZIL SPOOL-READER has no
+        // TAKEBIT). "take reader" must not succeed or move the machine into the player's inventory.
+        var target = GetTarget();
+        StartHere<Library>();
+
+        var response = await target.GetResponse("take reader");
+
+        response.Should().NotContain("Taken");
+        Context.HasItem<SpoolReader>().Should().BeFalse(); // the machine stays in the room
     }
 }

--- a/Planetfall/Item/Lawanda/Library/SpoolReader.cs
+++ b/Planetfall/Item/Lawanda/Library/SpoolReader.cs
@@ -1,6 +1,6 @@
 namespace Planetfall.Item.Lawanda.Library;
 
-public class SpoolReader : ContainerBase, ICanBeExamined, ICanBeTakenAndDropped, ICanContainItems, ICanBeRead
+public class SpoolReader : ContainerBase, ICanBeExamined, ICanContainItems, ICanBeRead
 {
     public override string[] NounsForMatching => ["spool reader", "reader", "screen"];
 
@@ -8,15 +8,15 @@ public class SpoolReader : ContainerBase, ICanBeExamined, ICanBeTakenAndDropped,
         ?  "The screen is currently displaying some information: " +
           ReadDescription
         : "The screen is currently blank. ");
-    
-    public string OnTheGroundDescription(ILocation currentLocation)
-    {
-        return NeverPickedUpDescription(currentLocation);
-    }
 
     protected override int SpaceForItems => 1;
 
-    public override string NeverPickedUpDescription(ILocation currentLocation)
+    // Issue #401: the reader is a machine fixed on a table (ZIL SPOOL-READER has no TAKEBIT), so it
+    // deliberately does NOT implement ICanBeTakenAndDropped - "take reader" must be refused, not pick
+    // up the machine. Because fixed (non-takeable) items get their room text from GenericDescription
+    // rather than NeverPickedUpDescription/OnTheGroundDescription (see LocationBase.GetItemDescriptions),
+    // the on-the-table description lives here.
+    public override string GenericDescription(ILocation? currentLocation)
     {
         return "There is a microfilm reader on one of the tables. " +
                (Items.Any() ? $"\n{ItemListDescription("microfilm reader", null)}" : "");


### PR DESCRIPTION
## Bug

The Library's microfilm reader (spool reader) implemented `ICanBeTakenAndDropped`, so `take reader` returned `Taken.` and put the table-mounted machine into inventory. The original ZIL `SPOOL-READER` (`historicalsource/planetfall/comptwo.zil:1173-1185`) has **no `TAKEBIT`** — it is a container fixed on the desk (`LIGHTBIT CONTBIT SEARCHBIT OPENBIT`).

Fixes #401.

## Root cause

`SpoolReader : ContainerBase, ICanBeExamined, ICanBeTakenAndDropped, ...` — implementing the take interface made the take verb succeed. No test covered the reader's own takeability, so it was an oversight.

## Fix

- Dropped `ICanBeTakenAndDropped` from `SpoolReader`. `take reader` now routes through `CannotBeTakenProcessor` → `NoVerbMatchInteractionResult` → the narrator's standard "you can't take that" response, and the machine stays in the room.
- Non-takeable ("fixed") items get their room text from `GenericDescription`, not `NeverPickedUpDescription`/`OnTheGroundDescription` (see `LocationBase.GetItemDescriptions`). So the on-the-table description — and its contained-spool listing — moved into a `GenericDescription` override, mirroring the existing `SmallDesk` pattern. Without this the reader would have silently vanished from the Library description.
- Container / examine / read / put-spool / take-spool-out behavior is unchanged.

## TDD

Added `SpoolReaderTests.TakeReader_IsRefused_NotCarried`:

- **Red** before the fix: `Did not expect response "Taken." to contain "Taken"`.
- **Green** after the fix; the machine is not in inventory.

## Verification

- New test passes.
- Full `Planetfall.Tests` suite: **2998 passed, 0 failed** (existing `Library_Look`, `PutIn_GreenSpool_Look`, `PutIn_TakeOut` etc. all still green — the reader still shows on the table and lists contained spools).

_Note: `Planetfall-Lambda.Tests` has a pre-existing NuGet package-downgrade build error (NU1605 on `Amazon.Lambda.*`), unrelated to this change — no `.csproj`/package references were touched._

🤖 Generated with [Claude Code](https://claude.com/claude-code)