### PR TITLE
Fix #404: examining lock doors no longer doubles the noun ("door door")

### DIFF
--- a/Planetfall.Tests/LabsAndDoorsTests.cs
+++ b/Planetfall.Tests/LabsAndDoorsTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using GameEngine;
+using Planetfall.Item.Lawanda.Lab;
 using Planetfall.Item.Lawanda.LabOffice;
 using Planetfall.Location.Lawanda.Lab;
 using Planetfall.Location.Lawanda.LabOffice;
@@ -686,5 +687,109 @@ public class LabsAndDoorsTests : EngineTestsBase
         var response = await target.GetResponse("press black");
 
         response.Should().Contain("relay clicking");
+    }
+
+    // Issue #404: SimpleDoor.ExaminationDescription unconditionally appended " door" to the primary
+    // noun, doubling it ("radiation-lock door door") for doors whose noun already ended in "door".
+
+    [Test]
+    public async Task ExamineRadiationLockDoor_NoDoubledNoun()
+    {
+        var target = GetTarget();
+        StartHere<RadiationLockEast>();
+
+        var response = await target.GetResponse("examine door");
+
+        response.Should().Contain("The radiation-lock door is closed");
+        response.Should().NotContain("door door");
+    }
+
+    [Test]
+    public async Task ExamineBioLockOuterDoor_NoDoubledNoun()
+    {
+        var target = GetTarget();
+        StartHere<BioLockWest>();
+
+        var response = await target.GetResponse("examine door");
+
+        response.Should().Contain("The bio-lock door is closed");
+        response.Should().NotContain("door door");
+    }
+
+    [Test]
+    public async Task ExamineBioLockInnerDoor_NoDoubledNoun()
+    {
+        var target = GetTarget();
+        StartHere<BioLockEast>();
+
+        var response = await target.GetResponse("examine door");
+
+        response.Should().Contain("The door is closed");
+        response.Should().NotContain("door door");
+    }
+
+    [Test]
+    public void RadiationLockInnerDoor_ExaminationDescription_NoDoubledNoun()
+    {
+        Repository.Reset();
+
+        GetItem<RadiationLockInnerDoor>().ExaminationDescription
+            .Should().Be("The radiation-lock door is closed. ");
+    }
+
+    [Test]
+    public void RadiationLockOuterDoor_ExaminationDescription_NoDoubledNoun()
+    {
+        Repository.Reset();
+
+        GetItem<RadiationLockOuterDoor>().ExaminationDescription
+            .Should().Be("The radiation-lock door is closed. ");
+    }
+
+    [Test]
+    public void BioLockOuterDoor_ExaminationDescription_NoDoubledNoun()
+    {
+        Repository.Reset();
+
+        GetItem<BioLockOuterDoor>().ExaminationDescription
+            .Should().Be("The bio-lock door is closed. ");
+    }
+
+    [Test]
+    public void BioLockInnerDoor_ExaminationDescription_NoDoubledNoun()
+    {
+        Repository.Reset();
+
+        GetItem<BioLockInnerDoor>().ExaminationDescription
+            .Should().Be("The door is closed. ");
+    }
+
+    [Test]
+    public void BioLockOuterDoor_ExaminationDescription_WhenOpen_NoDoubledNoun()
+    {
+        Repository.Reset();
+        var door = GetItem<BioLockOuterDoor>();
+        door.IsOpen = true;
+
+        door.ExaminationDescription.Should().Be("The bio-lock door is open. ");
+    }
+
+    [Test]
+    public void SimpleDoor_ExaminationDescription_BareNoun_StillAppendsDoor()
+    {
+        // Guard the issue's requirement: a door whose primary noun is bare (e.g. "cell")
+        // must still read "The cell door is …", not "The cell is …".
+        var door = new BareNounTestDoor { IsOpen = false };
+
+        door.ExaminationDescription.Should().Be("The cell door is closed. ");
+    }
+
+    /// <summary>
+    /// Test-only door with a bare primary noun, to prove the "append door" branch of
+    /// <see cref="SimpleDoor.ExaminationDescription"/> survives the issue #404 fix.
+    /// </summary>
+    private sealed class BareNounTestDoor : SimpleDoor
+    {
+        public override string[] NounsForMatching => ["cell"];
     }
 }

--- a/Planetfall/Item/Lawanda/Lab/SimpleDoor.cs
+++ b/Planetfall/Item/Lawanda/Lab/SimpleDoor.cs
@@ -4,7 +4,17 @@ internal abstract class SimpleDoor : ItemBase, IOpenAndClose, ICanBeExamined
 {
     public override string[] NounsForPreciseMatching => NounsForMatching.Except(["door"]).ToArray();
 
-    public string ExaminationDescription => $"The {NounsForMatching[0]} door is {(IsOpen ? "open" : "closed")}. ";
+    public string ExaminationDescription => $"The {DisplayName} is {(IsOpen ? "open" : "closed")}. ";
+
+    // Issue #404: some lock doors already carry "door" in their primary noun (e.g. "radiation-lock
+    // door", "bio-lock door", or the bare "door"), so unconditionally appending " door" doubled it
+    // ("radiation-lock door door"). Only append when the noun is a bare descriptor (e.g. "cell"),
+    // so those still read "The cell door is …". The original prints the door's DESC verbatim.
+    private string DisplayName =>
+        NounsForMatching[0].Equals("door", StringComparison.OrdinalIgnoreCase)
+        || NounsForMatching[0].EndsWith(" door", StringComparison.OrdinalIgnoreCase)
+            ? NounsForMatching[0]
+            : $"{NounsForMatching[0]} door";
 
     public bool IsOpen { get; set; }
 


### PR DESCRIPTION
## Summary

Examining the radiation-lock and bio-lock doors printed the word "door" twice — e.g. "The radiation-lock door **door** is closed." Fixes #404.

`SimpleDoor.ExaminationDescription` unconditionally appended `" door"` to `NounsForMatching[0]`. That's fine for a bare noun ("cell" → "The cell door is …") but doubles it for doors whose primary noun already ends in "door":

| Door | `NounsForMatching[0]` | Before | After |
|---|---|---|---|
| `RadiationLockInnerDoor` / `RadiationLockOuterDoor` | `"radiation-lock door"` | "…door **door** is closed." | "The radiation-lock door is closed." |
| `BioLockOuterDoor` | `"bio-lock door"` | "…door **door** is closed." | "The bio-lock door is closed." |
| `BioLockInnerDoor` | `"door"` | "The **door door** is closed." | "The door is closed." |

## Fix

Introduce a `DisplayName` that appends `" door"` **only** when the primary noun is a bare descriptor, and prints door-suffixed nouns verbatim. This matches the original ZIL: `V-LOOK-INSIDE` prints the door's `DESC` verbatim (`planetfall-source/verbs.zil:1016`), and the door `DESC`s are `"radiation-lock door"` / `"bio-lock door"` (`comptwo.zil:1804-1824`) — never doubled.

## TDD

- **Red:** 8 new tests in `LabsAndDoorsTests` failed with the exact diff `"…door door is closed. "` vs `"…door is closed. "`; the bare-noun guard test passed pre-fix (regression guard for the append branch).
- **Green:** all 9 new tests pass after the fix.
- **No regressions:** full `Planetfall.Tests` suite — **3018 passed, 0 failed**.

Coverage spans both the `examine door` command path (Radiation Lock East, Bio Lock West/East) and the `ExaminationDescription` property directly for all four doors, including open/closed states, plus a guard proving a bare-noun door still reads "The cell door is …".

🤖 Generated with [Claude Code](https://claude.com/claude-code)