### PR TITLE
Fix #430: Cryo-Elevator button gates on its noun, not the push verb alone

### DIFF
--- a/Planetfall.Tests/CryoElevatorButtonTests.cs
+++ b/Planetfall.Tests/CryoElevatorButtonTests.cs
@@ -95,4 +95,46 @@ public class CryoElevatorButtonTests : EngineTestsBase
         result.Should().NotBeNull();
         result!.InteractionMessage.Should().Contain("Nothing happens");
     }
+
+    [Test]
+    public void PushWall_DoesNotOperateElevator()
+    {
+        // The button must gate on its own noun. "push wall" (an unrelated noun) should NOT
+        // operate the elevator — it should fall through to the narrator via NoNounMatchInteractionResult.
+        _button.CountdownActive.Should().BeFalse();
+
+        var action = new SimpleIntent { Verb = "push", Noun = "wall" };
+        var result = _button.RespondToSimpleInteraction(action, _context, null!, null!).Result;
+
+        result.Should().BeOfType<NoNounMatchInteractionResult>();
+        _button.CountdownActive.Should().BeFalse("pushing the wall must not start the elevator countdown");
+    }
+
+    [Test]
+    public void PushButton_StartsCountdown()
+    {
+        // Pushing the button itself must still work (behavior preserved).
+        _button.CountdownActive.Should().BeFalse();
+
+        var action = new SimpleIntent { Verb = "push", Noun = "button" };
+        var result = _button.RespondToSimpleInteraction(action, _context, null!, null!).Result;
+
+        result.Should().BeOfType<PositiveInteractionResult>();
+        result!.InteractionMessage.Should().Contain("elevator begins to move downward");
+        _button.CountdownActive.Should().BeTrue();
+    }
+
+    [Test]
+    public void PushWall_AfterArrival_DoesNotKillPlayer()
+    {
+        // After arrival, only "push button" triggers the hilarious death. "push wall" must not.
+        _button.AlreadyArrived = true;
+        _button.CountdownActive = false;
+
+        var action = new SimpleIntent { Verb = "push", Noun = "wall" };
+        var result = _button.RespondToSimpleInteraction(action, _context, null!, null!).Result;
+
+        result.Should().BeOfType<NoNounMatchInteractionResult>();
+        result.Should().NotBeOfType<DeathInteractionResult>();
+    }
 }

--- a/Planetfall/Item/Lawanda/CryoElevator/CryoElevatorButton.cs
+++ b/Planetfall/Item/Lawanda/CryoElevator/CryoElevatorButton.cs
@@ -17,7 +17,10 @@ public class CryoElevatorButton : ItemBase, ITurnBasedActor
     public override Task<InteractionResult?> RespondToSimpleInteraction(
         SimpleIntent action, IContext context, IGenerationClient client, IItemProcessorFactory itemProcessorFactory)
     {
-        if (!action.MatchVerb(Verbs.PushVerbs))
+        // Gate on the button's own noun, not just the verb. Without the noun check, a stray
+        // "push wall" / "push floor" / "push door" would operate the elevator (and, after arrival,
+        // route any push to the instant-death ending). Mirror the sibling buttons' noun guard.
+        if (!action.MatchVerb(Verbs.PushVerbs) || !action.MatchNounAndAdjective(NounsForMatching))
             return base.RespondToSimpleInteraction(action, context, client, itemProcessorFactory);
 
         // Hilarious death if player pushes button after arriving


### PR DESCRIPTION
## Problem

The Cryo-Elevator button (`CryoElevatorButton`) responded to **any** push-verb command regardless of the noun. Because `CryoElevatorButton.RespondToSimpleInteraction` gated only on the verb (`if (!action.MatchVerb(Verbs.PushVerbs))`) and never checked the noun, a stray `push wall` / `push floor` / `push door` operated the elevator and started the escape sequence.

Worse, once the elevator had arrived (`AlreadyArrived == true`), the same handler routed **any** push — `push wall`, `push door`, anything — to the "hilarious death" ending. One move from winning Planetfall, a stray push was an instant game over.

## Root cause

`Planetfall/Item/Lawanda/CryoElevator/CryoElevatorButton.cs` had no `MatchNoun` / `MatchNounAndAdjective` check, so every push verb on every noun entered the button logic. The sibling buttons in the same game (`RedButton` / `WhiteButton` / `BlackButton`) all guard correctly on their own noun.

## Fix

Add a `MatchNounAndAdjective(NounsForMatching)` guard alongside the existing verb check, mirroring the sibling buttons:

```csharp
if (!action.MatchVerb(Verbs.PushVerbs) || !action.MatchNounAndAdjective(NounsForMatching))
    return base.RespondToSimpleInteraction(action, context, client, itemProcessorFactory);
```

Now only `push button` operates the elevator; unrelated nouns fall through to the narrator via `NoNounMatchInteractionResult`.

## Tests (TDD)

Added to `Planetfall.Tests/CryoElevatorButtonTests.cs`:

- **`PushWall_DoesNotOperateElevator`** — `push wall` returns `NoNounMatchInteractionResult` and does **not** set `CountdownActive`. *(red before, green after)*
- **`PushButton_StartsCountdown`** — `push button` still starts the countdown (behavior preserved).
- **`PushWall_AfterArrival_DoesNotKillPlayer`** — with `AlreadyArrived == true`, `push wall` returns `NoNounMatchInteractionResult`, not `DeathInteractionResult`. *(red before, green after)*

The two `push wall` tests fail before the fix (getting `PositiveInteractionResult` / `DeathInteractionResult`) and pass after. The full `Planetfall.Tests` suite (3095 tests) stays green.

Fixes #430

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012xHb9RPsE7taRX54Sa3UaX)_