### PR TITLE
Fix #435: ProjCon Office description drops doubled leading "T"

### DIFF
--- a/Planetfall.Tests/MuralTests.cs
+++ b/Planetfall.Tests/MuralTests.cs
@@ -53,6 +53,19 @@ public class MuralTests : EngineTestsBase
     }
 
     [Test]
+    public async Task ProjConOffice_DescriptionShouldNotStartWithDoubledLetter()
+    {
+        // Regression for #435: the pre-announcement description had a typo ("TThis office...").
+        var target = GetTarget();
+        StartHere<ProjConOffice>();
+
+        var response = await target.GetResponse("look");
+
+        response.Should().Contain("This office looks like a headquarters");
+        response.Should().NotContain("TThis");
+    }
+
+    [Test]
     public void ProjConOffice_MuralShouldBePresent()
     {
         GetTarget();

--- a/Planetfall.Tests/MuralTests.cs
+++ b/Planetfall.Tests/MuralTests.cs
@@ -61,7 +61,10 @@ public class MuralTests : EngineTestsBase
 
         var response = await target.GetResponse("look");
 
-        response.Should().Contain("This office looks like a headquarters");
+        // \b anchors "This" to a word boundary, so the bug ("TThis office...") fails to match while the
+        // correct text matches. This makes the positive assertion catch the regression on its own rather
+        // than resting solely on the NotContain guard below (a plain Contain would pass on "TThis" too).
+        response.Should().MatchRegex(@"\bThis office looks like a headquarters");
         response.Should().NotContain("TThis");
     }
 

--- a/Planetfall/Location/Lawanda/ProjConOffice.cs
+++ b/Planetfall/Location/Lawanda/ProjConOffice.cs
@@ -66,7 +66,7 @@ internal class ProjConOffice : FloydSpecialInteractionLocation
             ? "This office looks like a headquarters of some kind. Exits lead north and east. " +
               "The west wall displays a logo. The mural that previously adorned the south " +
               "wall has slid away, revealing an open doorway to a large elevator!"
-            : "TThis office looks like a headquarters of some kind. Exits lead north and east. The west wall displays a " +
+            : "This office looks like a headquarters of some kind. Exits lead north and east. The west wall displays a " +
               "logo. The south wall is completely covered by a garish mural which clashes with the other decor of the room. ";
     }
 }


### PR DESCRIPTION
## Problem

The ProjCon Office room description (shown on entry and `look` before the cryo announcement) began with a typo: **"TThis office looks like a headquarters..."** — a doubled leading "T".

The `AnnouncmentHasBeenMade == false` branch of `GetContextBasedDescription` in `Planetfall/Location/Lawanda/ProjConOffice.cs` had the literal typo, while the `AnnouncmentHasBeenMade == true` branch correctly started with "This office...". This description is on the critical path — the ProjCon Office is the only route to the Cryo-Elevator — so every player sees it.

Fixes #435.

## Fix

Drop the extra "T" from the pre-announcement string literal.

## Testing (TDD)

- **Red first:** Added `ProjConOffice_DescriptionShouldNotStartWithDoubledLetter` to `Planetfall.Tests/MuralTests.cs` (which already exercises the ProjCon Office description via `look`). It asserts the `look` output contains `"This office looks like a headquarters"` and does **not** contain `"TThis"`. It failed on the `NotContain("TThis")` assertion before the fix.
- **Green after:** The test passes with the fix.
- **No regressions:** Full `Planetfall.Tests` suite passes (3093 passed, 0 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UXoqVK1ar2Nrn3hnFUgKAy

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXoqVK1ar2Nrn3hnFUgKAy)_