### PR TITLE
Fix #424: Kitchen dispenser accepts "put canteen under spout"

### DIFF
--- a/Planetfall.Tests/KitchenAndCanteenTests.cs
+++ b/Planetfall.Tests/KitchenAndCanteenTests.cs
@@ -80,6 +80,54 @@ public class KitchenAndCanteenTests : EngineTestsBase
     }
 
     [Test]
+    public async Task PutCanteenInNiche()
+    {
+        // Regression guard for issue #424: the "in niche" phrasing must keep working.
+        var target = GetTarget();
+        StartHere<Kitchen>();
+        target.Context.ItemPlacedHere<Canteen>();
+
+        var response = await target.GetResponse("put canteen in niche");
+        response.Should()
+            .Contain(
+                "The canteen fits snugly into the octagonal niche, its mouth resting just below the spout of the machine");
+        Repository.GetItem<KitchenMachine>().Items.Should().Contain(Repository.GetItem<Canteen>());
+    }
+
+    [Test]
+    public async Task PutCanteenUnderSpout()
+    {
+        // Issue #424: the machine's own description calls the niche "beneath a spout" and the sibling
+        // Machine Shop dispenser accepts "put flask under spout", but this dispenser used to no-op on the
+        // equally-natural "put canteen under spout". It should land the canteen in the niche just like
+        // "put canteen in niche".
+        var target = GetTarget();
+        StartHere<Kitchen>();
+        target.Context.ItemPlacedHere<Canteen>();
+
+        var response = await target.GetResponse("put canteen under spout");
+        response.Should()
+            .Contain(
+                "The canteen fits snugly into the octagonal niche, its mouth resting just below the spout of the machine");
+        Repository.GetItem<KitchenMachine>().Items.Should().Contain(Repository.GetItem<Canteen>());
+    }
+
+    [Test]
+    public async Task PutCanteenUnderneathSpout()
+    {
+        // Issue #424: "underneath" is an equally-natural synonym for the same placement.
+        var target = GetTarget();
+        StartHere<Kitchen>();
+        target.Context.ItemPlacedHere<Canteen>();
+
+        var response = await target.GetResponse("put canteen underneath spout");
+        response.Should()
+            .Contain(
+                "The canteen fits snugly into the octagonal niche, its mouth resting just below the spout of the machine");
+        Repository.GetItem<KitchenMachine>().Items.Should().Contain(Repository.GetItem<Canteen>());
+    }
+
+    [Test]
     public async Task PressButton_MachineEmpty()
     {
         var target = GetTarget();

--- a/Planetfall.Tests/KitchenAndCanteenTests.cs
+++ b/Planetfall.Tests/KitchenAndCanteenTests.cs
@@ -128,6 +128,53 @@ public class KitchenAndCanteenTests : EngineTestsBase
     }
 
     [Test]
+    public async Task PutCanteenUnderSpout_CanteenNotInScope_FallsThroughToNarrator()
+    {
+        // Issue #424 review: when no canteen is in scope (not held, not in this room), the phrasing must
+        // fall through to the narrator rather than claiming "You don't have the canteen." - mirroring the
+        // Machine Shop and the "put canteen in niche" path.
+        var target = GetTarget();
+        StartHere<Kitchen>();
+        // The canteen exists in the story but is neither held nor present in the Kitchen.
+
+        var response = await target.GetResponse("put canteen under spout");
+
+        Repository.GetItem<KitchenMachine>().Items.Should().BeEmpty();
+        response.Should().NotContain("You don't have the canteen");
+        response.Should().NotContain("fits snugly into the octagonal niche");
+    }
+
+    [Test]
+    public async Task PutCanteenUnderSpout_OnFloorNotHeld()
+    {
+        // Issue #424 review: a canteen in scope but not held gets the same "you don't have it" guard as
+        // the in-niche path, and is not placed.
+        var target = GetTarget();
+        var kitchen = StartHere<Kitchen>();
+        kitchen.ItemPlacedHere(GetItem<Canteen>());
+
+        var response = await target.GetResponse("put canteen under spout");
+
+        response.Should().Contain("You don't have the canteen");
+        Repository.GetItem<KitchenMachine>().Items.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task PutKitUnderSpout_DoesNotFit()
+    {
+        // Issue #424 review: a wrong-type item under the spout gets the same "It doesn't fit in the niche."
+        // refusal as "put kit in machine", instead of falling through to the generic narrator.
+        var target = GetTarget();
+        StartHere<Kitchen>();
+        target.Context.ItemPlacedHere<SurvivalKit>();
+
+        var response = await target.GetResponse("put kit under spout");
+
+        response.Should().Contain("It doesn't fit in the niche");
+        Repository.GetItem<KitchenMachine>().Items.Should().BeEmpty();
+    }
+
+    [Test]
     public async Task PressButton_MachineEmpty()
     {
         var target = GetTarget();

--- a/Planetfall/Item/Kalamontee/KitchenMachine.cs
+++ b/Planetfall/Item/Kalamontee/KitchenMachine.cs
@@ -58,7 +58,31 @@ internal class KitchenMachine : ContainerBase, ICanBeExamined
         return await base.RespondToSimpleInteraction(action, context, client, itemProcessorFactory);
     }
 
-    // TODO: put canteen under spout. 
+    public override async Task<InteractionResult?> RespondToMultiNounInteraction(MultiNounIntent action,
+        IContext context)
+    {
+        // Issue #424: the machine describes its niche as "beneath a spout" and the sibling Machine Shop
+        // dispenser accepts "put flask under spout", but here "spout" was never a matching noun and
+        // PutProcessor only understands in/into/onto - never "under" - so "put canteen under spout"
+        // silently no-oped to the narrator. Mirror the Machine Shop and route the "under spout" phrasing
+        // to the same niche placement as "put canteen in niche".
+        var canteen = Repository.GetItem<Canteen>();
+        string[] verbs = ["put", "place", "move", "shove", "jam", "push"];
+        string[] receiverNouns = [.. NounsForMatching, "spout"];
+
+        if (action.Match(verbs, canteen.NounsForMatching, receiverNouns, ["under", "underneath"]))
+        {
+            // Mirror PutProcessor's "you don't have it" guard - and if it is already in the niche its
+            // CurrentLocation is this machine, not the player, so this also blocks re-placing it.
+            if (canteen.CurrentLocation is not IContext)
+                return new PositiveInteractionResult($"You don't have the {canteen.NounsForMatching.First()}. ");
+
+            ItemPlacedHere(canteen);
+            return new PositiveInteractionResult(ItemPlacedHereResult(canteen, context));
+        }
+
+        return await base.RespondToMultiNounInteraction(action, context);
+    }
 
     public override string ItemPlacedHereResult(IItem item, IContext context)
     {

--- a/Planetfall/Item/Kalamontee/KitchenMachine.cs
+++ b/Planetfall/Item/Kalamontee/KitchenMachine.cs
@@ -64,21 +64,33 @@ internal class KitchenMachine : ContainerBase, ICanBeExamined
         // Issue #424: the machine describes its niche as "beneath a spout" and the sibling Machine Shop
         // dispenser accepts "put flask under spout", but here "spout" was never a matching noun and
         // PutProcessor only understands in/into/onto - never "under" - so "put canteen under spout"
-        // silently no-oped to the narrator. Mirror the Machine Shop and route the "under spout" phrasing
-        // to the same niche placement as "put canteen in niche".
-        var canteen = Repository.GetItem<Canteen>();
+        // silently no-oped to the narrator. Route the "under spout" phrasing to the same niche placement
+        // as "put canteen in niche", applying the same guards (in that order) PutProcessor applies there.
         string[] verbs = ["put", "place", "move", "shove", "jam", "push"];
         string[] receiverNouns = [.. NounsForMatching, "spout"];
 
-        if (action.Match(verbs, canteen.NounsForMatching, receiverNouns, ["under", "underneath"]))
+        if (action.MatchVerb(verbs) && action.MatchNounTwo(receiverNouns) &&
+            action.MatchPreposition(["under", "underneath"]))
         {
-            // Mirror PutProcessor's "you don't have it" guard - and if it is already in the niche its
-            // CurrentLocation is this machine, not the player, so this also blocks re-placing it.
-            if (canteen.CurrentLocation is not IContext)
-                return new PositiveInteractionResult($"You don't have the {canteen.NounsForMatching.First()}. ");
+            // The parser hands us this phrasing even when nothing by that name is in scope. Fall through
+            // to the narrator rather than asserting the player doesn't have it - this mirrors the Machine
+            // Shop's NoNounMatch fall-through and the in-niche path's scope-aware missing-noun response.
+            var itemToPlace = Repository.GetItemInScope(action.NounOne, context);
+            if (itemToPlace is null)
+                return await base.RespondToMultiNounInteraction(action, context);
 
-            ItemPlacedHere(canteen);
-            return new PositiveInteractionResult(ItemPlacedHereResult(canteen, context));
+            // You can't place what you aren't holding - the same guard PutProcessor applies to "in niche".
+            // A canteen already resting in the niche has its CurrentLocation set to this machine (not the
+            // player), so this also blocks re-placing it - matching the in-niche path exactly.
+            if (itemToPlace.CurrentLocation is not IContext)
+                return new PositiveInteractionResult($"You don't have the {itemToPlace.NounsForMatching.First()}. ");
+
+            // Only a canteen fits; give a wrong-type item the same refusal as the in-niche path.
+            if (!CanOnlyHoldTheseTypes.Any(type => type.IsInstanceOfType(itemToPlace)))
+                return new PositiveInteractionResult(CanOnlyHoldTheseTypesErrorMessage(itemToPlace.Name));
+
+            ItemPlacedHere(itemToPlace);
+            return new PositiveInteractionResult(ItemPlacedHereResult(itemToPlace, context));
         }
 
         return await base.RespondToMultiNounInteraction(action, context);

--- a/UnitTests/IntentMappings/base-mappings.json
+++ b/UnitTests/IntentMappings/base-mappings.json
@@ -114,6 +114,8 @@
     { "inputs": ["place ladder across rift"], "verb": "place", "nounOne": "ladder", "nounTwo": "rift", "preposition": "across", "originalInput": "place ladder across rift" },
     { "inputs": ["put ladder across rift"], "verb": "put", "nounOne": "ladder", "nounTwo": "rift", "preposition": "across", "originalInput": "put ladder across rift" },
     { "inputs": ["put flask under spout"], "verb": "put", "nounOne": "flask", "nounTwo": "spout", "preposition": "under", "originalInput": "put flask under spout" },
+    { "inputs": ["put canteen under spout"], "verb": "put", "nounOne": "canteen", "nounTwo": "spout", "preposition": "under", "originalInput": "put canteen under spout" },
+    { "inputs": ["put canteen underneath spout"], "verb": "put", "nounOne": "canteen", "nounTwo": "spout", "preposition": "underneath", "originalInput": "put canteen underneath spout" },
     { "inputs": ["put trident in boat"], "verb": "put", "nounOne": "trident", "nounTwo": "boat", "preposition": "in", "originalInput": "put trident in boat" },
     { "inputs": ["put bar in boat"], "verb": "put", "nounOne": "bar", "nounTwo": "boat", "preposition": "in", "originalInput": "put bar in boat" },
     { "inputs": ["put emerald in boat"], "verb": "put", "nounOne": "emerald", "nounTwo": "boat", "preposition": "in", "originalInput": "put emerald in boat" },

--- a/UnitTests/IntentMappings/base-mappings.json
+++ b/UnitTests/IntentMappings/base-mappings.json
@@ -116,6 +116,7 @@
     { "inputs": ["put flask under spout"], "verb": "put", "nounOne": "flask", "nounTwo": "spout", "preposition": "under", "originalInput": "put flask under spout" },
     { "inputs": ["put canteen under spout"], "verb": "put", "nounOne": "canteen", "nounTwo": "spout", "preposition": "under", "originalInput": "put canteen under spout" },
     { "inputs": ["put canteen underneath spout"], "verb": "put", "nounOne": "canteen", "nounTwo": "spout", "preposition": "underneath", "originalInput": "put canteen underneath spout" },
+    { "inputs": ["put kit under spout"], "verb": "put", "nounOne": "kit", "nounTwo": "spout", "preposition": "under", "originalInput": "put kit under spout" },
     { "inputs": ["put trident in boat"], "verb": "put", "nounOne": "trident", "nounTwo": "boat", "preposition": "in", "originalInput": "put trident in boat" },
     { "inputs": ["put bar in boat"], "verb": "put", "nounOne": "bar", "nounTwo": "boat", "preposition": "in", "originalInput": "put bar in boat" },
     { "inputs": ["put emerald in boat"], "verb": "put", "nounOne": "emerald", "nounTwo": "boat", "preposition": "in", "originalInput": "put emerald in boat" },


### PR DESCRIPTION
## Summary

Fixes #424. In the Kalamontee **Kitchen**, the food dispenser accepted `put canteen in niche` but silently no-oped on the equally-natural `put canteen under spout` — even though the machine's own description calls out the spout (*"an octagonal niche beneath a spout"*), and the sibling Machine Shop dispenser already accepts `put flask under spout`.

## Root cause

`KitchenMachine` placed the canteen only via the container's `niche` matching noun, which routes through `PutProcessor`. `PutProcessor` understands the prepositions `in`/`into`/`onto` but never `under`, and `spout` was not in `NounsForMatching`, so `put canteen under spout` found no receiver and fell through to the AI narrator (`"This action or command has no effect on the game."`). The file even carried a standing `// TODO: put canteen under spout.` marker.

## Fix

- Override `RespondToMultiNounInteraction` on `KitchenMachine` to match `put/place/… canteen under|underneath spout` (spout added alongside the machine's existing nouns) and route it to the same niche-placement path as `put canteen in niche`, mirroring the Machine Shop's `["under", "underneath"]` + spout handling.
- Reuses `ItemPlacedHere` / `ItemPlacedHereResult` so the response string is identical to the `in niche` path, and mirrors `PutProcessor`'s "you don't have it" guard (which also blocks re-placing a canteen already in the niche).
- Removed the obsolete TODO.

## Testing (TDD)

Followed red → green. Added deterministic tests in `Planetfall.Tests/KitchenAndCanteenTests.cs`:

- `PutCanteenUnderSpout` — with the canteen held, `put canteen under spout` lands it in the niche with the same result string as `put canteen in niche` (failed before the fix: response was the empty narrator no-op).
- `PutCanteenUnderneathSpout` — same for the `underneath` synonym.
- `PutCanteenInNiche` — regression guard that the original `in niche` phrasing still works.

Added the matching entries to the shared `UnitTests/IntentMappings/base-mappings.json` so the deterministic test parser resolves the new phrasings (mirroring the existing `put flask under spout` mapping).

Existing non-canteen behavior is unchanged: `put kit in machine` still routes through `PutProcessor` and gets *"It doesn't fit in the niche."*

## Verification

- `dotnet test Planetfall.Tests` → **3075 passed, 0 failed**
- `dotnet test UnitTests` → **1033 passed, 0 failed** (shared intent-mapping change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZmJoSDPKGQHvNnhv7LyFi

---
_Generated by [Claude Code](https://claude.ai/code/session_01CZmJoSDPKGQHvNnhv7LyFi)_