### PR TITLE
Fix #411: bump Amazon.Lambda.Core/APIGatewayEvents in Lambda test projects (NU1605)

### DIFF
--- a/Lambda/test/Lambda.Tests/Lambda.Tests.csproj
+++ b/Lambda/test/Lambda.Tests/Lambda.Tests.csproj
@@ -17,9 +17,9 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="2.8.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
-    <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.7.0" />
+    <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.7.3" />
     <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.4.2" />

--- a/Planetfall-Lambda/test/Planetfall-Lambda.Tests/Planetfall-Lambda.Tests.csproj
+++ b/Planetfall-Lambda/test/Planetfall-Lambda.Tests/Planetfall-Lambda.Tests.csproj
@@ -17,9 +17,9 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="2.8.0" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
-    <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.7.0" />
+    <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.7.3" />
     <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.4.2" />


### PR DESCRIPTION
## Summary

Fixes #411. Both Lambda **test** projects failed `dotnet restore` with `NU1605` (package downgrade treated as error) and so could not be restored, built, or run:

- `Lambda/test/Lambda.Tests/Lambda.Tests.csproj`
- `Planetfall-Lambda/test/Planetfall-Lambda.Tests/Planetfall-Lambda.Tests.csproj`

Each pinned `Amazon.Lambda.Core` **2.2.0** and `Amazon.Lambda.APIGatewayEvents` **2.7.0** directly, below what the referenced production project pulls transitively via `Amazon.Lambda.AspNetCoreServer` **9.2.1** (`Core >= 2.8.0`, `APIGatewayEvents >= 2.7.3`). NuGet rejected the resulting downgrade.

## Change

Bumped the two direct references in **both** test `.csproj` files to exactly the transitively-required versions:

| Package | Before | After |
| --- | --- | --- |
| `Amazon.Lambda.Core` | 2.2.0 | **2.8.0** |
| `Amazon.Lambda.APIGatewayEvents` | 2.7.0 | **2.7.3** |

I kept the direct references (rather than dropping them) because the test code uses these packages directly — `ValuesControllerTests` references `APIGatewayProxyRequest` (from `APIGatewayEvents`) and `TestLambdaContext` (from `TestUtilities`), so pinning them explicitly is appropriate. Matching the exact transitive floor avoids an unnecessary over-bump.

## Verification

Reproduced the failure first, then confirmed the fix (using a locally-installed .NET 10 SDK, `10.0.302`):

- **Before:** `dotnet restore` on both projects failed with the two `NU1605` errors from the issue.
- **After:** both projects `dotnet restore` and build cleanly — `NU1605` gone.
- `Lambda.Tests` real tests (`GameRequestTests`, 4 tests) pass.

## Scope note — pre-existing dead scaffolding (not addressed here)

Once the suites could finally execute, a pre-existing failure surfaced in each, **unrelated to package versions** and outside this issue's scope. Both come from the AWS Lambda project template's stock `ValuesController` scaffolding, which was never removed when the real controllers (`ZorkOneController` / `PlanetfallController`) were added:

- `Lambda.Tests.ValuesControllerTests.TestGet` → **404** (the `/api/values` sample route no longer exists).
- `Planetfall-Lambda.Tests.ValuesControllerTests.TestGet` → throws `Missing environment variable OPEN_AI_KEY` while constructing the real `LambdaEntryPoint` (it also isn't deterministic/credential-free per the repo's testing rules).

These were never running before (restore was broken), so this PR doesn't regress anything. I've left them untouched to keep this PR scoped to the `NU1605` restore fix; cleaning up or rewriting the stale `ValuesController` scaffolding is a good follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UcfSsrvhaeBvsnuyHk7JvA

---
_Generated by [Claude Code](https://claude.ai/code/session_01UcfSsrvhaeBvsnuyHk7JvA)_