### PR TITLE
Fix #407: Blather now responds to attack, kick, salute, and take

### DIFF
--- a/Planetfall.Tests/BlatherTests.cs
+++ b/Planetfall.Tests/BlatherTests.cs
@@ -85,40 +85,18 @@ public class BlatherTests : EngineTestsBase
     // globals.zil:742-772). Attacking or kicking him is fatal; saluting and trying to
     // take him have authored flavor responses.
 
-    [Test]
-    public async Task AttackBlather_KillsThePlayer()
+    // All of ATTACK's synonyms (Verbs.KillVerbs, from ZIL syntax.zil:76) plus the separate KICK
+    // verb (syntax.zil:175) are fatal, so parameterize rather than duplicate the arrange/assert.
+    [TestCase("attack blather")]
+    [TestCase("kick blather")]
+    [TestCase("kill blather")]
+    public async Task AttackingBlather_KillsThePlayer(string command)
     {
         var target = GetTarget();
         var deckNine = StartHere<DeckNine>();
         GetItem<Blather>().JoinsTheScene(target.Context, deckNine);
 
-        var response = await target.GetResponse("attack blather");
-
-        response.Should().Contain("Blather removes several of your appendages and internal organs");
-        response.Should().Contain("*** You have died ***");
-    }
-
-    [Test]
-    public async Task KickBlather_KillsThePlayer()
-    {
-        var target = GetTarget();
-        var deckNine = StartHere<DeckNine>();
-        GetItem<Blather>().JoinsTheScene(target.Context, deckNine);
-
-        var response = await target.GetResponse("kick blather");
-
-        response.Should().Contain("Blather removes several of your appendages and internal organs");
-        response.Should().Contain("*** You have died ***");
-    }
-
-    [Test]
-    public async Task KillBlather_KillsThePlayer()
-    {
-        var target = GetTarget();
-        var deckNine = StartHere<DeckNine>();
-        GetItem<Blather>().JoinsTheScene(target.Context, deckNine);
-
-        var response = await target.GetResponse("kill blather");
+        var response = await target.GetResponse(command);
 
         response.Should().Contain("Blather removes several of your appendages and internal organs");
         response.Should().Contain("*** You have died ***");

--- a/Planetfall.Tests/BlatherTests.cs
+++ b/Planetfall.Tests/BlatherTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using GameEngine;
+using Planetfall.Item.Feinstein;
 using Planetfall.Location.Feinstein;
 
 namespace Planetfall.Tests;
@@ -78,5 +79,73 @@ public class BlatherTests : EngineTestsBase
         // Assert
         response.Should().Contain("brig");
         target.Context.CurrentLocation.Should().BeOfType<Brig>();
+    }
+
+    // Issue #407: Blather's single-noun interactions from the original (BLATHER-F,
+    // globals.zil:742-772). Attacking or kicking him is fatal; saluting and trying to
+    // take him have authored flavor responses.
+
+    [Test]
+    public async Task AttackBlather_KillsThePlayer()
+    {
+        var target = GetTarget();
+        var deckNine = StartHere<DeckNine>();
+        GetItem<Blather>().JoinsTheScene(target.Context, deckNine);
+
+        var response = await target.GetResponse("attack blather");
+
+        response.Should().Contain("Blather removes several of your appendages and internal organs");
+        response.Should().Contain("*** You have died ***");
+    }
+
+    [Test]
+    public async Task KickBlather_KillsThePlayer()
+    {
+        var target = GetTarget();
+        var deckNine = StartHere<DeckNine>();
+        GetItem<Blather>().JoinsTheScene(target.Context, deckNine);
+
+        var response = await target.GetResponse("kick blather");
+
+        response.Should().Contain("Blather removes several of your appendages and internal organs");
+        response.Should().Contain("*** You have died ***");
+    }
+
+    [Test]
+    public async Task KillBlather_KillsThePlayer()
+    {
+        var target = GetTarget();
+        var deckNine = StartHere<DeckNine>();
+        GetItem<Blather>().JoinsTheScene(target.Context, deckNine);
+
+        var response = await target.GetResponse("kill blather");
+
+        response.Should().Contain("Blather removes several of your appendages and internal organs");
+        response.Should().Contain("*** You have died ***");
+    }
+
+    [Test]
+    public async Task SaluteBlather_EarnsOnlyFiveDemerits()
+    {
+        var target = GetTarget();
+        var deckNine = StartHere<DeckNine>();
+        GetItem<Blather>().JoinsTheScene(target.Context, deckNine);
+
+        var response = await target.GetResponse("salute blather");
+
+        response.Should().Contain("Blather's sneer softens a bit");
+        response.Should().Contain("First right thing you've done today. Only five demerits.");
+    }
+
+    [Test]
+    public async Task TakeBlather_HeBrushesYouAway()
+    {
+        var target = GetTarget();
+        var deckNine = StartHere<DeckNine>();
+        GetItem<Blather>().JoinsTheScene(target.Context, deckNine);
+
+        var response = await target.GetResponse("take blather");
+
+        response.Should().Contain("Blather brushes you away, muttering about suspended shore leave.");
     }
 }

--- a/Planetfall/Item/Feinstein/Blather.cs
+++ b/Planetfall/Item/Feinstein/Blather.cs
@@ -22,6 +22,11 @@ internal class Blather : QuirkyCompanion, IAmANamedPerson, ITurnBasedActor, ICan
         "Ensign Blather is a tall, beefy officer with a tremendous, misshapen nose. His uniform is perfect in " +
         "every respect, and the crease in his trousers could probably slice diamonds in half. ";
 
+    // ATTACK/KICK are fatal (BLATHER-F, globals.zil:751-753). Built once, not per call (mirroring
+    // ZorkOne/Location/MirrorRoom.cs): the location forwards every simple command to every present
+    // item, so composing this inline would re-allocate on each dispatch before the noun check runs.
+    private static readonly string[] FatalVerbs = [..Verbs.KillVerbs, "kick"];
+
     // TAKE (BLATHER-F, globals.zil:770-772). Expressed as CannotBeTakenDescription so both the
     // simple-intent path (CannotBeTakenProcessor) and the AI-tagged TakeIntent path (TakeIt) respond.
     public override string? CannotBeTakenDescription =>
@@ -30,9 +35,8 @@ internal class Blather : QuirkyCompanion, IAmANamedPerson, ITurnBasedActor, ICan
     public override async Task<InteractionResult?> RespondToSimpleInteraction(SimpleIntent action, IContext context,
         IGenerationClient client, IItemProcessorFactory itemProcessorFactory)
     {
-        // ATTACK/KICK are fatal (BLATHER-F, globals.zil:751-753): Blather is not a combatant you
-        // can fight - any attempt is an instant, authored death.
-        if (action.Match([..Verbs.KillVerbs, "kick"], NounsForMatching))
+        // Blather is not a combatant you can fight - any attempt is an instant, authored death.
+        if (action.Match(FatalVerbs, NounsForMatching))
             return new DeathProcessor().Process(
                 "Blather removes several of your appendages and internal organs.", context);
 

--- a/Planetfall/Item/Feinstein/Blather.cs
+++ b/Planetfall/Item/Feinstein/Blather.cs
@@ -1,5 +1,6 @@
 ﻿using ChatLambda;
 using Model.AIGeneration;
+using Planetfall.Command;
 
 namespace Planetfall.Item.Feinstein;
 
@@ -20,6 +21,28 @@ internal class Blather : QuirkyCompanion, IAmANamedPerson, ITurnBasedActor, ICan
     public string ExaminationDescription =>
         "Ensign Blather is a tall, beefy officer with a tremendous, misshapen nose. His uniform is perfect in " +
         "every respect, and the crease in his trousers could probably slice diamonds in half. ";
+
+    // TAKE (BLATHER-F, globals.zil:770-772). Expressed as CannotBeTakenDescription so both the
+    // simple-intent path (CannotBeTakenProcessor) and the AI-tagged TakeIntent path (TakeIt) respond.
+    public override string? CannotBeTakenDescription =>
+        "Blather brushes you away, muttering about suspended shore leave. ";
+
+    public override async Task<InteractionResult?> RespondToSimpleInteraction(SimpleIntent action, IContext context,
+        IGenerationClient client, IItemProcessorFactory itemProcessorFactory)
+    {
+        // ATTACK/KICK are fatal (BLATHER-F, globals.zil:751-753): Blather is not a combatant you
+        // can fight - any attempt is an instant, authored death.
+        if (action.Match([..Verbs.KillVerbs, "kick"], NounsForMatching))
+            return new DeathProcessor().Process(
+                "Blather removes several of your appendages and internal organs.", context);
+
+        // SALUTE (BLATHER-F, globals.zil:754-757).
+        if (action.Match(["salute"], NounsForMatching))
+            return new PositiveInteractionResult(
+                "Blather's sneer softens a bit. \"First right thing you've done today. Only five demerits.\" ");
+
+        return await base.RespondToSimpleInteraction(action, context, client, itemProcessorFactory);
+    }
 
     public override async Task<InteractionResult?> RespondToMultiNounInteraction(MultiNounIntent action, IContext context)
     {

--- a/UnitTests/TestParser.cs
+++ b/UnitTests/TestParser.cs
@@ -28,7 +28,7 @@ public class TestParser : IntentParser
             "drink", "use", "count", "touch", "read", "turn", "wave", "move", "ring", "activate", "search",
             "smell", "turn on", "turn off", "throw", "light", "rub", "kiss", "wind", "kick", "deflate",
             "lower", "raise", "get", "inflate", "leave", "unlock", "lock", "climb", "extend", "lift", "shake",
-            "oil", "lubricate", "cross", "through", "go", "break", "smash", "squeeze"
+            "oil", "lubricate", "cross", "through", "go", "break", "smash", "squeeze", "attack", "kill", "salute"
         ];
 
         _allNouns = Repository.GetNouns(gameName);


### PR DESCRIPTION
Fixes #407.

## Problem

`Blather.cs` handled only `examine` and thrown objects (`RespondToMultiNounInteraction`), so the remaining single-noun interactions from the original `BLATHER-F` routine fell through to the generic AI "no effect" narration:

- **Attack/kick (critical)** — should kill the player, did nothing.
- **Salute (flavor)** — should soften his sneer, did nothing.
- **Take/grab (flavor)** — should brush you away, did nothing.

## Original behavior (ZIL evidence)

`BLATHER-F` (planetfall-source/globals.zil:742-772):

- `VERB? ATTACK KICK` → `JIGS-UP "Blather removes several of your appendages and internal organs."` (globals.zil:751-753)
- `VERB? SALUTE` → "Blather's sneer softens a bit. \"First right thing you've done today. Only five demerits.\"" (globals.zil:754-757)
- `VERB? TAKE` → "Blather brushes you away, muttering about suspended shore leave." (globals.zil:770-772)

ATTACK's synonyms are FIGHT HURT INJURE HIT KILL MURDER SLAY DISPATCH (syntax.zil:76); KICK is its own verb (syntax.zil:175), as is SALUTE (syntax.zil:348).

## Fix

`Planetfall/Item/Feinstein/Blather.cs`:

- New `RespondToSimpleInteraction` override (the `Flask`/`Slime` pattern):
  - `Verbs.KillVerbs` + `"kick"` → instant authored death via `DeathProcessor`, mirroring the ZIL attack-synonym family.
  - `"salute"` → the authored demerits line.
  - Everything else falls through to `base` — no unconditional catch-all (per the "examine catch-all" anti-pattern guidance).
- New `CannotBeTakenDescription` override for take/grab (the `Celery` pattern), so both the `CannotBeTakenProcessor` simple-intent path and the AI-tagged `TakeIntent` path (`TakeOrDropInteractionProcessor.TakeIt`) produce the authored refusal.

`UnitTests/TestParser.cs`: added `"attack"`, `"kill"`, `"salute"` to the test parser's verb list so tests exercise the same `SimpleIntent` path the production AI parser produces ("kick" and "take" were already present).

## TDD

Five new tests in `Planetfall.Tests/BlatherTests.cs`, written first and confirmed failing with the empty generated no-effect response (`Expected response "\n" to contain ...`):

- `AttackBlather_KillsThePlayer`, `KickBlather_KillsThePlayer`, `KillBlather_KillsThePlayer` — assert the death text and the `*** You have died ***` banner.
- `SaluteBlather_EarnsOnlyFiveDemerits`
- `TakeBlather_HeBrushesYouAway`

All are deterministic (mocked generation client, `JoinsTheScene` seeding — same approach as the celery tests).

## Verification

Solution-level `dotnet build` + `dotnet test` (what CI runs): **5,824 passed, 0 failed** — Planetfall.Tests 3,024 (includes the 5 new), ZorkOne.Tests 1,774, UnitTests 1,016, EscapeRoom.Tests 9.

Note: `Lambda/test/Lambda.Tests` and `Planetfall-Lambda/test/Planetfall-Lambda.Tests` fail `dotnet restore` with a pre-existing NU1605 package downgrade (`Amazon.Lambda.Core` 2.8.0→2.2.0 vs `Amazon.Lambda.AspNetCoreServer 9.2.1`) unrelated to this change; they are not part of `Zork.sln` and CI does not run them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017A2rVF5C6Gfwo6RbW6QShi