### PR TITLE
Fix #414: drop resolves the correct elevator card by its full name

### DIFF
--- a/GameEngine/Repository.cs
+++ b/GameEngine/Repository.cs
@@ -93,8 +93,35 @@ public static class Repository
 
         noun = noun.ToLowerInvariant().Trim();
 
+        // Issue #414: run the adjective-precise pass FIRST, exactly as GetItemInScope does for
+        // examine/take (#244) - but scoped to inventory, since you can only drop what you hold.
+        // Without this, the DROP path was adjective-blind: HasMatchingNoun's containment fallback
+        // matches any noun contained in the input, so the LOWER elevator card (bare noun "elevator
+        // access card") also matched "upper elevator access card", and whichever card sat earlier in
+        // inventory won - dropping the wrong card. This restores parity with the examine path, whose
+        // GetPreciseMatchInScope already distinguished the two cards via NounsForPreciseMatching.
+        var preciseMatch = GetPreciseMatchInInventory(noun, context);
+        if (preciseMatch != null)
+            return preciseMatch;
+
         var (hasMatch, item) = context.HasMatchingNoun(noun, lookInsideContainers: true);
         return hasMatch ? item : null;
+    }
+
+    /// <summary>
+    /// Inventory-scoped counterpart to <see cref="GetPreciseMatchInScope"/>: finds the item the player
+    /// is carrying (directly or nested inside a held/worn container) whose
+    /// <see cref="IItem.NounsForPreciseMatching"/> contains an exact match for the noun. DROP must
+    /// prefer an inventory match over a room match (you can only drop what you hold), so unlike the
+    /// room-first <see cref="GetPreciseMatchInScope"/> this deliberately never looks at the current
+    /// location. Returns null when nothing carried matches precisely, leaving the adjective-blind
+    /// containment fallback in the caller intact for bare/compound nouns (issue #414).
+    /// </summary>
+    private static IItem? GetPreciseMatchInInventory(string noun, IContext context)
+    {
+        return (context.GetAllItemsRecursively ?? [])
+            .FirstOrDefault(item => item.NounsForPreciseMatching
+                .Any(n => n.Equals(noun, StringComparison.InvariantCultureIgnoreCase)));
     }
 
     /// <summary>

--- a/Planetfall.Tests/CardTests.cs
+++ b/Planetfall.Tests/CardTests.cs
@@ -1,5 +1,10 @@
 using FluentAssertions;
 using GameEngine;
+using GameEngine.Item.ItemProcessor;
+using Model.AIGeneration;
+using Model.AIParsing;
+using Model.Intent;
+using Moq;
 using Planetfall.Item.Kalamontee.Admin;
 using Planetfall.Location.Kalamontee;
 
@@ -391,5 +396,115 @@ public class CardTests : EngineTestsBase
 
         Repository.GetPreciseMatchInScope("kitchen card", engine.Context).Should().Be(kitchen);
         Repository.GetItemInScope("kitchen card", engine.Context).Should().Be(kitchen);
+    }
+
+    // Issue #414: while holding BOTH elevator access cards, dropping one by its full, specific name
+    // failed - the DROP path resolves nouns via Repository.GetItemInInventory, which (unlike the
+    // examine path's GetItemInScope) was adjective-blind: it fell straight to HasMatchingNoun's
+    // containment fallback. The LOWER card's bare noun "elevator access card" is contained in the
+    // input "upper elevator access card", so whichever card sat earlier in inventory won and DROP
+    // acted on the wrong card. These lock in that GetItemInInventory now honors the precise
+    // (adjective-qualified) noun regardless of inventory order, matching the examine path.
+    [Test]
+    [TestCase(true)] // lower carried first - the issue's reported failing order
+    [TestCase(false)] // upper carried first
+    public void ElevatorCard_DropResolution_HonorsAdjective_RegardlessOfInventoryOrder(bool lowerFirst)
+    {
+        var engine = GetTarget();
+        engine.Context.CurrentLocation = Repository.GetLocation<MessCorridor>();
+
+        var upper = Repository.GetItem<UpperElevatorAccessCard>();
+        var lower = Repository.GetItem<LowerElevatorAccessCard>();
+
+        if (lowerFirst)
+        {
+            engine.Context.ItemPlacedHere(lower);
+            engine.Context.ItemPlacedHere(upper);
+        }
+        else
+        {
+            engine.Context.ItemPlacedHere(upper);
+            engine.Context.ItemPlacedHere(lower);
+        }
+
+        Repository.GetItemInInventory("upper elevator access card", engine.Context).Should().Be(upper);
+        Repository.GetItemInInventory("lower elevator access card", engine.Context).Should().Be(lower);
+    }
+
+    // Asymmetry guard (issue #414): the examine path (GetItemInScope -> GetPreciseMatchInScope) already
+    // resolved the adjective correctly. Pin that so the drop-path fix keeps parity with examine and the
+    // shared precise-matching definitions can't silently drift.
+    [Test]
+    [TestCase(true)]
+    [TestCase(false)]
+    public void ElevatorCard_ExamineResolution_HonorsAdjective_RegardlessOfInventoryOrder(bool lowerFirst)
+    {
+        var engine = GetTarget();
+        engine.Context.CurrentLocation = Repository.GetLocation<MessCorridor>();
+
+        var upper = Repository.GetItem<UpperElevatorAccessCard>();
+        var lower = Repository.GetItem<LowerElevatorAccessCard>();
+
+        if (lowerFirst)
+        {
+            engine.Context.ItemPlacedHere(lower);
+            engine.Context.ItemPlacedHere(upper);
+        }
+        else
+        {
+            engine.Context.ItemPlacedHere(upper);
+            engine.Context.ItemPlacedHere(lower);
+        }
+
+        Repository.GetItemInScope("upper elevator access card", engine.Context).Should().Be(upper);
+        Repository.GetItemInScope("lower elevator access card", engine.Context).Should().Be(lower);
+    }
+
+    // Issue #414, engine-path proof: while holding BOTH cards, "drop upper elevator access card" must
+    // drop the UPPER card and leave the lower one in hand. In production the real drop parser hands the
+    // full noun phrase to GetItemsToDrop; the harness's default parser reduces it to the distinctive
+    // second word ("upper"), sidestepping the collision. So we drive the real DropIntent dispatch target
+    // (TakeOrDropInteractionProcessor.Process) with a parser that returns the full phrase, mirroring prod.
+    [Test]
+    [TestCase(true)] // lower carried first - the issue's reported failing order
+    [TestCase(false)] // upper carried first
+    public async Task DropUpperElevatorCard_WhileHoldingBoth_DropsUpperCard(bool lowerFirst)
+    {
+        var engine = GetTarget();
+        var room = Repository.GetLocation<MessCorridor>();
+        engine.Context.CurrentLocation = room;
+
+        var upper = Repository.GetItem<UpperElevatorAccessCard>();
+        var lower = Repository.GetItem<LowerElevatorAccessCard>();
+
+        if (lowerFirst)
+        {
+            engine.Context.ItemPlacedHere(lower);
+            engine.Context.ItemPlacedHere(upper);
+        }
+        else
+        {
+            engine.Context.ItemPlacedHere(upper);
+            engine.Context.ItemPlacedHere(lower);
+        }
+
+        var dropParser = new Mock<IAITakeAndAndDropParser>();
+        dropParser.Setup(s => s.GetListOfItemsToDrop(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(["upper elevator access card"]);
+        var processor = new TakeOrDropInteractionProcessor(dropParser.Object);
+
+        var (_, message) = await processor.Process(
+            new DropIntent
+            {
+                OriginalInput = "drop upper elevator access card",
+                Noun = "upper elevator access card"
+            },
+            engine.Context,
+            Mock.Of<IGenerationClient>());
+
+        message.Should().Contain("Dropped");
+        engine.Context.Items.Should().NotContain(upper);
+        engine.Context.Items.Should().Contain(lower);
+        upper.CurrentLocation.Should().BeOfType<MessCorridor>();
     }
 }


### PR DESCRIPTION
## Summary

Fixes #414. While holding **both** the upper and lower elevator access cards, dropping either one by its full, specific name (`drop upper elevator access card`) acted on the wrong card — even though `examine` resolved the very same noun correctly. The two paths diverged on identical input.

## Root cause

The take/drop path resolves nouns via `Repository.GetItemInInventory`, which went straight to `HasMatchingNoun`'s **adjective-blind** containment fallback. The lower card's bare noun `"elevator access card"` is contained in the input `"upper elevator access card"`, so whichever card sat earlier in inventory won the match — dropping the wrong card.

The examine path (`GetItemInScope` → `GetPreciseMatchInScope`) already ran an **adjective-aware** pass first, honoring each card's `NounsForPreciseMatching` (the `ElevatorAccessCard`/`AccessCard` hardening that strips the shared `"card"`/`"elevator access card"` nouns). That's exactly why `examine` worked and `drop` didn't.

## Fix

`Repository.GetItemInInventory` now runs the same precise-match pass **first**, but scoped to inventory (you can only drop what you hold), via a new `GetPreciseMatchInInventory` helper — restoring parity with the examine path. When nothing carried matches precisely, the adjective-blind containment fallback is left intact for bare/compound nouns, so existing resolution is unchanged. `DropIt`'s deliberately flat top-level possession check is untouched, so the issue #362 nested-in-a-worn-pocket behavior (`drop card` → "You don't have that!" while the ID card stays in the uniform pocket) still holds.

Only the `drop`-side resolver changed; `take`/`examine` already went through the adjective-aware `GetItemInScope`, and `SlotBase` resolves cards by type, so the slide-through-slot path is unaffected.

## Testing (TDD)

Added deterministic tests in `Planetfall.Tests/CardTests.cs`, driven by both orders of inventory (the lower-card-first order is the issue's reported failing case):

- **`ElevatorCard_DropResolution_HonorsAdjective_RegardlessOfInventoryOrder`** — asserts `GetItemInInventory("upper elevator access card")` → upper card and `"lower elevator access card"` → lower card. **Red before / green after.**
- **`DropUpperElevatorCard_WhileHoldingBoth_DropsUpperCard`** — drives the real `DropIntent` dispatch target (`TakeOrDropInteractionProcessor.Process`) with a parser that returns the full noun phrase (mirroring production, since the harness's default parser reduces it to the distinctive second word). Asserts the **upper** card leaves inventory and the lower one stays. **Red before / green after.**
- **`ElevatorCard_ExamineResolution_HonorsAdjective_RegardlessOfInventoryOrder`** — asymmetry guard pinning the examine path's already-correct resolution, so the two paths can't drift apart again. Green before and after.

Before the fix the two drop tests failed for the right reason (the wrong card was resolved/dropped) while the examine guard passed — the exact "examine works / drop fails" asymmetry from the issue.

### Test runs (no regressions)

| Suite | Result |
|---|---|
| Planetfall.Tests | 3030 passed |
| UnitTests | 1016 passed, 1 skipped |
| ZorkOne.Tests | 1774 passed |

The #362 `PatrolUniform_DropCard_StillInPocket_DoesNotDrop` regression guard still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Ftf3pHQDgTdzMpvc7HFee

---
_Generated by [Claude Code](https://claude.ai/code/session_017Ftf3pHQDgTdzMpvc7HFee)_