### PR TITLE
Fix #412: Comm Room playback button matches its label and descriptors

### DIFF
--- a/Planetfall.Tests/CommRoomAndMachineRoomTests.cs
+++ b/Planetfall.Tests/CommRoomAndMachineRoomTests.cs
@@ -274,4 +274,28 @@ public class CommRoomAndMachineRoomTests : EngineTestsBase
         target.Context.Score.Should().Be(6);
         Console.WriteLine(GetLocation<SystemsMonitors>().GetDescriptionForGeneration(target.Context));
     }
+
+    // Issue #412: the Comm Room shows the player a "glowing button marked 'Mesij Plaabak'", and pressing
+    // it plays back the Feinstein's cut-off transmission (a real story beat). Every phrasing below is
+    // something the room's own text invites the player to type, so each must reach the playback handler.
+    // Before the fix only the bare noun "button" matched; the label and descriptors fell through to the
+    // AI narrator and the transmission was never delivered (worse, the narrator sometimes falsely
+    // claimed success). "press button" is the regression guard for the phrasing that already worked.
+    [TestCase("press button")]
+    [TestCase("press mesij plaabak")]
+    [TestCase("push mesij plaabak")]
+    [TestCase("press playback button")]
+    [TestCase("press message playback button")]
+    [TestCase("press glowing button")]
+    [Test]
+    public async Task PressPlaybackButton_PlaysFeinsteinTransmission(string command)
+    {
+        var target = GetTarget();
+        StartHere<CommRoom>();
+
+        var response = await target.GetResponse(command);
+
+        response.Should().Contain("communications officer");
+        response.Should().Contain("burst of static");
+    }
 }

--- a/Planetfall/Location/Kalamontee/Tower/CommRoom.cs
+++ b/Planetfall/Location/Kalamontee/Tower/CommRoom.cs
@@ -106,7 +106,19 @@ internal class CommRoom : LocationWithNoStartingItems, IFloydDoesNotTalkHere
     public override async Task<InteractionResult> RespondToSimpleInteraction(SimpleIntent action, IContext context,
         IGenerationClient client, IItemProcessorFactory itemProcessorFactory)
     {
-        if (action.Match(Verbs.PushVerbs, ["button"]))
+        // Issue #412: the room describes a "glowing button marked \"Mesij Plaabak\"", so accept the printed
+        // label and the descriptors the player is shown — not just the bare noun "button". Matching only
+        // "button" let every natural/labelled phrasing ("mesij plaabak", "playback button", "message
+        // playback button", "glowing button") fall through to the narrator, which never played the
+        // transmission and sometimes falsely claimed it had. Mirrors the rich synonym sets used by the
+        // coolant-pour handler above. (Bare "message"/"console" stay with the read/examine handler below.)
+        string[] buttonNouns =
+        [
+            "button", "glowing button", "playback button", "message playback button",
+            "playback", "message playback", "mesij plaabak", "mesij", "plaabak"
+        ];
+
+        if (action.Match(Verbs.PushVerbs, buttonNouns))
             return new PositiveInteractionResult(
                 "A voice fills the room ... the voice of the Feinstein's communications officer! \"Stellar Patrol " +
                 "Ship Feinstein to planetside ... Please respond on frequency 48.5 ... SPS Feinstein to planetside ... " +

--- a/UnitTests/IntentMappings/base-mappings.json
+++ b/UnitTests/IntentMappings/base-mappings.json
@@ -35,6 +35,12 @@
     { "inputs": ["press the blue button"], "verb": "press", "noun": "blue button", "adverb": "the" },
     { "inputs": ["press the red button"], "verb": "press", "noun": "red button", "adverb": "the" },
 
+    { "inputs": ["press mesij plaabak"], "verb": "press", "noun": "mesij plaabak" },
+    { "inputs": ["push mesij plaabak"], "verb": "push", "noun": "mesij plaabak" },
+    { "inputs": ["press playback button"], "verb": "press", "noun": "playback button" },
+    { "inputs": ["press message playback button"], "verb": "press", "noun": "message playback button" },
+    { "inputs": ["press glowing button"], "verb": "press", "noun": "glowing button" },
+
     { "inputs": ["open red door"], "verb": "open", "noun": "red door" },
     { "inputs": ["close red door"], "verb": "close", "noun": "red door" },
     { "inputs": ["examine red door"], "verb": "examine", "noun": "red door" },


### PR DESCRIPTION
## Summary

Fixes #412. In the Tower's **Comm Room** (Planetfall), the Receive Station has a prominent, glowing, *labelled* button — the room's own text reads: *"Next to the light is a glowing button marked "Mesij Plaabak.""* Pressing it plays back the Feinstein's cut-off transmission (a genuine story beat).

But the handler in `CommRoom.RespondToSimpleInteraction` only matched the bare noun `"button"`. Every natural phrasing that used the button's own printed label or descriptors missed the handler, fell through to the AI narrator, and the transmission was never delivered — worse, with the narrator on the player was sometimes *falsely told* the message played.

| Command | Before | After |
|---|---|---|
| `press button` | ✅ plays transmission | ✅ plays transmission |
| `press mesij plaabak` (the printed label) | ❌ narrator, false success | ✅ plays transmission |
| `press playback button` | ❌ narrator | ✅ plays transmission |
| `press message playback button` | ❌ "no effect" | ✅ plays transmission |
| `press glowing button` | ❌ narrator | ✅ plays transmission |

## Root cause

`Planetfall/Location/Kalamontee/Tower/CommRoom.cs` matched only `["button"]`, while the room describes the same object as a *glowing button* marked *"Mesij Plaabak"*. None of the label/descriptor phrasings were accepted nouns, so they never reached the playback handler.

## Fix

Broaden the push-button match set to include the label and the descriptors the room presents to the player, mirroring the rich synonym sets already used by the coolant-pour handler two methods up in the same file. Bare `"button"` still works. Bare `"message"`/`"console"` stay with the read/examine handler (different verb set — no collision).

This is an **internal-consistency** fix, provable from the engine's own presented text. The gitignored Planetfall ZIL sub-checkout was not present in this environment, so this does not rest on an original-vs-port divergence claim.

## Testing (TDD)

Added a parameterized `GetResponse` test in `Planetfall.Tests/CommRoomAndMachineRoomTests.cs` that drives the real pipeline (no RNG/clock/network/AI) and asserts the Feinstein transmission actually plays (stable substrings `communications officer` and `burst of static`) for each labelled/descriptive phrasing, plus `press button` as a regression guard.

- **Red before:** the 5 labelled/descriptive phrasings returned the empty narrator response (`Expected response "\n" to contain "communications officer"`); `press button` passed.
- **Green after:** all 6 pass.
- Full `Planetfall.Tests` (3030 passed) and `UnitTests` (1016 passed) suites pass, no regressions.

To keep the test deterministic, added matching entries to the shared `UnitTests/IntentMappings/base-mappings.json` so the `TestParser` produces the same full noun phrase the production AI parser emits for these inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PJqHqjz3CCoi5WNQ8ZQgke)_