### PR TITLE
Fix #422: canteen and medicine bottle refuse wrong-type items deterministically

### DIFF
--- a/Planetfall.Tests/KitchenAndCanteenTests.cs
+++ b/Planetfall.Tests/KitchenAndCanteenTests.cs
@@ -172,5 +172,22 @@ public class KitchenAndCanteenTests : EngineTestsBase
     }
 
     // TODO: drink dont have it
-    // TODO: put something in canteen
+
+    [Test]
+    public async Task PutBrushInCanteen_TypeRefusal_NamesTheItem_AndIsNotBlank()
+    {
+        var target = GetTarget();
+        StartHere<MessCorridor>();
+        Take<Canteen>().IsOpen = true;
+        Take<Brush>();
+
+        var response = await target.GetResponse("put brush in canteen");
+
+        // Issue #422: the canteen only holds protein liquid, so a brush is refused on type. That
+        // refusal must be a deterministic message that names the item - not a fall-through to the
+        // AI narrator, which (with a stubbed generation client) leaves a blank line.
+        response.Should().NotBeNullOrWhiteSpace();
+        response.Should().Contain("brush");
+        GetItem<Canteen>().Items.Should().BeEmpty();
+    }
 }

--- a/Planetfall.Tests/SicknessSystemTests.cs
+++ b/Planetfall.Tests/SicknessSystemTests.cs
@@ -225,4 +225,27 @@ public class SicknessSystemTests : EngineTestsBase
         await target.GetResponse("drink medicine");
         context.SicknessCounter.Should().Be(3);
     }
+
+    [Test]
+    public async Task PutBrushInMedicineBottle_TypeRefusal_NamesTheItem_AndIsNotBlank()
+    {
+        var target = GetTarget();
+        var context = target.Context;
+        StartHere<MessCorridor>();
+
+        // Hold the open bottle (with its medicine inside) plus a brush to try to stuff into it.
+        var bottle = GetItem<MedicineBottle>();
+        bottle.IsOpen = true;
+        context.ItemPlacedHere(bottle);
+        context.ItemPlacedHere(GetItem<Brush>());
+
+        var response = await target.GetResponse("put brush in bottle");
+
+        // Issue #422: the bottle only holds medicine, so a brush is refused on type. That refusal
+        // must be a deterministic message that names the item - not a fall-through to the AI
+        // narrator, which (with a stubbed generation client) leaves a blank line.
+        response.Should().NotBeNullOrWhiteSpace();
+        response.Should().Contain("brush");
+        bottle.Items.Should().NotContain(GetItem<Brush>());
+    }
 }

--- a/Planetfall/Item/Kalamontee/Canteen.cs
+++ b/Planetfall/Item/Kalamontee/Canteen.cs
@@ -6,6 +6,13 @@ public class Canteen : OpenAndCloseContainerBase, ICanBeExamined, ICanBeTakenAnd
 
     public override Type[] CanOnlyHoldTheseTypes => [typeof(ProteinLiquid)];
 
+    // Issue #422: the canteen-holds-only-protein-liquid restriction is a port addition (the original
+    // CANTEEN has no ACTION routine guarding PUT). It is kept deliberately, but a bare type rejection
+    // returns no message and falls through to the AI narrator in MultiNounEngine - a blank line when
+    // generation returns nothing. Naming the item keeps the refusal deterministic.
+    public override string CanOnlyHoldTheseTypesErrorMessage(string nameOfItemWeTriedToPlace) =>
+        $"The {nameOfItemWeTriedToPlace} won't fit through the mouth of the canteen. ";
+
     public override int Size => 1;
 
     public override bool IsTransparent => false;

--- a/Planetfall/Item/Lawanda/MedicineBottle.cs
+++ b/Planetfall/Item/Lawanda/MedicineBottle.cs
@@ -8,6 +8,13 @@ internal class MedicineBottle : OpenAndCloseContainerBase, ICanBeTakenAndDropped
 
     public override Type[] CanOnlyHoldTheseTypes => [typeof(Medicine)];
 
+    // Issue #422: the bottle-holds-only-medicine restriction is a port addition (the original
+    // MEDICINE-BOTTLE has no ACTION routine guarding PUT). It is kept deliberately, but a bare type
+    // rejection returns no message and falls through to the AI narrator in MultiNounEngine - a blank
+    // line when generation returns nothing. Naming the item keeps the refusal deterministic.
+    public override string CanOnlyHoldTheseTypesErrorMessage(string nameOfItemWeTriedToPlace) =>
+        $"The {nameOfItemWeTriedToPlace} won't fit in the bottle. ";
+
     public override bool IsTransparent => true;
 
     public string ExaminationDescription => ReadDescription;


### PR DESCRIPTION
## Summary

Fixes #422. The `Canteen` (holds only `ProteinLiquid`) and `MedicineBottle` (holds only `Medicine`) carry a `CanOnlyHoldTheseTypes` restriction the original Planetfall never had — neither `CANTEEN` (`compone.zil:803`) nor `MEDICINE-BOTTLE` (`comptwo.zil:146`) has an `ACTION` routine guarding `PUT`.

Per the decision on the issue, **the restriction is kept** (Option 2), but the *secondary symptom* is fixed: neither class overrode `CanOnlyHoldTheseTypesErrorMessage`, so a type rejection returned `NoNounMatchInteractionResult` and `MultiNounEngine.ProcessNonLocationTwoItemInteraction` fell through to `GetGeneratedVerbNotUsefulResponse` — an LLM call standing in for what should be a deterministic refusal, and a **blank line** whenever generation returns nothing (e.g. `put brush in canteen`).

## Changes

- `Canteen.cs` — override `CanOnlyHoldTheseTypesErrorMessage` → `"The {item} won't fit through the mouth of the canteen. "`
- `MedicineBottle.cs` — override `CanOnlyHoldTheseTypesErrorMessage` → `"The {item} won't fit in the bottle. "`

This matches the sibling containers that already supply a message (`Laser`, `LargeMetalCube`, `SpoolReader`, `KitchenMachine`, `FromitzAccessPanel`). Each override carries a comment noting the restriction is a deliberately-kept port addition, so no false ZIL citation is implied.

## Behavior preserved

Filling the canteen at the dispenser (`KitchenMachine` → `canteen.ItemPlacedHere(ProteinLiquid)`) and seeding the bottle's medicine (`StartWithItemInside<Medicine>()`) both go through `ItemPlacedHere`, which bypasses the `PutProcessor` type check — so those paths, and drinking, are unaffected.

## Testing (TDD)

Added deterministic tests driving `GetResponse(...)` under the stubbed generation client, each of which failed first (response was `"\n"`) and passes after the fix:

- `KitchenAndCanteenTests.PutBrushInCanteen_TypeRefusal_NamesTheItem_AndIsNotBlank`
- `SicknessSystemTests.PutBrushInMedicineBottle_TypeRefusal_NamesTheItem_AndIsNotBlank`

Verification:
- `Planetfall.Tests` — 3074 passed, 0 failed (guards dispenser fill, drinking, sickness/medicine one-shot behavior).
- `UnitTests` `PutProcessorTests` — 15 passed, 0 failed (the type-restriction/error-message path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JziNmkqTWoSFjz5F3f3m6H

---
_Generated by [Claude Code](https://claude.ai/code/session_01JziNmkqTWoSFjz5F3f3m6H)_