### PR TITLE
Fix #407: Blather now answers attack/kick (death), salute, and take

### DIFF
--- a/Planetfall.Tests/BlatherTests.cs
+++ b/Planetfall.Tests/BlatherTests.cs
@@ -1,11 +1,67 @@
 using FluentAssertions;
 using GameEngine;
+using Planetfall.Item.Feinstein;
 using Planetfall.Location.Feinstein;
 
 namespace Planetfall.Tests;
 
 public class BlatherTests : EngineTestsBase
 {
+    // Issue #407: BLATHER-F (planetfall-source/globals.zil:742-772) also handles ATTACK/KICK (an
+    // authored death), SALUTE, and TAKE. The port only covered examine and throw, so these verbs
+    // fell through to the generic narrator instead of their authored responses.
+
+    [Test]
+    public async Task AttackBlather_KillsThePlayer()
+    {
+        var target = GetTarget();
+        var deckNine = StartHere<DeckNine>();
+        GetItem<Blather>().JoinsTheScene(target.Context, deckNine);
+
+        var response = await target.GetResponse("attack blather");
+
+        response.Should().Contain("Blather removes several of your appendages and internal organs");
+        response.Should().Contain("You have died");
+    }
+
+    [Test]
+    public async Task KickBlather_KillsThePlayer()
+    {
+        var target = GetTarget();
+        var deckNine = StartHere<DeckNine>();
+        GetItem<Blather>().JoinsTheScene(target.Context, deckNine);
+
+        var response = await target.GetResponse("kick blather");
+
+        response.Should().Contain("Blather removes several of your appendages and internal organs");
+        response.Should().Contain("You have died");
+    }
+
+    [Test]
+    public async Task SaluteBlather_SneerSoftens()
+    {
+        var target = GetTarget();
+        var deckNine = StartHere<DeckNine>();
+        GetItem<Blather>().JoinsTheScene(target.Context, deckNine);
+
+        var response = await target.GetResponse("salute blather");
+
+        response.Should().Contain("Blather's sneer softens a bit");
+        response.Should().Contain("First right thing you've done today. Only five demerits.");
+    }
+
+    [Test]
+    public async Task TakeBlather_BrushesYouAway()
+    {
+        var target = GetTarget();
+        var deckNine = StartHere<DeckNine>();
+        GetItem<Blather>().JoinsTheScene(target.Context, deckNine);
+
+        var response = await target.GetResponse("take blather");
+
+        response.Should().Contain("Blather brushes you away, muttering about suspended shore leave.");
+    }
+
     [Test]
     public async Task StayInBlatherLocationThreeTimes_EndUpInBrig()
     {

--- a/Planetfall/Item/Feinstein/Blather.cs
+++ b/Planetfall/Item/Feinstein/Blather.cs
@@ -1,12 +1,13 @@
 ﻿using ChatLambda;
 using Model.AIGeneration;
+using Planetfall.Command;
 
 namespace Planetfall.Item.Feinstein;
 
 internal class Blather : QuirkyCompanion, IAmANamedPerson, ITurnBasedActor, ICanBeTalkedTo
 {
     private readonly ChatWithBlather _chatWithBlather = new(null);
-    
+
     [UsedImplicitly]
     public int TurnsOnDeckNine { get; set; }
 
@@ -17,9 +18,32 @@ internal class Blather : QuirkyCompanion, IAmANamedPerson, ITurnBasedActor, ICan
 
     public override string[] NounsForMatching => ["blather", "ensign blather"];
 
+    // BLATHER-F's TAKE branch. Routed through CannotBeTakenDescription (not a verb match) so both
+    // the SimpleIntent path and the live AI parser's TakeIntent path get the authored line.
+    public override string? CannotBeTakenDescription =>
+        "Blather brushes you away, muttering about suspended shore leave. ";
+
     public string ExaminationDescription =>
         "Ensign Blather is a tall, beefy officer with a tremendous, misshapen nose. His uniform is perfect in " +
         "every respect, and the crease in his trousers could probably slice diamonds in half. ";
+
+    // BLATHER-F (planetfall-source/globals.zil:742-772): besides examine/throw (handled elsewhere),
+    // the original answers ATTACK/KICK with an authored death and SALUTE with a demerit reprieve.
+    public override async Task<InteractionResult?> RespondToSimpleInteraction(SimpleIntent action, IContext context,
+        IGenerationClient client, IItemProcessorFactory itemProcessorFactory)
+    {
+        // The original's <VERB? ATTACK KICK> — "kick" is matched locally because it is not a
+        // KillVerbs synonym (it is ordinarily a harmless flavor verb, e.g. kicking Floyd).
+        if (action.Match(Verbs.KillVerbs, NounsForMatching) || action.Match(["kick"], NounsForMatching))
+            return new DeathProcessor().Process(
+                "Blather removes several of your appendages and internal organs.", context);
+
+        if (action.Match(["salute"], NounsForMatching))
+            return new PositiveInteractionResult(
+                "Blather's sneer softens a bit. \"First right thing you've done today. Only five demerits.\" ");
+
+        return await base.RespondToSimpleInteraction(action, context, client, itemProcessorFactory);
+    }
 
     public override async Task<InteractionResult?> RespondToMultiNounInteraction(MultiNounIntent action, IContext context)
     {

--- a/UnitTests/TestParser.cs
+++ b/UnitTests/TestParser.cs
@@ -28,7 +28,7 @@ public class TestParser : IntentParser
             "drink", "use", "count", "touch", "read", "turn", "wave", "move", "ring", "activate", "search",
             "smell", "turn on", "turn off", "throw", "light", "rub", "kiss", "wind", "kick", "deflate",
             "lower", "raise", "get", "inflate", "leave", "unlock", "lock", "climb", "extend", "lift", "shake",
-            "oil", "lubricate", "cross", "through", "go", "break", "smash", "squeeze"
+            "oil", "lubricate", "cross", "through", "go", "break", "smash", "squeeze", "attack", "salute"
         ];
 
         _allNouns = Repository.GetNouns(gameName);


### PR DESCRIPTION
Fixes #407.

## What

Ensign Blather ignored **attack/kick** (supposed to be an authored death), **salute**, and **take** — all fell through to the generic AI-narrator response. Only examine and throw were implemented.

## Ground truth

`BLATHER-F` (planetfall-source/globals.zil:742-772):

- `<VERB? ATTACK KICK>` → `JIGS-UP "Blather removes several of your appendages and internal organs."`
- `<VERB? SALUTE>` → `"Blather's sneer softens a bit. \"First right thing you've done today. Only five demerits.\""`
- `<VERB? TAKE>` → `"Blather brushes you away, muttering about suspended shore leave."`

## How

`Blather` gets a `RespondToSimpleInteraction` override (mirroring the `Mural` pattern):

- **attack/kick** → `DeathProcessor` death. `Verbs.KillVerbs` plus a local `"kick"` match, since kick is deliberately not a kill synonym (kicking Floyd is harmless flavor) — mirrors the original's single `<VERB? ATTACK KICK>` branch.
- **salute** → the authored demerit-reprieve line.
- **take** → routed through `CannotBeTakenDescription` (the `Celery`/`Mural` seam) rather than a verb match, so both the deterministic SimpleIntent path and the live AI parser's `TakeIntent` path (`TakeOrDropInteractionProcessor.TakeIt`) produce the authored line, and `take all` reports it consistently with the engine's pinned convention.

Existing examine/throw handling is untouched. `TestParser` learns `attack`/`salute` so the new tests parse deterministically.

## TDD

Four new tests in `Planetfall.Tests/BlatherTests.cs` (red before the fix — engine returned an empty narrator response; green after):

- `AttackBlather_KillsThePlayer` / `KickBlather_KillsThePlayer` — death text + "You have died"
- `SaluteBlather_SneerSoftens`
- `TakeBlather_BrushesYouAway`

## Verification

- Planetfall.Tests: **3023 passed**
- UnitTests: **1016 passed** (1 pre-existing skip)
- ZorkOne.Tests: **1774 passed**
- EscapeRoom.Tests: **9 passed** (uses the shared `TestParser`)
- Planetfall-Lambda.Tests: fails NuGet restore (`NU1605` Amazon.Lambda.Core downgrade) — verified pre-existing on an unmodified tree, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)