### PR TITLE
Fix #436: Admin Corridor South no longer swallows every two-noun command when the magnet is on the floor

### DIFF
--- a/Planetfall.Tests/AdminCorridorSouthTests.cs
+++ b/Planetfall.Tests/AdminCorridorSouthTests.cs
@@ -1,4 +1,7 @@
 using FluentAssertions;
+using Model.AIGeneration;
+using Model.Interface;
+using Moq;
 using Planetfall.Item.Feinstein;
 using Planetfall.Item.Kalamontee.Admin;
 using Planetfall.Item.Kalamontee.Mech;
@@ -93,8 +96,17 @@ public class AdminCorridorSouthTests : EngineTestsBase
         Context.HasItem<Magnet>().Should().BeFalse();
         GetItem<Magnet>().CurrentLocation.Should().Be(GetLocation<AdminCorridorSouth>());
 
+        // A genuinely magnet-unrelated two-noun command. The brush (size 2) can't fit the Patrol
+        // uniform's one-slot pocket, so the normal PutProcessor path answers "There's no room." -
+        // exactly the control the issue documented while the magnet was still held. Asserting that
+        // positive outcome (not merely the absence of the bar message) proves the command is really
+        // routed to normal handling, and would fail if it were swallowed some other wrong way.
+        Take<Brush>();
+        Take<PatrolUniform>();
+
         var response = await target.GetResponse("put brush in uniform");
 
+        response.Should().Contain("There's no room");
         response.Should().NotContain("You don't have the curved metal bar");
     }
 
@@ -114,6 +126,54 @@ public class AdminCorridorSouthTests : EngineTestsBase
         response.Should().Contain("You don't have the curved metal bar");
         Context.HasItem<Key>().Should().BeFalse();
         GetLocation<AdminCorridorSouth>().HasTakenTheKey.Should().BeFalse();
+    }
+
+    // Issue #436 review follow-up: the glint-of-light daemon now rolls via the injectable
+    // IRandomChooser instead of Random.Shared (CLAUDE.md's randomness rule), so its 1-in-3 behavior
+    // is deterministic under test. A successful roll shows the glint hint...
+    [Test]
+    public async Task Act_WhenGlintRollSucceeds_ShowsGlintOfLight()
+    {
+        GetTarget();
+        var room = GetLocation<AdminCorridorSouth>();
+        var mockChooser = new Mock<IRandomChooser>();
+        mockChooser.Setup(r => r.RollDiceSuccess(3)).Returns(true);
+        room.Chooser = mockChooser.Object;
+
+        var result = await room.Act(Context, Mock.Of<IGenerationClient>());
+
+        result.Should().Contain("glint of light");
+    }
+
+    // ...and a failed roll stays silent.
+    [Test]
+    public async Task Act_WhenGlintRollFails_StaysSilent()
+    {
+        GetTarget();
+        var room = GetLocation<AdminCorridorSouth>();
+        var mockChooser = new Mock<IRandomChooser>();
+        mockChooser.Setup(r => r.RollDiceSuccess(3)).Returns(false);
+        room.Chooser = mockChooser.Object;
+
+        var result = await room.Act(Context, Mock.Of<IGenerationClient>());
+
+        result.Should().BeEmpty();
+    }
+
+    // Once the key is discovered or taken, the daemon is dormant regardless of the roll.
+    [Test]
+    public async Task Act_AfterKeyTaken_StaysSilentEvenOnSuccessfulRoll()
+    {
+        GetTarget();
+        var room = GetLocation<AdminCorridorSouth>();
+        room.HasTakenTheKey = true;
+        var mockChooser = new Mock<IRandomChooser>();
+        mockChooser.Setup(r => r.RollDiceSuccess(3)).Returns(true);
+        room.Chooser = mockChooser.Object;
+
+        var result = await room.Act(Context, Mock.Of<IGenerationClient>());
+
+        result.Should().BeEmpty();
     }
 
     [Test]

--- a/Planetfall.Tests/AdminCorridorSouthTests.cs
+++ b/Planetfall.Tests/AdminCorridorSouthTests.cs
@@ -78,6 +78,44 @@ public class AdminCorridorSouthTests : EngineTestsBase
         GetLocation<AdminCorridorSouth>().HasTakenTheKey.Should().BeFalse();
     }
 
+    // Issue #436 — the multi-noun analog of the examine catch-all fixed in #291. While the magnet
+    // is set down in this room (not held), the "you don't have the curved metal bar" hint must fire
+    // ONLY for genuine magnet/key-fishing attempts, not for every two-noun command. A magnet-unrelated
+    // command like "put brush in uniform" must fall through to normal handling.
+    [Test]
+    public async Task MagnetUnrelatedTwoNounCommand_WithMagnetOnFloorHere_DoesNotClaimMissingBar()
+    {
+        var target = GetTarget();
+        StartHere<AdminCorridorSouth>();
+
+        // Magnet is in this room but NOT in the player's inventory.
+        GetLocation<AdminCorridorSouth>().ItemPlacedHere(GetItem<Magnet>());
+        Context.HasItem<Magnet>().Should().BeFalse();
+        GetItem<Magnet>().CurrentLocation.Should().Be(GetLocation<AdminCorridorSouth>());
+
+        var response = await target.GetResponse("put brush in uniform");
+
+        response.Should().NotContain("You don't have the curved metal bar");
+    }
+
+    // Issue #436 — the flip side: a real fishing attempt while the magnet is on the floor here must
+    // still get the "you don't have the bar" hint (and must not silently retrieve the key).
+    [Test]
+    public async Task FishingAttempt_WithMagnetOnFloorHere_StillGivesBarHint()
+    {
+        var target = GetTarget();
+        StartHere<AdminCorridorSouth>();
+
+        GetLocation<AdminCorridorSouth>().ItemPlacedHere(GetItem<Magnet>());
+        Context.HasItem<Magnet>().Should().BeFalse();
+
+        var response = await target.GetResponse("get key with magnet");
+
+        response.Should().Contain("You don't have the curved metal bar");
+        Context.HasItem<Key>().Should().BeFalse();
+        GetLocation<AdminCorridorSouth>().HasTakenTheKey.Should().BeFalse();
+    }
+
     [Test]
     public async Task UseMagnetOnCrevice_AlreadyHasKey_NothingHappens()
     {

--- a/Planetfall/Location/Kalamontee/Admin/AdminCorridorSouth.cs
+++ b/Planetfall/Location/Kalamontee/Admin/AdminCorridorSouth.cs
@@ -1,5 +1,6 @@
 using GameEngine.Location;
 using Model.AIGeneration;
+using Newtonsoft.Json;
 using Planetfall.Item.Kalamontee.Admin;
 using Planetfall.Item.Kalamontee.Mech;
 using Planetfall.Item.Kalamontee.Mech.FloydPart;
@@ -12,6 +13,11 @@ public class AdminCorridorSouth : LocationBase, ITurnBasedActor
 
     [UsedImplicitly] public bool HasTakenTheKey { get; set; }
 
+    // Use the injectable chooser, not Random directly, so the glint-of-light daemon is deterministic
+    // under test (CLAUDE.md: "Never use `Random` directly in game code - always use `IRandomChooser`").
+    [UsedImplicitly] [JsonIgnore]
+    public IRandomChooser Chooser { get; set; } = new RandomChooser();
+
     public override string Name => "Admin Corridor South";
 
     public Task<string> Act(IContext context, IGenerationClient client)
@@ -19,9 +25,8 @@ public class AdminCorridorSouth : LocationBase, ITurnBasedActor
         if (HasSeenTheLight || HasTakenTheKey)
             return Task.FromResult(string.Empty);
 
-        var chance = Random.Shared.Next(3);
-
-        if (chance == 0)
+        // One-in-three chance per turn, matching the original Random.Shared.Next(3) == 0.
+        if (Chooser.RollDiceSuccess(3))
             return Task.FromResult(
                 "\n\nYou catch, out of the corner of your eye, a glint of light from the direction of the floor. ");
 

--- a/Planetfall/Location/Kalamontee/Admin/AdminCorridorSouth.cs
+++ b/Planetfall/Location/Kalamontee/Admin/AdminCorridorSouth.cs
@@ -68,14 +68,6 @@ public class AdminCorridorSouth : LocationBase, ITurnBasedActor
     public override async Task<InteractionResult?> RespondToMultiNounInteraction(MultiNounIntent action,
         IContext context)
     {
-        if (!context.HasItem<Magnet>())
-        {
-            if (Repository.GetItem<Magnet>().CurrentLocation == this)
-                return new PositiveInteractionResult("You don't have the curved metal bar. ");
-
-            return new NoNounMatchInteractionResult();
-        }
-
         var magnetNouns = Repository.GetItem<Magnet>().NounsForMatching;
 
         // The crevice and its neighbours. "hole" is one of the crevice's ZIL synonyms
@@ -124,22 +116,31 @@ public class AdminCorridorSouth : LocationBase, ITurnBasedActor
                     "yank", "drag", "reel", "pluck", "nab", "haul", "obtain", "draw"]).ToArray(),
             keyNouns, magnetNouns, ["with", "using", "to", "toward", "towards"]);
 
-        if (match)
-        {
-            if (HasTakenTheKey)
-                return new PositiveInteractionResult("Nothing interesting happens. ");
+        // Only a magnet/key-fishing attempt reaches here. Anything else falls through to base so an
+        // unrelated two-noun command (e.g. "put brush in uniform") is handled normally — the old code
+        // gated the "you don't have the bar" hint on the magnet's mere presence in the room, so it
+        // swallowed EVERY two-noun command while the magnet was set down here (issue #436, the
+        // multi-noun sibling of the examine catch-all fixed in #291).
+        if (!match)
+            return await base.RespondToMultiNounInteraction(action, context);
 
-            HasTakenTheKey = true;
-            context.ItemPlacedHere<Key>();
+        // It's a genuine fishing attempt, but the player isn't holding the magnet.
+        if (!context.HasItem<Magnet>())
+            return Repository.GetItem<Magnet>().CurrentLocation == this
+                ? new PositiveInteractionResult("You don't have the curved metal bar. ")
+                : new NoNounMatchInteractionResult();
 
-            Repository.GetItem<Floyd>().CommentOnAction(FloydPrompts.MagnetRetrievesKey, context);
+        if (HasTakenTheKey)
+            return new PositiveInteractionResult("Nothing interesting happens. ");
 
-            return new PositiveInteractionResult(
-                "With a spray of dust and a loud clank, a piece of metal leaps from the crevice and " +
-                "affixes itself to the magnet. It is a steel key! With a tug, you remove the key from the magnet. ");
-        }
+        HasTakenTheKey = true;
+        context.ItemPlacedHere<Key>();
 
-        return await base.RespondToMultiNounInteraction(action, context);
+        Repository.GetItem<Floyd>().CommentOnAction(FloydPrompts.MagnetRetrievesKey, context);
+
+        return new PositiveInteractionResult(
+            "With a spray of dust and a loud clank, a piece of metal leaps from the crevice and " +
+            "affixes itself to the magnet. It is a steel key! With a tug, you remove the key from the magnet. ");
     }
 
     public override async Task<InteractionResult> RespondToSimpleInteraction(SimpleIntent action, IContext context,


### PR DESCRIPTION
## Problem

In **Admin Corridor South**, if the magnet (curved metal bar) is in the room but not held, **every** multi-noun command returned "You don't have the curved metal bar." — regardless of what it referred to.

```
(hold the magnet, go to Admin Corridor South)
put brush in uniform   -> "There's no room."                      (control, handled normally while holding the magnet)
drop magnet            -> "Dropped"                               (magnet now on the floor here)
put brush in uniform   -> "You don't have the curved metal bar."  (BUG — nothing to do with the magnet)
```

This is the multi-noun sibling of the examine catch-all fixed in #291 (that one was in `RespondToSimpleInteraction`; this survived in `RespondToMultiNounInteraction`).

## Root cause

`Planetfall/Location/Kalamontee/Admin/AdminCorridorSouth.cs` emitted the "you don't have the bar" branch **before**, and independently of, the actual magnet/key-fishing match logic. It was gated only on the magnet's presence/location in the room, not on whether the command was about the magnet/key/crevice — so it intercepted every `MultiNounIntent` the `MultiNounEngine` routed to the location.

## Fix

Compute the fishing `match` first. If the command isn't a magnet/key-fishing attempt, fall through to `base` so unrelated two-noun commands (`put X in Y`, `give X to Y`, …) are handled normally. Only when a genuine fishing attempt matches but the player isn't holding the magnet do we emit the "you don't have the curved metal bar" hint. No behavior change for any actual fishing phrasing.

## Testing (TDD)

Added two tests to `Planetfall.Tests/AdminCorridorSouthTests.cs`, with the magnet set down in the room (not held):

- `MagnetUnrelatedTwoNounCommand_WithMagnetOnFloorHere_DoesNotClaimMissingBar` — `put brush in uniform` no longer returns the bar message (**red before, green after**).
- `FishingAttempt_WithMagnetOnFloorHere_StillGivesBarHint` — a real fishing attempt (`get key with magnet`) still gets the hint and does not silently retrieve the key (guard against over-correcting).

The first test fails on `main` for the right reason (asserts against the literal "You don't have the curved metal bar." output) and passes after the fix. Full `Planetfall.Tests` suite: **3103 passing, 0 failing**.

Closes #436.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WKJsoGJLfmasTD18EHYAc1)_