### PR TITLE
Fix #437: laser depression is a single slot, refusing a second battery

### DIFF
--- a/Planetfall.Tests/LaserTests.cs
+++ b/Planetfall.Tests/LaserTests.cs
@@ -1398,6 +1398,65 @@ public class LaserTests : EngineTestsBase
 
     #endregion
 
+    #region Battery Capacity Tests
+
+    [Test]
+    public async Task PutSecondBattery_WhileOldStillInside_IsRefused()
+    {
+        // Issue #437: the depression holds a single battery. Inserting the fresh battery WITHOUT
+        // first removing the dead one must be refused - otherwise both end up in the slot and firing
+        // keeps drawing from the first-inserted (dead) battery, which reads as "the fresh one is dead
+        // too." ContainerBase.SpaceForItems defaults to 2 and each battery is Size 1, so without a
+        // single-slot override the laser silently admitted the second battery (1 + 1 <= 2).
+        var target = GetTarget();
+        StartHere<ToolRoom>();
+        Take<Laser>();
+        var laser = GetItem<Laser>();
+        var oldBattery = GetItem<OldBattery>();
+        var freshBattery = Take<FreshBattery>();
+
+        // The laser starts holding exactly the old battery.
+        laser.Items.Should().ContainSingle().Which.Should().Be(oldBattery);
+
+        var response = await target.GetResponse("put fresh in laser");
+
+        // The extra battery is refused...
+        response.Should().Contain("already a battery");
+        response.Should().NotContain("resting in the depression");
+        // ...the depression still holds only the old battery, and the fresh one stays in hand.
+        laser.Items.Should().ContainSingle().Which.Should().Be(oldBattery);
+        laser.Items.Should().NotContain(freshBattery);
+        target.Context.Items.Should().Contain(freshBattery);
+    }
+
+    [Test]
+    public async Task SwapBattery_RemoveOldThenInsertFresh_LeavesOnlyFresh()
+    {
+        // Issue #437: the single-slot limit must not break the intended swap. With the dead battery
+        // removed first, the fresh one drops neatly into the now-empty depression.
+        var target = GetTarget();
+        // ToolRoom avoids DeckNine's random actor spawning (Ambassador places slime which also
+        // responds to "remove"), matching the sibling RemoveBattery_MultipleTimes_CanReinsert test.
+        StartHere<ToolRoom>();
+        Take<Laser>();
+        var laser = GetItem<Laser>();
+        var oldBattery = GetItem<OldBattery>();
+
+        // Remove the dead battery first - only the old battery is in scope at this point.
+        await target.GetResponse("remove battery");
+        laser.Items.Should().NotContain(oldBattery);
+        laser.Items.Should().BeEmpty();
+
+        // Now bring in the fresh battery and insert it into the empty depression.
+        var freshBattery = Take<FreshBattery>();
+        var response = await target.GetResponse("put fresh in laser");
+
+        response.Should().Contain("resting in the depression");
+        laser.Items.Should().ContainSingle().Which.Should().Be(freshBattery);
+    }
+
+    #endregion
+
     #region Wrong Item Tests
 
     [Test]

--- a/Planetfall.Tests/LaserTests.cs
+++ b/Planetfall.Tests/LaserTests.cs
@@ -1420,9 +1420,9 @@ public class LaserTests : EngineTestsBase
 
         var response = await target.GetResponse("put fresh in laser");
 
-        // The extra battery is refused...
+        // The extra battery is refused (not admitted with the success message)...
         response.Should().Contain("already a battery");
-        response.Should().NotContain("resting in the depression");
+        response.Should().NotContain("now resting in the depression, attached to the laser");
         // ...the depression still holds only the old battery, and the fresh one stays in hand.
         laser.Items.Should().ContainSingle().Which.Should().Be(oldBattery);
         laser.Items.Should().NotContain(freshBattery);
@@ -1453,6 +1453,13 @@ public class LaserTests : EngineTestsBase
 
         response.Should().Contain("resting in the depression");
         laser.Items.Should().ContainSingle().Which.Should().Be(freshBattery);
+
+        // End-to-end: after the correct swap the laser fires from the live fresh battery (a beam),
+        // not the removed dead one (which would "Click."). This guards the issue's headline symptom -
+        // that firing kept drawing from the first-inserted dead battery.
+        var shootResponse = await target.GetResponse("shoot laser");
+        shootResponse.Should().Contain("beam of light");
+        shootResponse.Should().NotContain("Click");
     }
 
     #endregion

--- a/Planetfall/Item/Kalamontee/Mech/Laser.cs
+++ b/Planetfall/Item/Kalamontee/Mech/Laser.cs
@@ -37,6 +37,21 @@ public class Laser : ContainerBase, ICanBeTakenAndDropped, ICanBeExamined, ITurn
 
     public override Type[] CanOnlyHoldTheseTypes => [typeof(BatteryBase)];
 
+    // Issue #437: the depression is a SINGLE slot. ContainerBase.SpaceForItems defaults to 2 and each
+    // battery is Size 1, so without this override the laser silently admitted a second battery
+    // (1 + 1 <= 2). A player who inserts the fresh battery without first removing the dead one then
+    // ends up with both in the slot, and TryFireLaser keeps drawing from Items.FirstOrDefault() - the
+    // first-inserted (dead) battery - so firing yields "Click." as if the fresh battery were dead too.
+    // One slot forces the correct swap (remove the old battery, then insert the fresh one).
+    protected override int SpaceForItems => 1;
+
+    // With the depression full, refuse the extra battery by asserting the occupancy (mirrors the spool
+    // reader, issue #417). This is safe here because a battery is always Size 1: HaveRoomForItem can
+    // only fail for a battery when one is already resting in the slot. The type check runs before the
+    // room check (PutProcessor, issue #417), so a non-battery still gets the "won't fit" message below.
+    public override string NoRoomMessage =>
+        "There's already a battery resting in the laser's depression. ";
+
     // The original refuses a non-battery by naming the item and the depression it won't go into
     // (LASER-F, comptwo.zil:2686). Without this the type rejection has no message and falls through
     // to the AI narrator, which answers a deterministic refusal with a generated one (and a blank


### PR DESCRIPTION
## Summary

Fixes #437. The Planetfall laser's battery depression is meant to hold a single battery, but it silently accepted a **second** one. If the player inserted the fresh battery without first removing the dead one, the depression ended up holding both, and firing kept drawing from the first-inserted (dead) battery — so the fresh battery was ignored and the laser fired `Click.` as if the fresh battery were dead too.

## Root cause

`ContainerBase.SpaceForItems` defaults to **2** (`GameEngine/Item/ContainerBase.cs:19`) and each battery is `Size => 1` (`BatteryBase.cs`). `Laser` type-locked its depression to `BatteryBase` but never capped the count, so `HaveRoomForItem` computed `1 + 1 = 2 <= 2 → true` and admitted the second battery. `TryFireLaser` then reads `Items.FirstOrDefault()` — the first-inserted (dead) battery — so a "replace without removing" swap silently failed.

## Fix

`Planetfall/Item/Kalamontee/Mech/Laser.cs`:

- `protected override int SpaceForItems => 1;` — the depression is now a true single slot, so a second battery is refused and the player is nudged to swap correctly (remove the dead battery, then insert the fresh one).
- Added a laser-specific `NoRoomMessage` ("There's already a battery resting in the laser's depression.") mirroring the spool reader (issue #417). This is safe because a battery is always `Size 1`, so `HaveRoomForItem` can only fail when one is already in the slot. The type check runs before the room check in `PutProcessor` (issue #417), so a non-battery still gets its existing "won't fit in the laser's depression" refusal.

## Testing (TDD)

Added two deterministic tests in `Planetfall.Tests/LaserTests.cs` using real `Repository` objects (new `Battery Capacity Tests` region):

- `PutSecondBattery_WhileOldStillInside_IsRefused` — holding the laser with the old battery inside, `put fresh in laser` is refused; the depression still holds exactly the old battery and the fresh one stays in hand. **Red before the fix (the second battery was admitted), green after.**
- `SwapBattery_RemoveOldThenInsertFresh_LeavesOnlyFresh` — `remove battery` then `put fresh in laser` leaves only the fresh battery, confirming the single-slot limit preserves the intended swap.

Verification (each project run separately per CLAUDE.md):
- Full `Planetfall.Tests` suite: **3094 passed**.
- Shared put/room logic `UnitTests` → `PutProcessorTests`: **15 passed**.

## Notes

Sibling of #434 (same item, different root cause: hardcoded examine text vs. capacity). The `planetfall-source/` ZIL checkout is not present in this environment, so no ZIL `file:line` citation is included; the fix restores the intended single-slot behavior described in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014gfcaqRpnwiGgv8xaJkydi

---
_Generated by [Claude Code](https://claude.ai/code/session_014gfcaqRpnwiGgv8xaJkydi)_