### PR TITLE
Fix #438: Mess Hall description reflects the kitchen door's open state

### DIFF
--- a/Planetfall.Tests/MessKitchenDoorTests.cs
+++ b/Planetfall.Tests/MessKitchenDoorTests.cs
@@ -57,4 +57,37 @@ public class MessKitchenDoorTests : EngineTestsBase
 
         target.Context.CurrentLocation.Should().BeOfType<Kitchen>();
     }
+
+    [Test]
+    public async Task Look_MessHall_DescribesDoorAsOpen_WhenKitchenDoorOpen()
+    {
+        // Issue #438: the room description hardcoded "A door to the south is closed" and never consulted
+        // the kitchen door's state, contradicting "examine kitchen door" and the fact that you can walk
+        // south while it is open.
+        var target = GetTarget();
+        var room = Repository.GetLocation<MessHall>();
+        room.Init();
+        Repository.GetItem<KitchenDoor>().IsOpen = true;
+        target.Context.CurrentLocation = room;
+
+        var response = await target.GetResponse("look");
+
+        response.Should().Contain("A door to the south is open");
+        response.Should().NotContain("A door to the south is closed");
+    }
+
+    [Test]
+    public async Task Look_MessHall_DescribesDoorAsClosed_WhenKitchenDoorClosed()
+    {
+        // Issue #438: the closed-state description must still render when the door is shut.
+        var target = GetTarget();
+        var room = Repository.GetLocation<MessHall>();
+        room.Init();
+        Repository.GetItem<KitchenDoor>().IsOpen = false;
+        target.Context.CurrentLocation = room;
+
+        var response = await target.GetResponse("look");
+
+        response.Should().Contain("A door to the south is closed");
+    }
 }

--- a/Planetfall/Location/Kalamontee/MessHall.cs
+++ b/Planetfall/Location/Kalamontee/MessHall.cs
@@ -43,9 +43,11 @@ internal class MessHall : LocationBase
 
     protected override string GetContextBasedDescription(IContext context)
     {
+        // Interpolate the kitchen door's actual state (issue #438). Hardcoding "closed" contradicted
+        // "examine kitchen door" and the fact that you can walk south while it is open. Mirrors RecArea.
         return
             "This is a large hall lined with tables and benches. An opening to the north leads back to the corridor. " +
-            "A door to the south is closed. Next to the door is a small slot. ";
+            $"A door to the south is {(GetItem<KitchenDoor>().IsOpen ? "open" : "closed")}. Next to the door is a small slot. ";
     }
 
     public override Task<string> AfterEnterLocation(IContext context, ILocation previousLocation,


### PR DESCRIPTION
## Summary

Fixes #438. The Mess Hall room description hardcoded `A door to the south is closed.` and never consulted the kitchen door's actual state. While the door was open (after sliding the kitchen access card), `look` contradicted both `examine kitchen door` (which reported "open") and the fact that the player could walk south.

## Root cause

`Planetfall/Location/Kalamontee/MessHall.cs` — `GetContextBasedDescription` returned a constant string with `closed` baked in, so `KitchenDoor.IsOpen` was ignored. The sibling room `RecArea.cs` already does this correctly by interpolating the door state.

## Fix

Interpolate the kitchen door's state, mirroring the `RecArea` pattern:

```csharp
$"A door to the south is {(GetItem<KitchenDoor>().IsOpen ? "open" : "closed")}. Next to the door is a small slot. ";
```

`GetItem<KitchenDoor>()` is already used elsewhere in this file for the movement gating, so no new dependency is introduced.

## Tests (TDD)

Added two tests to `Planetfall.Tests/MessKitchenDoorTests.cs`:

- `Look_MessHall_DescribesDoorAsOpen_WhenKitchenDoorOpen` — red before the fix (room said "closed" while the door was open), green after.
- `Look_MessHall_DescribesDoorAsClosed_WhenKitchenDoorClosed` — guards the closed-state description.

Verified the open-state test fails for the right reason before the change, both pass after, and the full `Planetfall.Tests` suite (3094 tests) is green with no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UXUzmjVYVJFGjntDc5u5Mi

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXUzmjVYVJFGjntDc5u5Mi)_