### PR TITLE
Fix #433: Miniaturization Booth keyboard gates on its noun, not the type/press/push verb alone

### DIFF
--- a/Planetfall.Tests/MiniaturizationBoothTests.cs
+++ b/Planetfall.Tests/MiniaturizationBoothTests.cs
@@ -1,5 +1,7 @@
 using System.Text;
 using FluentAssertions;
+using Model.Intent;
+using Model.Interaction;
 using Planetfall.Item.Kalamontee.Admin;
 using Planetfall.Item.Kalamontee.Mech.FloydPart;
 using Planetfall.Item.Lawanda.Lab;
@@ -177,6 +179,69 @@ public class MiniaturizationBoothTests : EngineTestsBase
         response.Should().Contain("Ooops! You seem to have transported yourself into an active sector of the computer");
         response.Should().Contain("fried by powerful electric currents");
         response.Should().Contain("You have died");
+    }
+
+    // Issue #433: the keyboard handler used to fire on the type/press/push/key verb alone, ignoring
+    // the noun. "push slot" must address the slot (fall through to base), NOT the booth's keyboard
+    // logic — so it must not emit the "not activated" or "numeric keys" booth messages.
+    [Test]
+    public async Task PushSlot_NotActivated_DoesNotHitKeyboardLogic()
+    {
+        var target = GetTarget();
+        StartHere<MiniaturizationBooth>();
+
+        GetLocation<MiniaturizationBooth>().IsEnabled.Should().BeFalse();
+
+        var response = await target.GetResponse("push slot");
+
+        response.Should().NotContain("Internal computer repair booth not activated");
+        response.Should().NotContain("The keyboard only has numeric keys");
+    }
+
+    // Issue #433: "press wall" (an unrelated noun) must fall through to the narrator, not the booth
+    // keyboard logic. Called directly on the location because the test parser doesn't recognize "wall"
+    // as a noun; this exercises the location's routing regardless of the parser.
+    [Test]
+    public async Task PressWall_NotActivated_FallsThroughToNarrator()
+    {
+        var target = GetTarget();
+        var booth = StartHere<MiniaturizationBooth>();
+        booth.IsEnabled.Should().BeFalse();
+
+        var action = new SimpleIntent { Verb = "press", Noun = "wall" };
+        var result = await booth.RespondToSimpleInteraction(action, target.Context, null!, null!);
+
+        // Before the fix this returned the booth's "not activated" PositiveInteractionResult; the noun
+        // guard now lets an unrelated noun fall through to a NoNounMatch (the narrator handles it).
+        result.Should().BeOfType<NoNounMatchInteractionResult>();
+    }
+
+    // Issue #433: the noun guard must not break operating the keyboard itself. "press keyboard" still
+    // reaches the keyboard logic (reporting the booth isn't activated when it isn't).
+    [Test]
+    public async Task PressKeyboard_NotActivated_StillReachesKeyboardLogic()
+    {
+        var target = GetTarget();
+        StartHere<MiniaturizationBooth>();
+
+        var response = await target.GetResponse("press keyboard");
+
+        response.Should().Contain("Internal computer repair booth not activated");
+    }
+
+    // Issue #433: when the booth is enabled, pressing the keyboard with no numeric key still reaches
+    // the keyboard logic and reports that only numeric keys exist.
+    [Test]
+    public async Task PressKeyboard_Activated_ReportsNumericKeysOnly()
+    {
+        var target = GetTarget();
+        StartHere<MiniaturizationBooth>();
+        Take<MiniaturizationAccessCard>();
+
+        await target.GetResponse("slide miniaturization card through slot");
+        var response = await target.GetResponse("press keyboard");
+
+        response.Should().Contain("The keyboard only has numeric keys");
     }
 
     // Issue #399: sliding the card activates the booth for only 30 turns in the original

--- a/Planetfall.Tests/MiniaturizationBoothTests.cs
+++ b/Planetfall.Tests/MiniaturizationBoothTests.cs
@@ -1,7 +1,11 @@
 using System.Text;
 using FluentAssertions;
+using GameEngine.Item;
+using Model.AIGeneration;
+using Model.AIParsing;
 using Model.Intent;
 using Model.Interaction;
+using Moq;
 using Planetfall.Item.Kalamontee.Admin;
 using Planetfall.Item.Kalamontee.Mech.FloydPart;
 using Planetfall.Item.Lawanda.Lab;
@@ -209,11 +213,33 @@ public class MiniaturizationBoothTests : EngineTestsBase
         booth.IsEnabled.Should().BeFalse();
 
         var action = new SimpleIntent { Verb = "press", Noun = "wall" };
-        var result = await booth.RespondToSimpleInteraction(action, target.Context, null!, null!);
+        // Pass a real client/factory (not null) so the fall-through into base -> item processors stays
+        // exercised even if the booth later gains items whose routing dereferences them.
+        var factory = new ItemProcessorFactory(Mock.Of<IAITakeAndAndDropParser>());
+        var result = await booth.RespondToSimpleInteraction(action, target.Context, Mock.Of<IGenerationClient>(), factory);
 
         // Before the fix this returned the booth's "not activated" PositiveInteractionResult; the noun
         // guard now lets an unrelated noun fall through to a NoNounMatch (the narrator handles it).
         result.Should().BeOfType<NoNounMatchInteractionResult>();
+    }
+
+    // Issue #433: the shadowing is worst when the booth IS activated - the old verb-only gate answered
+    // "push slot" with "The keyboard only has numeric keys." (past the !IsEnabled check), burying the
+    // booth's own slot. The noun guard must reject the non-keyboard noun before that point too.
+    [Test]
+    public async Task PushSlot_Activated_DoesNotHitKeyboardLogic()
+    {
+        var target = GetTarget();
+        StartHere<MiniaturizationBooth>();
+        Take<MiniaturizationAccessCard>();
+
+        await target.GetResponse("slide miniaturization card through slot");
+        GetLocation<MiniaturizationBooth>().IsEnabled.Should().BeTrue();
+
+        var response = await target.GetResponse("push slot");
+
+        response.Should().NotContain("The keyboard only has numeric keys");
+        response.Should().NotContain("Internal computer repair booth not activated");
     }
 
     // Issue #433: the noun guard must not break operating the keyboard itself. "press keyboard" still

--- a/Planetfall/Location/Lawanda/MiniaturizationBooth.cs
+++ b/Planetfall/Location/Lawanda/MiniaturizationBooth.cs
@@ -50,12 +50,17 @@ internal class MiniaturizationBooth : LocationBase, ICardActivatedDevice
             "and next to it a keyboard with numeric keys. The exit is to the north. ";
     }
 
+    // The keyboard's scenery nouns (issue #315). Single source of truth: both the examinable scenery
+    // and the keypress noun-guard (issue #433) match against this so they can't drift apart.
+    private static readonly string[] KeyboardNouns =
+        ["keyboard", "numeric keyboard", "keypad", "keys", "numeric keys"];
+
     // The keyboard is described in the room prose but is not a discrete game object (it's scenery the
     // booth handles via the type/press verbs above). Without this, "examine keyboard" fell through to
     // the narrator, which falsely told the player the keyboard wasn't here (issue #315).
     protected override IReadOnlyList<SceneryItem> Scenery =>
     [
-        new(["keyboard", "numeric keyboard", "keypad", "keys", "numeric keys"],
+        new(KeyboardNouns,
             "It's a simple numeric keypad, its ten keys numbered zero through nine. ",
             "The keyboard is mounted firmly to the wall. ")
     ];
@@ -63,7 +68,12 @@ internal class MiniaturizationBooth : LocationBase, ICardActivatedDevice
     public override async Task<InteractionResult> RespondToSimpleInteraction(SimpleIntent action, IContext context,
         IGenerationClient client, IItemProcessorFactory itemProcessorFactory)
     {
-        if (action.MatchVerb(Verbs.TypeVerbs.Union(["press", "push", "key"]).ToArray()))
+        // Issue #433: gate on the noun, not the verb alone. Without this, "push slot" / "press wall"
+        // (any type/press/push/key verb on any noun) hit the keyboard logic instead of the actual noun,
+        // shadowing the booth's own slot. Only operate the keyboard when the noun is the keyboard itself
+        // or a numeric key (e.g. "type 384"); anything else falls through to the noun/narrator.
+        if (action.MatchVerb(Verbs.TypeVerbs.Union(["press", "push", "key"]).ToArray())
+            && (action.MatchNoun(KeyboardNouns) || action.Noun.ToInteger().HasValue))
         {
             if (!IsEnabled)
                 return new PositiveInteractionResult("A recording says \"Internal computer repair booth not activated.\"");

--- a/Planetfall/Location/Lawanda/MiniaturizationBooth.cs
+++ b/Planetfall/Location/Lawanda/MiniaturizationBooth.cs
@@ -68,17 +68,18 @@ internal class MiniaturizationBooth : LocationBase, ICardActivatedDevice
     public override async Task<InteractionResult> RespondToSimpleInteraction(SimpleIntent action, IContext context,
         IGenerationClient client, IItemProcessorFactory itemProcessorFactory)
     {
-        // Issue #433: gate on the noun, not the verb alone. Without this, "push slot" / "press wall"
-        // (any type/press/push/key verb on any noun) hit the keyboard logic instead of the actual noun,
-        // shadowing the booth's own slot. Only operate the keyboard when the noun is the keyboard itself
-        // or a numeric key (e.g. "type 384"); anything else falls through to the noun/narrator.
-        if (action.MatchVerb(Verbs.TypeVerbs.Union(["press", "push", "key"]).ToArray())
-            && (action.MatchNoun(KeyboardNouns) || action.Noun.ToInteger().HasValue))
+        if (action.MatchVerb(Verbs.TypeVerbs.Union(["press", "push", "key"]).ToArray()))
         {
+            // Issue #433: gate on the noun, not the verb alone. Without this, "push slot" / "press wall"
+            // (a keypress verb on any noun) hit the keyboard logic instead of the actual noun, shadowing
+            // the booth's own slot. Only operate the keyboard when the noun is the keyboard itself or a
+            // numeric key (e.g. "type 384"); anything else falls through to the noun/narrator below.
+            var keyPress = action.Noun.ToInteger();
+            if (!action.MatchNoun(KeyboardNouns) && !keyPress.HasValue)
+                return await base.RespondToSimpleInteraction(action, context, client, itemProcessorFactory);
+
             if (!IsEnabled)
                 return new PositiveInteractionResult("A recording says \"Internal computer repair booth not activated.\"");
-
-            var keyPress = action.Noun.ToInteger();
 
             if (keyPress.HasValue)
             {


### PR DESCRIPTION
## Problem

`MiniaturizationBooth.RespondToSimpleInteraction` fired the keyboard handler on any `type` / `press` / `push` / `key` verb **regardless of the noun**. So `push slot` and `press wall` were treated as operating the numeric keyboard, emitting the booth's "Internal computer repair booth not activated." / "The keyboard only has numeric keys." messages instead of addressing the actual noun — and it could shadow the booth's own slot item entirely.

This is the same noun-guard omission that was fixed for the sibling Cryo-Elevator button (#430) — a different item/room, identical shape.

## Root cause

The gate checked the verb only:

```csharp
if (action.MatchVerb(Verbs.TypeVerbs.Union(["press", "push", "key"]).ToArray()))
```

There was no check that `action.Noun` referred to the keyboard, so any push/press/type verb on any noun entered the block.

## Fix

Gate on the noun as well. The keyboard is scenery (issue #315) rather than a discrete item, so match its scenery nouns explicitly — **or** a numeric key:

```csharp
if (action.MatchVerb(Verbs.TypeVerbs.Union(["press", "push", "key"]).ToArray())
    && (action.MatchNoun(KeyboardNouns) || action.Noun.ToInteger().HasValue))
```

The keyboard-noun **OR** numeric guard is required: the number-typing path carries the digit as the noun (`type 384` → `Noun` `"384"`), so a keyboard-only guard would have broken the teleport. Unrelated nouns (`push slot`, `press wall`) now fall through to the actual noun / narrator.

Also hoisted the keyboard scenery nouns into a single `KeyboardNouns` constant so the examinable scenery (#315) and the keypress guard share one source of truth and can't drift.

## TDD

Following the repo's mandatory TDD-for-bugfixes rule, added to `Planetfall.Tests/MiniaturizationBoothTests.cs`:

- `PushSlot_NotActivated_DoesNotHitKeyboardLogic` — `push slot` no longer emits the booth keyboard messages (**red** before, **green** after).
- `PressWall_NotActivated_FallsThroughToNarrator` — `press wall` returns `NoNounMatchInteractionResult` instead of the booth's "not activated" result (**red** before, **green** after). Called directly on the location because the test parser doesn't recognize "wall" as a noun.
- `PressKeyboard_NotActivated_StillReachesKeyboardLogic` and `PressKeyboard_Activated_ReportsNumericKeysOnly` — guard the preserved keyboard behavior.

Existing coverage (`type 384` teleport, `type 5` / `press 7` / `key 3` death, 30-turn expiry) continues to exercise the number path.

## Verification

Full `Planetfall.Tests` suite: **3102 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016jiwi1Zjw5tKbkHjtaoi2m)_