### PR TITLE
Fix #431: unlock padlock with key guards on Locked state

### DIFF
--- a/Planetfall.Tests/MessHallPadlockedDoorTests.cs
+++ b/Planetfall.Tests/MessHallPadlockedDoorTests.cs
@@ -43,6 +43,24 @@ public class MessHallPadlockedDoorTests : EngineTestsBase
     }
 
     [Test]
+    public async Task UnlockPadlockWithKey_Again_SaysAlreadyOpen()
+    {
+        var target = GetTarget();
+        target.Context.CurrentLocation = Repository.GetLocation<MessCorridor>();
+        target.Context.ItemPlacedHere<Key>();
+
+        var first = await target.GetResponse("unlock padlock with key");
+        first.Should().Contain("springs open");
+        Repository.GetItem<Padlock>().Locked.Should().BeFalse();
+
+        // Issuing it again must not re-narrate "springs open" — the padlock is already unlocked.
+        // The multi-noun path must guard on Locked state, matching the simple-interaction path.
+        var second = await target.GetResponse("unlock padlock with key");
+        second.Should().Contain("The padlock is already open.");
+        second.Should().NotContain("springs open");
+    }
+
+    [Test]
     public async Task UnlockDoorWithKey_UnlocksPadlock()
     {
         var target = GetTarget();

--- a/Planetfall/Item/Kalamontee/Padlock.cs
+++ b/Planetfall/Item/Kalamontee/Padlock.cs
@@ -75,6 +75,11 @@ public class Padlock : ItemBase, ICanBeTakenAndDropped
 
         if (match)
         {
+            // Guard on Locked state, not just the command phrasing — otherwise "unlock padlock with key"
+            // re-narrates "springs open" on an already-open padlock. Mirrors the simple-interaction path.
+            if (!Locked)
+                return new PositiveInteractionResult("The padlock is already open. ");
+
             Locked = false;
             Repository.GetItem<Floyd>().CommentOnAction(FloydPrompts.PadlockUnlocked, context);
             return new PositiveInteractionResult("The padlock springs open. ");


### PR DESCRIPTION
## Summary

Fixes #431. `unlock padlock with key` re-narrated "The padlock springs open." even when the padlock was already unlocked, contradicting the class's own simple-interaction path which correctly says "The padlock is already open." for the same state.

## Root cause

In `Planetfall/Item/Kalamontee/Padlock.cs`, the multi-noun handler (`RespondToMultiNounInteraction`) keyed off the command matching (verb + padlock + key + preposition) rather than the padlock's `Locked` state. It flipped `Locked = false` and returned "springs open" unconditionally on every match — so identical game state produced two different responses depending only on phrasing. This is anti-pattern #2 from CLAUDE.md ("Matching on command text instead of object state").

## Fix

Add the same `!Locked` short-circuit the simple-interaction path already uses, before flipping state:

```csharp
if (match)
{
    if (!Locked)
        return new PositiveInteractionResult("The padlock is already open. ");

    Locked = false;
    Repository.GetItem<Floyd>().CommentOnAction(FloydPrompts.PadlockUnlocked, context);
    return new PositiveInteractionResult("The padlock springs open. ");
}
```

## Testing (TDD)

Added `UnlockPadlockWithKey_Again_SaysAlreadyOpen` to `Planetfall.Tests/MessHallPadlockedDoorTests.cs`, using real `Repository` objects with the key in inventory and the padlock present:

- First `unlock padlock with key` → "springs open", `Locked == false`.
- Second `unlock padlock with key` → "The padlock is already open." (not "springs open").

The test fails before the fix (returns "springs open" the second time) and passes after. All 3093 Planetfall.Tests pass with no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RGN8cGpvGE1YcoxqvWhhTb)_