### PR TITLE
Fix #429: throw-into-rift resolves its target from scope, not a global lookup

### DIFF
--- a/Planetfall.Tests/AdminCorridorTests.cs
+++ b/Planetfall.Tests/AdminCorridorTests.cs
@@ -1,7 +1,10 @@
 using FluentAssertions;
+using Planetfall.Item.Feinstein;
 using Planetfall.Item.Kalamontee;
+using Planetfall.Item.Kalamontee.Mech;
 using Planetfall.Location.Kalamontee;
 using Planetfall.Location.Kalamontee.Admin;
+using Planetfall.Location.Kalamontee.Mech;
 
 namespace Planetfall.Tests;
 
@@ -254,5 +257,52 @@ public class AdminCorridorTests : EngineTestsBase
 
         response.Should().Contain("already spans the rift");
         GetLocation<AdminCorridorNorth>().Items.Count(i => i is Ladder).Should().Be(1);
+    }
+
+    // Issue #429: the generic "throw <thing> into rift" handler in RiftLocationBase resolved the
+    // thrown object with a GLOBAL Repository.GetItem lookup that ignores scope/state. Two divergences
+    // followed, both reproduced on prod. These mirror the sibling ladder guards (#297) above.
+    [TestFixture]
+    public class ThrowIntoRift : AdminCorridorTests
+    {
+        // Divergence A: throwing an item that lives in a completely different part of the complex
+        // still "succeeded" — the global lookup found the singleton regardless of location and
+        // deleted it (CurrentLocation = null). Because critical-path items (e.g. the laser) can be
+        // destroyed this way without the player ever touching them, this is a softlock vector.
+        [Test]
+        public async Task ThrowIntoRift_ItemInAnotherRoom_IsNotDestroyedAndNoLossNarrated()
+        {
+            var target = GetTarget();
+            StartHere<AdminCorridorNorth>();
+            var laser = GetItem<Laser>();
+            // The laser sits in the Mech area — not carried, not here at the rift.
+            GetLocation<ToolRoom>().ItemPlacedHere(laser);
+
+            var response = await target.GetResponse("throw laser into rift");
+
+            response.Should().NotContain("sails gracefully into the rift");
+            // The out-of-scope laser must not be deleted from the game.
+            laser.CurrentLocation.Should().Be(GetLocation<ToolRoom>());
+        }
+
+        // Divergence B: once a thrown item's CurrentLocation is null, the command still matched and
+        // the global lookup still returned the singleton, so the loss was narrated a second time.
+        [Test]
+        public async Task ThrowIntoRift_ReThrowingAlreadyLostItem_DoesNotReNarrateLoss()
+        {
+            var target = GetTarget();
+            StartHere<AdminCorridorNorth>();
+            var diary = Take<Diary>();
+
+            // First throw: the held diary really does sail into the rift and leaves play.
+            var first = await target.GetResponse("throw diary into rift");
+            first.Should().Contain("sails gracefully into the rift");
+            diary.CurrentLocation.Should().BeNull();
+            Context.Items.Should().NotContain(diary);
+
+            // Second throw of the now-gone diary must not re-narrate success.
+            var second = await target.GetResponse("throw diary into rift");
+            second.Should().NotContain("sails gracefully into the rift");
+        }
     }
 }

--- a/Planetfall/Location/Kalamontee/Admin/RiftLocationBase.cs
+++ b/Planetfall/Location/Kalamontee/Admin/RiftLocationBase.cs
@@ -14,8 +14,14 @@ internal abstract class RiftLocationBase : LocationWithNoStartingItems
         if (!action.MatchVerb(Verbs.ThrowVerbs) || !action.MatchNounTwo(RiftNouns))
             return await base.RespondToMultiNounInteraction(action, context);
 
-        // What are we throwing? 
-        var itemWeJustLostForever = Repository.GetItem(action.NounOne);
+        // Issue #429: resolve the thrown object from the player's SCOPE (carried or here at the
+        // rift), not a global Repository.GetItem lookup. Keying off the command text alone let the
+        // singleton be found regardless of location, so "throw laser into rift" deleted the laser
+        // from across the map with a false success (a softlock vector, Divergence A), and
+        // re-throwing an already-lost item (CurrentLocation == null, so out of scope) re-narrated
+        // the loss (Divergence B). Gating on the object's presence mirrors the sibling ladder fix
+        // (#297) in AdminCorridor; an out-of-scope noun now falls through to normal routing.
+        var itemWeJustLostForever = Repository.GetItemInScope(action.NounOne, context);
         if (itemWeJustLostForever is null)
             return await base.RespondToMultiNounInteraction(action, context);
 

--- a/UnitTests/IntentMappings/base-mappings.json
+++ b/UnitTests/IntentMappings/base-mappings.json
@@ -113,6 +113,8 @@
     { "inputs": ["throw garlic at mirror"], "verb": "throw", "nounOne": "garlic", "nounTwo": "mirror", "preposition": "at", "originalInput": "throw garlic at mirror" },
     { "inputs": ["place ladder across rift"], "verb": "place", "nounOne": "ladder", "nounTwo": "rift", "preposition": "across", "originalInput": "place ladder across rift" },
     { "inputs": ["put ladder across rift"], "verb": "put", "nounOne": "ladder", "nounTwo": "rift", "preposition": "across", "originalInput": "put ladder across rift" },
+    { "inputs": ["throw diary into rift"], "verb": "throw", "nounOne": "diary", "nounTwo": "rift", "preposition": "into", "originalInput": "throw diary into rift" },
+    { "inputs": ["throw laser into rift"], "verb": "throw", "nounOne": "laser", "nounTwo": "rift", "preposition": "into", "originalInput": "throw laser into rift" },
     { "inputs": ["put flask under spout"], "verb": "put", "nounOne": "flask", "nounTwo": "spout", "preposition": "under", "originalInput": "put flask under spout" },
     { "inputs": ["put trident in boat"], "verb": "put", "nounOne": "trident", "nounTwo": "boat", "preposition": "in", "originalInput": "put trident in boat" },
     { "inputs": ["put bar in boat"], "verb": "put", "nounOne": "bar", "nounTwo": "boat", "preposition": "in", "originalInput": "put bar in boat" },


### PR DESCRIPTION
## What & why

Fixes #429.

The generic **throw-into-rift** handler in `RiftLocationBase.RespondToMultiNounInteraction` matched on the command text (throw-verb + rift-noun) and then resolved the *thrown* object with a repository-wide `Repository.GetItem(action.NounOne)` lookup that ignores `CurrentLocation`. Because the singleton resolves regardless of where it is, this produced two user-visible divergences (both reproduced on prod via the AdventureBreaker harness):

- **Divergence A — softlock vector.** Standing at the rift, `throw laser into rift` "succeeded" and destroyed the laser even though it was in the Mech area — the global lookup found it, `CurrentLocation?.RemoveItem(...)` + `CurrentLocation = null` deleted it, and the game narrated *"…sails gracefully into the rift."* Any item anywhere in the game — including critical-path items — could be removed this way without the player ever touching it.
- **Divergence B — stale narration.** Once a thrown item's `CurrentLocation` is `null`, the command still matched and the global lookup still returned the singleton, so re-throwing an already-lost item re-narrated the loss.

This is the same class of bug that #297 fixed for the *sibling* ladder-bridging handler in `AdminCorridor` ("Thrown item resolved via global `Repository.GetItem` with no 'is it here / do I have it / is it already gone' guard"), but the guard was never applied to this shared throw routine.

## The fix

Resolve the thrown object from the player's **scope** via `Repository.GetItemInScope(action.NounOne, context)` (carried, or here at the rift) instead of a global lookup, and fall through to normal routing when the item isn't in scope. This mirrors the engine's rules used by other player-initiated actions and matches the #297 precedent. It fixes **B** for free, since an already-thrown item (`CurrentLocation == null`, removed from its room/inventory) is no longer in scope.

## Changes

- `Planetfall/Location/Kalamontee/Admin/RiftLocationBase.cs` — swap the global `Repository.GetItem` for `Repository.GetItemInScope`, with a comment documenting the trap.
- `Planetfall.Tests/AdminCorridorTests.cs` — new `ThrowIntoRift` fixture with the two regression tests below.
- `UnitTests/IntentMappings/base-mappings.json` — deterministic `throw diary/laser into rift` TestParser mappings the tests need to reach the multi-noun handler.

## TDD

Per CLAUDE.md, red-before / green-after, using real `Repository` objects:

- **A:** `throw laser into rift` while the laser is in `ToolRoom` → no "sails gracefully into the rift" narration and the laser's `CurrentLocation` is unchanged (not deleted).
- **B:** throw a held diary into the rift (success, leaves play), then re-issue the same command → does **not** re-narrate success.

Both tests fail against the old code for the right reason and pass after the fix.

## Verification

Ran each affected suite separately (no regressions):

- `Planetfall.Tests` — 3086 passed, 0 failed
- `UnitTests` — 1033 passed, 0 failed
- `ZorkOne.Tests` — 1781 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBntuFoL8paDN4o3cpYt1w)_