### PR TITLE
Fix #406: non-takeable items now honor their authored refusal for every take verb

### DIFF
--- a/GameEngine/Item/ItemProcessor/CannotBeTakenProcessor.cs
+++ b/GameEngine/Item/ItemProcessor/CannotBeTakenProcessor.cs
@@ -17,10 +17,15 @@ public class CannotBeTakenProcessor : IVerbProcessor
         // drifted from Verbs.TakeVerbs (it was missing "get"/"grab"), so those phrasings skipped the
         // item's authored CannotBeTakenDescription and fell through to the improvised "verb has no
         // effect" narration (issue #406).
-        if (Verbs.TakeVerbs.Contains(action.Verb.ToLowerInvariant().Trim()))
-            return !string.IsNullOrEmpty(castItem.CannotBeTakenDescription)
-                ? Task.FromResult<InteractionResult?>(new PositiveInteractionResult(castItem.CannotBeTakenDescription))
-                : Task.FromResult<InteractionResult?>(null);
+        var verb = action.Verb.ToLowerInvariant().Trim();
+        if (Verbs.TakeVerbs.Contains(verb) && !string.IsNullOrEmpty(castItem.CannotBeTakenDescription))
+        {
+            // Mirror TakeOrDropInteractionProcessor.TakeIt's refusal branch: fire the same
+            // OnFailingToBeTaken hook, or a failed take's side effects (the destroy-on-failed-take
+            // seam Slag/ToolChests use) would depend on which parse path delivered the verb.
+            ((ItemBase)castItem).OnFailingToBeTaken(context);
+            return Task.FromResult<InteractionResult?>(new PositiveInteractionResult(castItem.CannotBeTakenDescription));
+        }
 
         return Task.FromResult<InteractionResult?>(null);
     }

--- a/GameEngine/Item/ItemProcessor/CannotBeTakenProcessor.cs
+++ b/GameEngine/Item/ItemProcessor/CannotBeTakenProcessor.cs
@@ -1,3 +1,4 @@
+using Model;
 using Model.AIGeneration;
 using Model.Interface;
 using Model.Item;
@@ -12,17 +13,14 @@ public class CannotBeTakenProcessor : IVerbProcessor
         if (item is not IItem castItem)
             throw new Exception("Cast Error");
 
-        switch (action.Verb.ToLowerInvariant().Trim())
-        {
-            case "hold":
-            case "take":
-            case "pick up":
-            case "acquire":
-            case "snatch":
-                return !string.IsNullOrEmpty(castItem.CannotBeTakenDescription)
-                    ? Task.FromResult<InteractionResult?>(new PositiveInteractionResult(castItem.CannotBeTakenDescription))
-                    : Task.FromResult<InteractionResult?>(null);
-        }
+        // Consult the canonical take-verb family, not a local copy: a hardcoded list here had
+        // drifted from Verbs.TakeVerbs (it was missing "get"/"grab"), so those phrasings skipped the
+        // item's authored CannotBeTakenDescription and fell through to the improvised "verb has no
+        // effect" narration (issue #406).
+        if (Verbs.TakeVerbs.Contains(action.Verb.ToLowerInvariant().Trim()))
+            return !string.IsNullOrEmpty(castItem.CannotBeTakenDescription)
+                ? Task.FromResult<InteractionResult?>(new PositiveInteractionResult(castItem.CannotBeTakenDescription))
+                : Task.FromResult<InteractionResult?>(null);
 
         return Task.FromResult<InteractionResult?>(null);
     }

--- a/Model/Verbs.cs
+++ b/Model/Verbs.cs
@@ -8,8 +8,10 @@ public static class Verbs
     /// <summary>
     ///     The "pick it up" family. Kept here as the single source of truth so the take/drop processor,
     ///     the pronoun resolver, and the "them" antecedent tracking all agree on what counts as taking.
+    ///     "carry" is a canonical original synonym (Planetfall syntax.zil:334
+    ///     &lt;SYNONYM TAKE GET HOLD CARRY&gt;).
     /// </summary>
-    public static readonly string[] TakeVerbs = ["take", "get", "grab", "pick up", "hold", "acquire", "snatch"];
+    public static readonly string[] TakeVerbs = ["take", "get", "grab", "pick up", "hold", "acquire", "snatch", "carry"];
 
     /// <summary>
     ///     The "put it down" family. A short list today (the engine only acts on "drop"), but centralized

--- a/Planetfall.Tests/AdminCorridorSouthTests.cs
+++ b/Planetfall.Tests/AdminCorridorSouthTests.cs
@@ -125,6 +125,25 @@ public class AdminCorridorSouthTests : EngineTestsBase
     }
 
     [Test]
+    public async Task SnatchKeyWithMagnet_RetrievesKey()
+    {
+        // Review follow-up to issue #406: the retrieval framing's verb list is now built on
+        // Verbs.TakeVerbs instead of a partial hand-rolled copy that omitted "snatch", "acquire",
+        // "hold", and "carry" - those phrasings fell through to the AI narrator, which improvised
+        // a refusal contradicting the authored success text.
+        var target = GetTarget();
+        StartHere<AdminCorridorSouth>();
+        Take<Magnet>();
+
+        var response = await target.GetResponse("snatch key with magnet");
+
+        response.Should().Contain("a piece of metal leaps from the crevice");
+        response.Should().Contain("steel key");
+        Context.HasItem<Key>().Should().BeTrue();
+        GetLocation<AdminCorridorSouth>().HasTakenTheKey.Should().BeTrue();
+    }
+
+    [Test]
     public async Task TakeKeyWithMagnet_RetrievesKey()
     {
         var target = GetTarget();

--- a/Planetfall.Tests/DeckNineTests.cs
+++ b/Planetfall.Tests/DeckNineTests.cs
@@ -122,6 +122,25 @@ public class DeckNineTests : EngineTestsBase
         }
 
         [Test]
+        public async Task GetCelery_WhileAmbassadorIsPresent_YieldsProtocolRefusal()
+        {
+            // Issue #406: "get" is a TAKE synonym in the original (syntax.zil:334
+            // <SYNONYM TAKE GET HOLD CARRY>), and the engine already treats it as one for takeable
+            // items (Verbs.TakeVerbs). CannotBeTakenProcessor, however, kept its own hardcoded copy
+            // of the take-verb family that had drifted ("get"/"grab" missing), so "get celery"
+            // skipped the ambassador's authored refusal and fell through to the improvised
+            // "verb has no effect" AI narration.
+            var engine = GetTarget();
+            var deckNine = StartHere<DeckNine>();
+            GetItem<Ambassador>().JoinsTheScene(engine.Context, deckNine);
+
+            var response = await engine.GetResponse("get celery");
+
+            response.Should().Contain("The ambassador seems perturbed by your lack of normal protocol.");
+            engine.Context.Items.Should().NotContain(GetItem<Celery>());
+        }
+
+        [Test]
         public async Task EatCelery_WhileAmbassadorIsPresent_KillsThePlayer()
         {
             var engine = GetTarget();

--- a/Planetfall.Tests/DeckNineTests.cs
+++ b/Planetfall.Tests/DeckNineTests.cs
@@ -114,6 +114,7 @@ public class DeckNineTests : EngineTestsBase
             var engine = GetTarget();
             var deckNine = StartHere<DeckNine>();
             GetItem<Ambassador>().JoinsTheScene(engine.Context, deckNine);
+            ForceAmbassadorIdle();
 
             var response = await engine.GetResponse("take celery");
 
@@ -121,20 +122,22 @@ public class DeckNineTests : EngineTestsBase
             engine.Context.Items.Should().NotContain(GetItem<Celery>());
         }
 
-        [Test]
-        public async Task GetCelery_WhileAmbassadorIsPresent_YieldsProtocolRefusal()
+        [TestCase("get celery")]
+        [TestCase("carry celery")]
+        public async Task TakeSynonymCelery_WhileAmbassadorIsPresent_YieldsProtocolRefusal(string input)
         {
-            // Issue #406: "get" is a TAKE synonym in the original (syntax.zil:334
-            // <SYNONYM TAKE GET HOLD CARRY>), and the engine already treats it as one for takeable
-            // items (Verbs.TakeVerbs). CannotBeTakenProcessor, however, kept its own hardcoded copy
-            // of the take-verb family that had drifted ("get"/"grab" missing), so "get celery"
-            // skipped the ambassador's authored refusal and fell through to the improvised
-            // "verb has no effect" AI narration.
+            // Issue #406: "get" and "carry" are TAKE synonyms in the original (syntax.zil:334
+            // <SYNONYM TAKE GET HOLD CARRY>), and the engine treats the whole Verbs.TakeVerbs
+            // family as takes for takeable items. CannotBeTakenProcessor, however, kept its own
+            // hardcoded copy of the family that had drifted ("get"/"grab" missing, "carry" absent
+            // from Verbs.TakeVerbs entirely), so these phrasings skipped the ambassador's authored
+            // refusal and fell through to the improvised "verb has no effect" AI narration.
             var engine = GetTarget();
             var deckNine = StartHere<DeckNine>();
             GetItem<Ambassador>().JoinsTheScene(engine.Context, deckNine);
+            ForceAmbassadorIdle();
 
-            var response = await engine.GetResponse("get celery");
+            var response = await engine.GetResponse(input);
 
             response.Should().Contain("The ambassador seems perturbed by your lack of normal protocol.");
             engine.Context.Items.Should().NotContain(GetItem<Celery>());
@@ -146,11 +149,24 @@ public class DeckNineTests : EngineTestsBase
             var engine = GetTarget();
             var deckNine = StartHere<DeckNine>();
             GetItem<Ambassador>().JoinsTheScene(engine.Context, deckNine);
+            ForceAmbassadorIdle();
 
             var response = await engine.GetResponse("eat celery");
 
             response.Should().Contain("Blow'k-Bibben-Gordoan metabolism is not compatible with our own");
             response.Should().Contain("You die of all sorts of convulsions");
+        }
+
+        /// <summary>
+        /// The ambassador is a registered actor once he joins, and his Act() rolls RollDice(10) on
+        /// the production RandomChooser (idle / leave / quirky speech). Force the idle branch so
+        /// these tests never execute live randomness (CLAUDE.md: always mock IRandomChooser).
+        /// </summary>
+        private void ForceAmbassadorIdle()
+        {
+            var mockChooser = new Mock<IRandomChooser>();
+            mockChooser.Setup(c => c.RollDice(10)).Returns(1);
+            GetItem<Ambassador>().Chooser = mockChooser.Object;
         }
 
         [Test]
@@ -163,6 +179,7 @@ public class DeckNineTests : EngineTestsBase
             var engine = GetTarget();
             var deckNine = StartHere<DeckNine>();
             GetItem<Ambassador>().JoinsTheScene(engine.Context, deckNine);
+            ForceAmbassadorIdle();
 
             var response = await engine.GetResponse("take all");
 

--- a/Planetfall/Location/Kalamontee/Admin/AdminCorridorSouth.cs
+++ b/Planetfall/Location/Kalamontee/Admin/AdminCorridorSouth.cs
@@ -114,10 +114,14 @@ public class AdminCorridorSouth : LocationBase, ITurnBasedActor
         // contradicting the success text. Match only the key's own nouns here, not the crack/floor
         // synonyms: you retrieve the key "with" the magnet, you don't "lift the floor with" it.
         var keyNouns = Repository.GetItem<Key>().NounsForMatching;
+        // The take family comes from Verbs.TakeVerbs rather than a partial hand-rolled copy - the
+        // old inline list omitted "snatch"/"acquire"/"hold" (issue #406's drift class), so those
+        // phrasings fell to the narrator's contradictory "non-magnetic" improvisation.
         match |= action.Match(
-            ["get", "take", "grab", "pick up", "retrieve", "lift", "fish", "pull", "attract",
-                "remove", "snag", "hook", "fetch", "extract", "scoop", "catch", "collect", "recover",
-                "yank", "drag", "reel", "pluck", "nab", "haul", "obtain", "draw"],
+            Verbs.TakeVerbs.Concat(
+                ["retrieve", "lift", "fish", "pull", "attract",
+                    "remove", "snag", "hook", "fetch", "extract", "scoop", "catch", "collect", "recover",
+                    "yank", "drag", "reel", "pluck", "nab", "haul", "obtain", "draw"]).ToArray(),
             keyNouns, magnetNouns, ["with", "using", "to", "toward", "towards"]);
 
         if (match)

--- a/UnitTests/IntentMappings/base-mappings.json
+++ b/UnitTests/IntentMappings/base-mappings.json
@@ -156,6 +156,7 @@
     { "inputs": ["use bar on crevice"], "verb": "use", "nounOne": "bar", "nounTwo": "crevice", "preposition": "on", "originalInput": "use bar on crevice" },
     { "inputs": ["get key with magnet"], "verb": "get", "nounOne": "key", "nounTwo": "magnet", "preposition": "with", "originalInput": "get key with magnet" },
     { "inputs": ["take key with magnet"], "verb": "take", "nounOne": "key", "nounTwo": "magnet", "preposition": "with", "originalInput": "take key with magnet" },
+    { "inputs": ["snatch key with magnet"], "verb": "snatch", "nounOne": "key", "nounTwo": "magnet", "preposition": "with", "originalInput": "snatch key with magnet" },
     { "inputs": ["attract key with magnet"], "verb": "attract", "nounOne": "key", "nounTwo": "magnet", "preposition": "with", "originalInput": "attract key with magnet" },
     { "inputs": ["fish key out with magnet"], "verb": "fish", "nounOne": "key", "nounTwo": "magnet", "preposition": "with", "originalInput": "fish key out with magnet" },
     { "inputs": ["put magnet in crevice"], "verb": "put", "nounOne": "magnet", "nounTwo": "crevice", "preposition": "in", "originalInput": "put magnet in crevice" },

--- a/UnitTests/SingleNounProcessors/TakeProcessorTests.cs
+++ b/UnitTests/SingleNounProcessors/TakeProcessorTests.cs
@@ -1,4 +1,5 @@
 using GameEngine;
+using GameEngine.Item;
 using GameEngine.Item.ItemProcessor;
 using Model.AIGeneration;
 using Model.Intent;
@@ -44,36 +45,37 @@ public class TakeProcessorTests : EngineTestsBase
             Mock.Of<IGenerationClient>()));
     }
 
-    [Test]
-    public async Task CannotBeTaken_PositiveInteraction()
-    {
-        var target = GetTarget();
-
-        var result = await target.GetResponse("take mailbox");
-
-        result.Should().Contain("securely");
-    }
-
-    [Test]
-    public async Task CannotBeTaken_GetVerb_PositiveInteraction()
+    [TestCase("take mailbox")]
+    [TestCase("get mailbox")]
+    public async Task CannotBeTaken_PositiveInteraction(string input)
     {
         // Issue #406: "get" must behave exactly like "take" on a non-takeable item. It used to fall
         // through to the improvised "verb has no effect" narration instead of the authored refusal.
         var target = GetTarget();
 
-        var result = await target.GetResponse("get mailbox");
+        var result = await target.GetResponse(input);
 
         result.Should().Contain("securely");
     }
 
-    [TestCaseSource(nameof(AllTakeVerbs))]
+    [TestCase("take")]
+    [TestCase("get")]
+    [TestCase("grab")]
+    [TestCase("pick up")]
+    [TestCase("hold")]
+    [TestCase("acquire")]
+    [TestCase("snatch")]
+    [TestCase("carry")]
     public async Task CannotBeTaken_CoversTheWholeTakeVerbFamily(string verb)
     {
         // Issue #406: CannotBeTakenProcessor kept its own hardcoded copy of the take verbs, which
         // had drifted from Verbs.TakeVerbs ("get" and "grab" were missing). Every verb the engine
         // treats as a take must surface the item's authored CannotBeTakenDescription, just as
-        // TakeOrDropInteractionProcessor does for takeable items. Sourcing the cases from
-        // Verbs.TakeVerbs keeps this contract from drifting again when a synonym is added.
+        // TakeOrDropInteractionProcessor does for takeable items. The cases are deliberately
+        // literal, not sourced from Verbs.TakeVerbs: a self-referential source would shrink in
+        // lockstep if a synonym were ever removed from the family, hiding the regression. "carry"
+        // is a canonical original synonym (planetfall-source syntax.zil:334
+        // <SYNONYM TAKE GET HOLD CARRY>).
         var target = GetTarget();
 
         IVerbProcessor processor = new CannotBeTakenProcessor();
@@ -86,7 +88,42 @@ public class TakeProcessorTests : EngineTestsBase
         result!.InteractionMessage.Should().Contain("securely anchored");
     }
 
-    private static IEnumerable<string> AllTakeVerbs => Verbs.TakeVerbs;
+    [Test]
+    public async Task CannotBeTaken_FiresTheOnFailingToBeTakenHook()
+    {
+        // The TakeIntent refusal branch (TakeOrDropInteractionProcessor.TakeIt) invokes
+        // OnFailingToBeTaken before returning CannotBeTakenDescription. This SimpleIntent branch
+        // must do the same, or a failed take's side effects (the Slag/ToolChests
+        // destroy-on-failed-take seam) would depend on which parse path delivered the verb.
+        var target = GetTarget();
+        var relic = new AnchoredRelic();
+
+        IVerbProcessor processor = new CannotBeTakenProcessor();
+        var result = await processor.Process(
+            new SimpleIntent { Verb = "take", Noun = "relic", OriginalInput = "take relic" },
+            target.Context, relic, Client.Object);
+
+        result!.InteractionMessage.Should().Contain("fused to its pedestal");
+        relic.FailedTakeCount.Should().Be(1, "the refusal must fire the same hook the TakeIntent path fires");
+    }
+
+    private class AnchoredRelic : ItemBase
+    {
+        public int FailedTakeCount { get; private set; }
+
+        public override string[] NounsForMatching => ["relic"];
+
+        public override string? CannotBeTakenDescription
+        {
+            get => "The relic is fused to its pedestal. ";
+            set { }
+        }
+
+        public override void OnFailingToBeTaken(IContext context)
+        {
+            FailedTakeCount++;
+        }
+    }
 
     [Test]
     public async Task TakeSecondItemFromContainer()

--- a/UnitTests/SingleNounProcessors/TakeProcessorTests.cs
+++ b/UnitTests/SingleNounProcessors/TakeProcessorTests.cs
@@ -2,6 +2,7 @@ using GameEngine;
 using GameEngine.Item.ItemProcessor;
 using Model.AIGeneration;
 using Model.Intent;
+using Model.Interaction;
 using Model.Interface;
 
 namespace UnitTests.SingleNounProcessors;
@@ -52,6 +53,40 @@ public class TakeProcessorTests : EngineTestsBase
 
         result.Should().Contain("securely");
     }
+
+    [Test]
+    public async Task CannotBeTaken_GetVerb_PositiveInteraction()
+    {
+        // Issue #406: "get" must behave exactly like "take" on a non-takeable item. It used to fall
+        // through to the improvised "verb has no effect" narration instead of the authored refusal.
+        var target = GetTarget();
+
+        var result = await target.GetResponse("get mailbox");
+
+        result.Should().Contain("securely");
+    }
+
+    [TestCaseSource(nameof(AllTakeVerbs))]
+    public async Task CannotBeTaken_CoversTheWholeTakeVerbFamily(string verb)
+    {
+        // Issue #406: CannotBeTakenProcessor kept its own hardcoded copy of the take verbs, which
+        // had drifted from Verbs.TakeVerbs ("get" and "grab" were missing). Every verb the engine
+        // treats as a take must surface the item's authored CannotBeTakenDescription, just as
+        // TakeOrDropInteractionProcessor does for takeable items. Sourcing the cases from
+        // Verbs.TakeVerbs keeps this contract from drifting again when a synonym is added.
+        var target = GetTarget();
+
+        IVerbProcessor processor = new CannotBeTakenProcessor();
+        var result = await processor.Process(
+            new SimpleIntent { Verb = verb, Noun = "mailbox", OriginalInput = $"{verb} mailbox" },
+            target.Context, Repository.GetItem<Mailbox>(), Client.Object);
+
+        result.Should().BeOfType<PositiveInteractionResult>(
+            $"'{verb}' is in Verbs.TakeVerbs, so it must trigger the authored refusal");
+        result!.InteractionMessage.Should().Contain("securely anchored");
+    }
+
+    private static IEnumerable<string> AllTakeVerbs => Verbs.TakeVerbs;
 
     [Test]
     public async Task TakeSecondItemFromContainer()

--- a/UnitTests/TestParser.cs
+++ b/UnitTests/TestParser.cs
@@ -27,7 +27,7 @@ public class TestParser : IntentParser
             "deactivate", "type", "key", "punch", "push", "pull", "burn", "set", "search", "empty", "wear",
             "drink", "use", "count", "touch", "read", "turn", "wave", "move", "ring", "activate", "search",
             "smell", "turn on", "turn off", "throw", "light", "rub", "kiss", "wind", "kick", "deflate",
-            "lower", "raise", "get", "inflate", "leave", "unlock", "lock", "climb", "extend", "lift", "shake",
+            "lower", "raise", "get", "carry", "inflate", "leave", "unlock", "lock", "climb", "extend", "lift", "shake",
             "oil", "lubricate", "cross", "through", "go", "break", "smash", "squeeze"
         ];
 

--- a/ZorkOne.Tests/Places/BatRoomTests.cs
+++ b/ZorkOne.Tests/Places/BatRoomTests.cs
@@ -48,6 +48,30 @@ public class BatRoomTests : EngineTestsBase
         target.Context.CurrentLocation.Should().Be(expectedRoom);
     }
 
+    [TestCase("take bat")]
+    [TestCase("carry bat")]
+    public async Task ProvokeBatWithTakeSynonym_WithoutGarlic_CarriesPlayerOff(string input)
+    {
+        // Review follow-up to issue #406: Bat.ProvokingVerbs now concatenates Verbs.TakeVerbs
+        // instead of a hand-inlined copy, so every take synonym provokes the bat identically.
+        // "carry" is the original's fourth TAKE synonym (<SYNONYM TAKE GET HOLD CARRY>) and was
+        // covered by neither the old copy nor Verbs.TakeVerbs.
+        var target = GetTarget();
+        target.Context.Take(Repository.GetItem<Lantern>());
+        Repository.GetItem<Lantern>().IsOn = true;
+        target.Context.CurrentLocation = Repository.GetLocation<BatRoom>();
+
+        var mockChooser = new Mock<IRandomChooser>();
+        mockChooser.Setup(r => r.Choose(It.IsAny<List<ILocation>>()))
+            .Returns(Repository.GetLocation<MineEntrance>());
+        Repository.GetLocation<BatRoom>().Chooser = mockChooser.Object;
+
+        var response = await target.GetResponse(input);
+
+        response.Should().Contain("Fweep!");
+        target.Context.CurrentLocation.Should().Be(Repository.GetLocation<MineEntrance>());
+    }
+
     [Test]
     public async Task EnterFromTheSouthWithoutGarlic_CarriesPlayerOff()
     {

--- a/ZorkOne/Item/Bat.cs
+++ b/ZorkOne/Item/Bat.cs
@@ -17,10 +17,12 @@ public class Bat : ItemBase
 
     /// <summary>
     /// Provoking the bat (attacking or trying to take it) without garlic carries you off, same as
-    /// just walking into the room without it - see BatRoom.CarryPlayerOff.
+    /// just walking into the room without it - see BatRoom.CarryPlayerOff. Built on Verbs.TakeVerbs
+    /// rather than a hand-inlined copy so a take synonym added to the family (issue #406's drift
+    /// class) provokes the bat instead of silently printing the ceiling refusal.
     /// </summary>
     private static readonly string[] ProvokingVerbs =
-        Verbs.KillVerbs.Concat(["hold", "take", "pick up", "grab", "get", "acquire", "snatch"]).ToArray();
+        Verbs.KillVerbs.Concat(Verbs.TakeVerbs).ToArray();
 
     public override string NeverPickedUpDescription(ILocation currentLocation)
     {


### PR DESCRIPTION
Fixes #406.

## The bug

`get celery` (and `grab celery`) on Deck Nine skipped the ambassador's authored refusal — "The ambassador seems perturbed by your lack of normal protocol." — and fell through to the improvised "verb has no effect" AI narration (the issue's observed "This action or command has no effect on the game." in offline/fallback mode). The same authored-response loss applied to **every** non-takeable item with a `CannotBeTakenDescription` in both games (mailbox, chain, mural, plaque, goo, machine, …).

## Root cause (a refinement of the issue's analysis)

The issue attributes the gap to `ItemProcessorFactory` wiring `CannotBeTakenProcessor` only for `ICanBeTakenAndDropped` items. On current `main` that specific gating no longer exists — the factory's `else` branch adds `CannotBeTakenProcessor` for every non-takeable item, and the existing PR #384 tests prove plain `take celery` works on both the `SimpleIntent` and `TakeIntent` paths.

The *live* defect producing the reported symptom is one layer deeper: `CannotBeTakenProcessor` kept its own hardcoded take-verb list (`hold`/`take`/`pick up`/`acquire`/`snatch`), which had **drifted from the canonical `Verbs.TakeVerbs` family — `get` and `grab` were missing**. Takeable items were unaffected because `TakeOrDropInteractionProcessor` consults `Verbs.TakeVerbs` directly, so `get lamp` worked while `get mailbox` lost its authored response and landed in `SimpleInteractionEngine`'s `NoVerbMatch` → generated-narration fallback.

## Original behavior (ZIL, reference only)

- `planetfall-source/syntax.zil:334` — `<SYNONYM TAKE GET HOLD CARRY>`: GET **is** TAKE in the original parser.
- `planetfall-source/globals.zil:791-798` — `CELERY-F`'s `<VERB? TAKE>` branch prints the perturbed-protocol line, so the original answers "get celery" with the authored refusal.

## The fix

`CannotBeTakenProcessor` now consults `Verbs.TakeVerbs` (a strict superset of the old hardcoded list) instead of a local copy that can drift again — the same source of truth the take/drop processor and `SimpleInteractionEngine` already use.

## Review follow-ups (second commit)

An adversarial multi-angle review of the first commit surfaced follow-ups, each applied red-first:

- **`Verbs.TakeVerbs` gains `carry`** — the fourth canonical synonym on the very ZIL line cited above. Without it, `carry celery` still skipped the refusal and `carry lamp` performed no take at all on the `SimpleIntent` path. One line propagates to every family consumer.
- **Two hand-rolled take-verb copies consolidated onto the family** — `Bat.ProvokingVerbs` (which would have split on the `carry` addition: ceiling refusal instead of the carry-off) and the magnet-retrieval verb list in `AdminCorridorSouth` (whose partial copy already dropped `snatch`/`acquire`/`hold` phrasings into the narrator's contradictory "non-magnetic" improvisation).
- **`CannotBeTakenProcessor` now fires `OnFailingToBeTaken`**, mirroring `TakeOrDropInteractionProcessor.TakeIt`'s refusal branch, so a failed take's side effects can never depend on which parse path delivered the verb. Guard flattened to the sibling idiom.
- **Test hardening**: the family test uses literal verb cases (a `TestCaseSource` fed by `Verbs.TakeVerbs` shrank in lockstep with the array, so removing a synonym failed nothing); the redundant get-mailbox clone is folded into the parameterized take/get engine test; all four ambassador-present celery tests mock `IRandomChooser` to force the ambassador's `Act` idle branch per the repo's determinism rule.

Surfaced by the same review but **deliberately left for separate issues** (pre-existing, unrelated mechanisms): SafetyWeb's noun-blind `get` interception in the Escape Pod, `EatAndDrinkInteractionProcessor`'s drink-verb drift (`gulp`/`guzzle`/`slurp` missing vs `Verbs.DrinkVerbs`), drop-family handling for non-takeable items, and `ItemProcessorFactory`'s duplicate `TakeOrDropInteractionProcessor` registration.

## TDD

Red first, then green — commit 1:

- `Planetfall.Tests` → `CeleryTests` engine test for the issue's scenario (failed with the empty narrator fallback before the fix).
- `UnitTests` → `TakeProcessorTests.CannotBeTaken_CoversTheWholeTakeVerbFamily` (the `get` and `grab` cases failed with the processor returning `null`; the other five verbs passed, pinning no regression).

Commit 2 reds: the `carry` family case (`null`), `carry celery` (narrator fallback), `carry bat` (ceiling refusal instead of the carry-off), `snatch key with magnet` (narrator fallback), and the `OnFailingToBeTaken` hook test (count 0) — all green after.

## Verification

- Full suites pass at the rebased head: UnitTests (1026), ZorkOne.Tests (1776), Planetfall.Tests (3022), EscapeRoom.Tests (9). `dotnet build Zork.sln` clean.
- Lambda.Tests / Planetfall-Lambda.Tests currently fail NuGet **restore** on `main` (pre-existing NU1605 `Amazon.Lambda.*` package downgrade errors, unrelated to these .cs-only changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DFSnpjkNBJKmVKRmYhMqsz