### PR TITLE
Fix #417: wrong-type items get the type refusal, not a false "no room"

### DIFF
--- a/GameEngine/Item/MultiItemProcessor/PutProcessor.cs
+++ b/GameEngine/Item/MultiItemProcessor/PutProcessor.cs
@@ -60,10 +60,12 @@ public class PutProcessor : IMultiNounVerbProcessor
         if (itemReceiver is IOpenAndClose { IsOpen: false })
             return new PositiveInteractionResult("It's closed. ");
 
-        if (!itemReceiver.HaveRoomForItem(item))
-            return new PositiveInteractionResult(itemReceiver.NoRoomMessage);
-
-        if (itemReceiver.CanOnlyHoldTheseTypes.Any() && 
+        // Issue #417: type before room. HaveRoomForItem is size-based, so a container with a small
+        // SpaceForItems (the spool reader has 1) rejects any oversized item even when it is empty -
+        // and its NoRoomMessage can then assert an occupancy that isn't true ("There's already a
+        // spool in the reader."). An item the container can never hold deserves the type refusal
+        // whatever its size; NoRoomMessage is reserved for items that really are the right type.
+        if (itemReceiver.CanOnlyHoldTheseTypes.Any() &&
             !itemReceiver.CanOnlyHoldTheseTypes.Any(allowedType => allowedType.IsInstanceOfType(item)))
         {
             string? itemMismatchError = itemReceiver.CanOnlyHoldTheseTypesErrorMessage(item.Name);
@@ -72,6 +74,9 @@ public class PutProcessor : IMultiNounVerbProcessor
 
             return new NoNounMatchInteractionResult();
         }
+
+        if (!itemReceiver.HaveRoomForItem(item))
+            return new PositiveInteractionResult(itemReceiver.NoRoomMessage);
 
         item.CurrentLocation?.RemoveItem(item);
         item.CurrentLocation = itemReceiver;

--- a/Planetfall.Tests/CourseControlTests.cs
+++ b/Planetfall.Tests/CourseControlTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using GameEngine;
+using Planetfall.Item.Feinstein;
 using Planetfall.Item.Kalamontee.Mech;
 using Planetfall.Item.Lawanda;
 using Planetfall.Location.Kalamontee.Admin;
@@ -434,5 +435,21 @@ public class CourseControlTests : EngineTestsBase
 
         target.Context.HasItem<FusedBedistor>().Should().BeFalse();
         GetItem<LargeMetalCube>().HasItem<FusedBedistor>().Should().BeTrue();
+    }
+
+    [Test]
+    public async Task PutWrongItemInCube_GetsAuthoredRefusal()
+    {
+        // The original cube ends its "put" handler with a refusal naming the item (CUBE-F,
+        // comptwo.zil:583). The port declared CanOnlyHoldTheseTypes but no message for it, so the
+        // refusal fell through to the AI narrator instead of a crisp, deterministic reply.
+        var target = GetTarget();
+        StartHere<CourseControl>();
+        GetItem<LargeMetalCube>().IsOpen = true;
+        Take<Brush>();
+
+        var response = await target.GetResponse("put brush in cube");
+
+        response.Should().Contain("The brush doesn't fit");
     }
 }

--- a/Planetfall.Tests/LaserTests.cs
+++ b/Planetfall.Tests/LaserTests.cs
@@ -3,6 +3,7 @@ using GameEngine;
 using Model.Interface;
 using Moq;
 using Planetfall;
+using Planetfall.Item.Feinstein;
 using Planetfall.Item.Kalamontee.Mech;
 using Planetfall.Item.Kalamontee.Mech.FloydPart;
 using Planetfall.Item.Lawanda.Lab;
@@ -1393,6 +1394,26 @@ public class LaserTests : EngineTestsBase
         // Verify Floyd's pending comment was NOT set
         var pfContext = (PlanetfallContext)target.Context;
         pfContext.PendingFloydActionCommentPrompt.Should().BeNull();
+    }
+
+    #endregion
+
+    #region Wrong Item Tests
+
+    [Test]
+    public async Task PutWrongItemInLaser_GetsAuthoredRefusal()
+    {
+        // The original laser refuses a non-battery by naming the item and the depression it won't go
+        // into (LASER-F, comptwo.zil:2686). The port declared CanOnlyHoldTheseTypes but no message for
+        // it, so the refusal fell through to the AI narrator instead of a crisp, deterministic reply.
+        var target = GetTarget();
+        StartHere<MachineShop>();
+        Take<Laser>();
+        Take<Brush>();
+
+        var response = await target.GetResponse("put brush in laser");
+
+        response.Should().Contain("The brush won't fit in the laser's depression");
     }
 
     #endregion

--- a/Planetfall.Tests/PlanetaryDefenseTests.cs
+++ b/Planetfall.Tests/PlanetaryDefenseTests.cs
@@ -213,8 +213,9 @@ public class PlanetaryDefenseTests : EngineTestsBase
         StartHere<PlanetaryDefense>();
         GetItem<FromitzAccessPanel>().IsOpen = true;
         Take<Canteen>();
-        Take<FriedFromitzBoard>();
 
+        // Issue #417: no need to free a socket first. The wrong type is refused on type alone, so
+        // this now proves the type rejection whether the panel is full or not.
         var response = await target.GetResponse("put canteen in panel");
 
         response.Should().Contain("The canteen doesn't fit.");

--- a/Planetfall.Tests/PlanetaryDefenseTests.cs
+++ b/Planetfall.Tests/PlanetaryDefenseTests.cs
@@ -194,12 +194,14 @@ public class PlanetaryDefenseTests : EngineTestsBase
     [Test]
     public async Task PutInPanel_Full()
     {
+        // Issue #417: PutProcessor now refuses a wrong-type item on type, not room, so "full" has to
+        // be proven with an item the panel really would accept - all four sockets already hold a board.
         var target = GetTarget();
         StartHere<PlanetaryDefense>();
         GetItem<FromitzAccessPanel>().IsOpen = true;
-        Take<Canteen>();
+        Take<ShinyFromitzBoard>();
 
-        var response = await target.GetResponse("put canteen in panel");
+        var response = await target.GetResponse("put shiny in panel");
 
         response.Should().Contain("There's no room");
     }

--- a/Planetfall.Tests/SpoolReaderTests.cs
+++ b/Planetfall.Tests/SpoolReaderTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using Planetfall.Item.Feinstein;
 using Planetfall.Item.Kalamontee.Mech;
 using Planetfall.Item.Lawanda.Library;
 using Planetfall.Location.Lawanda;
@@ -54,6 +55,24 @@ public class SpoolReaderTests : EngineTestsBase
         response.Should().Contain("It doesn't fit in the circular opening");
     }
     
+    [Test]
+    public async Task PutIn_OversizedNonSpool_EmptyReader()
+    {
+        // Issue #417: the reader's NoRoomMessage asserts a spool is already loaded, so it must never
+        // fire for a wrong-type item. The brush is Size 2 and the reader has SpaceForItems 1, so a
+        // room-before-type check in PutProcessor made an EMPTY reader claim "There's already a spool
+        // in the reader." Type rejection has to win, whatever the item's size.
+        var target = GetTarget();
+        StartHere<Library>();
+        Take<Brush>();
+
+        var response = await target.GetResponse("put brush in reader");
+
+        response.Should().Contain("It doesn't fit in the circular opening");
+        response.Should().NotContain("There's already a spool in the reader");
+        Context.HasItem<Brush>().Should().BeTrue();
+    }
+
     [Test]
     public async Task PutIn_GreenSpool_Look()
     {

--- a/Planetfall/Item/Kalamontee/Mech/Laser.cs
+++ b/Planetfall/Item/Kalamontee/Mech/Laser.cs
@@ -37,6 +37,13 @@ public class Laser : ContainerBase, ICanBeTakenAndDropped, ICanBeExamined, ITurn
 
     public override Type[] CanOnlyHoldTheseTypes => [typeof(BatteryBase)];
 
+    // The original refuses a non-battery by naming the item and the depression it won't go into
+    // (LASER-F, comptwo.zil:2686). Without this the type rejection has no message and falls through
+    // to the AI narrator, which answers a deterministic refusal with a generated one (and a blank
+    // line if generation fails).
+    public override string CanOnlyHoldTheseTypesErrorMessage(string nameOfItemWeTriedToPlace) =>
+        $"The {nameOfItemWeTriedToPlace} won't fit in the laser's depression. ";
+
     public override int Size => 1;
 
     public override string ItemPlacedHereResult(IItem item, IContext context)

--- a/Planetfall/Item/Lawanda/LargeMetalCube.cs
+++ b/Planetfall/Item/Lawanda/LargeMetalCube.cs
@@ -12,6 +12,12 @@ public class LargeMetalCube : OpenAndCloseContainerBase
     // "is open" and hid the contents.
     public override Type[] CanOnlyHoldTheseTypes => [typeof(BedistorBase)];
 
+    // The original's "put" handler ends with a refusal naming the item (CUBE-F, comptwo.zil:583).
+    // Without this the type rejection has no message and falls through to the AI narrator, which
+    // answers a deterministic refusal with a generated one (and a blank line if generation fails).
+    public override string CanOnlyHoldTheseTypesErrorMessage(string nameOfItemWeTriedToPlace) =>
+        $"The {nameOfItemWeTriedToPlace} doesn't fit. ";
+
     public override int Size => 1;
 
     public override string NeverPickedUpDescription(ILocation currentLocation)

--- a/UnitTests/MultiNounProcessors/PutProcessorTests.cs
+++ b/UnitTests/MultiNounProcessors/PutProcessorTests.cs
@@ -1,4 +1,5 @@
 using GameEngine;
+using GameEngine.Item;
 using GameEngine.Item.MultiItemProcessor;
 using Model.Intent;
 using Model.Item;
@@ -304,5 +305,90 @@ public class PutProcessorTests : EngineTestsBase
         result!.InteractionHappened.Should().BeTrue();
         result.InteractionMessage.Should().Contain("no room");
         garlic.CurrentLocation.Should().NotBe(mailbox);
+    }
+
+    /// <summary>
+    ///     Issue #417: a typed container's NoRoomMessage is free to assert occupancy ("There's already
+    ///     a spool in the reader"), so it must never answer an item the container could not hold at any
+    ///     size. HaveRoomForItem is size-based, so checking room first made an EMPTY container blame
+    ///     room for what was really a type mismatch. This guards the ordering in the engine itself -
+    ///     no Zork container is typed, so only the game suites would otherwise catch a regression here.
+    /// </summary>
+    [Test]
+    public void PutProcessor_WrongTypeAndTooBig_RefusesOnTypeNotRoom()
+    {
+        var target = new PutProcessor();
+        var sword = Repository.GetItem<Sword>(); // Size 5, far bigger than the receiver holds
+        var receiver = new OnlyHoldsLeafletsContainer();
+        sword.CurrentLocation = new ZorkIContext();
+
+        // Act
+        var result = target.Process(new MultiNounIntent
+        {
+            Verb = "put",
+            NounOne = "sword",
+            NounTwo = "tiny box",
+            Preposition = "inside",
+            OriginalInput = ""
+        }, null!, sword, receiver);
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.InteractionHappened.Should().BeTrue();
+        result.InteractionMessage.Should().Contain("only holds leaflets");
+        result.InteractionMessage.Should().NotContain("occupied");
+        sword.CurrentLocation.Should().NotBe(receiver);
+    }
+
+    /// <summary>
+    ///     The companion to the test above: a receiver that IS the right type still gets the room
+    ///     refusal, so moving the type check first did not disable the room check.
+    /// </summary>
+    [Test]
+    public void PutProcessor_RightTypeButTooBig_StillRefusesOnRoom()
+    {
+        var target = new PutProcessor();
+        var leaflet = Repository.GetItem<Leaflet>();
+        var receiver = new OnlyHoldsLeafletsContainer();
+        receiver.ItemPlacedHere(Repository.GetItem<Matchbook>()); // fills the single slot
+        leaflet.CurrentLocation = new ZorkIContext();
+
+        // Act
+        var result = target.Process(new MultiNounIntent
+        {
+            Verb = "put",
+            NounOne = "leaflet",
+            NounTwo = "tiny box",
+            Preposition = "inside",
+            OriginalInput = ""
+        }, null!, leaflet, receiver);
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.InteractionHappened.Should().BeTrue();
+        result.InteractionMessage.Should().Contain("occupied");
+        leaflet.CurrentLocation.Should().NotBe(receiver);
+    }
+
+    /// <summary>
+    ///     A type-restricted container with room for exactly one item, whose NoRoomMessage asserts
+    ///     occupancy the way SpoolReader's does - so a type mismatch answered with it would be a lie.
+    /// </summary>
+    private class OnlyHoldsLeafletsContainer : ContainerBase
+    {
+        public override string[] NounsForMatching => ["tiny box"];
+
+        protected override int SpaceForItems => 1;
+
+        public override Type[] CanOnlyHoldTheseTypes => [typeof(Leaflet)];
+
+        public override string CanOnlyHoldTheseTypesErrorMessage(string nameOfItemWeTriedToPlace) =>
+            "That box only holds leaflets. ";
+
+        public override string NoRoomMessage => "The box is already occupied. ";
+
+        public override void Init()
+        {
+        }
     }
 }


### PR DESCRIPTION
Fixes #417.

## The bug

In the Library, `put brush in reader` on an **empty** microfilm reader answered **"There's already a spool in the reader."** — false, and the brush was not consumed. Smaller wrong-type items (`diary`, `chronometer`) correctly got "It doesn't fit in the circular opening."

## Root cause

`PutProcessor` checked **room before type**. `HaveRoomForItem` is size-based (`Items.Sum(Size) + item.Size <= SpaceForItems`), so a container with a small `SpaceForItems` rejects an oversized item **even when empty**. `SpoolReader.SpaceForItems` is `1` and the brush is `Size 2`, so `0 + 2 <= 1` failed and the player got the reader's `NoRoomMessage` — which hardcodes an occupancy claim — instead of ever reaching the type check. The brush is simply the one wrong-type item large enough to trip the size check first.

## Fix

`GameEngine/Item/MultiItemProcessor/PutProcessor.cs` now checks **type before room**. An item the container can never hold gets the type refusal whatever its size, and `NoRoomMessage` is reserved for items that really are the right type. All spools are `Size 1` and the reader holds `1`, so the reader's occupancy message can now only fire when a spool genuinely is loaded — it is truthful in every case it can still fire.

This is the general fix suggested in the issue, so it also stops any other typed, size-limited container from blaming room for what is really a type mismatch.

## TDD

Red first, for the right reason:

```
Expected response "There's already a spool in the reader.
" to contain "It doesn't fit in the circular opening".
```

- **New:** `SpoolReaderTests.PutIn_OversizedNonSpool_EmptyReader` — empty reader, `put brush in reader` returns the type refusal, never the occupancy claim, and the brush stays in inventory.
- **Regression guards already present and still green:** `PutIn_Pliers` (type rejection), `PutIn_GreenSpool` (insertion succeeds), `PutIn_AlreadyHasOne` (second spool still gets "There's already a spool in the reader"), `PutIn_Disambiguation`, `PutIn_TakeOut`.

One existing test changed: `PlanetaryDefenseTests.PutInPanel_Full` proved fullness with a **canteen**, which is also the wrong type for the fromitz panel, so under the new ordering it got the type refusal. It now uses the **shiny fromitz board** — an item the panel would accept — so it still tests the fullness path it is named for.

## Verification

Run per project (`dotnet test A B` errors with MSB1008):

| Suite | Result |
|---|---|
| Planetfall.Tests | 3040 passed, 0 failed |
| ZorkOne.Tests | 1776 passed, 0 failed |
| UnitTests | 1026 passed, 1 skipped, 0 failed |
| EscapeRoom.Tests | 9 passed, 0 failed |

`Lambda.Tests` / `Planetfall-Lambda.Tests` each have one failing `ValuesControllerTests.TestGet` (200 vs 404) — **pre-existing**, confirmed failing with these changes stashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Follow-up commit: review fixes

Reviewing the reorder surfaced that making the type check authoritative exposes a gap — four typed containers declare `CanOnlyHoldTheseTypes` but no `CanOnlyHoldTheseTypesErrorMessage`, so their refusal returns `NoNounMatchInteractionResult` and [MultiNounEngine.cs:132](GameEngine/IntentEngine/MultiNounEngine.cs:132) falls through to an LLM call — answering what should be a deterministic refusal with a generated one, and a blank line whenever generation returns nothing.

The ZIL shows two of the four were **authored refusals the port dropped**:

| Container | Original | Now |
|---|---|---|
| `LargeMetalCube` | `CUBE-F` ends its put handler naming the item (comptwo.zil:583) | `The {item} doesn't fit.` |
| `Laser` | `LASER-F` names the item and the depression (comptwo.zil:2686) | `The {item} won't fit in the laser's depression.` |

Both follow the sibling `FromitzAccessPanel` pattern already in the codebase.

**`Canteen` and `MedicineBottle` are deliberately untouched.** The original declares them plain `CONTBIT` containers with *no type restriction at all* (compone.zil:803, comptwo.zil:146) — the port invented the restriction. Authoring a refusal there would deepen the divergence rather than fix it, and removing the restriction is a gameplay change. Worth its own issue.

Also from the review:

- **`PutProcessorTests` gains the ordering guard the engine lacked.** No Zork container is typed, so reverting the reorder previously went unnoticed by every `UnitTests` case — only a Planetfall test would have caught it. The new test fails with `"The box is already occupied."` on the old ordering, the exact class of lie #417 reported; its companion proves a right-type item still gets the room refusal, so the room check wasn't disabled.
- **`PutInPanel_WrongItem`** no longer frees a socket first — under type-first ordering that setup was vestigial and made the test read as fullness-gated.

Final suite counts: Planetfall 3042, UnitTests 1028, ZorkOne 1776, EscapeRoom 9 — all passing.
