### PR TITLE
Fix #434: examine laser reflects the depression's actual contents

### DIFF
--- a/Planetfall.Tests/LaserTests.cs
+++ b/Planetfall.Tests/LaserTests.cs
@@ -1464,6 +1464,65 @@ public class LaserTests : EngineTestsBase
 
     #endregion
 
+    #region Examine Tests
+
+    [Test]
+    public async Task ExamineLaser_WithOldBattery_MentionsBatteryInDepression()
+    {
+        // Baseline: while the (starting) old battery is in the depression, examine should still
+        // describe it as an old battery.
+        var target = GetTarget();
+        Take<Laser>();
+
+        var response = await target.GetResponse("examine laser");
+
+        response.Should().Contain("depression");
+        response.Should().Contain("old battery");
+    }
+
+    [Test]
+    public async Task ExamineLaser_AfterRemovingBattery_ReportsEmptyDepression()
+    {
+        // Issue #434: the battery clause was a hardcoded "contains an old battery" that ignored the
+        // laser's actual contents. After the player removes the battery the depression is empty, yet
+        // examine kept claiming a battery was present.
+        var target = GetTarget();
+        StartHere<ToolRoom>(); // ToolRoom avoids DeckNine's random actor spawning ("remove" collisions)
+        Take<Laser>();
+
+        await target.GetResponse("remove battery");
+        GetItem<Laser>().Items.Should().BeEmpty();
+
+        var response = await target.GetResponse("examine laser");
+
+        response.Should().NotContain("old battery");
+        response.Should().Contain("empty depression");
+    }
+
+    [Test]
+    public async Task ExamineLaser_WithFreshBattery_DoesNotCallItOld()
+    {
+        // Issue #434: after the required old->fresh swap the depression holds the FRESH battery, but
+        // the hardcoded clause still described it as "an old battery."
+        var target = GetTarget();
+        Take<Laser>();
+        var oldBattery = GetItem<OldBattery>();
+        var freshBattery = GetItem<FreshBattery>();
+        var laser = GetItem<Laser>();
+
+        // Swap the dead battery for the fresh one.
+        laser.Items.Clear();
+        oldBattery.CurrentLocation = null;
+        laser.ItemPlacedHere(freshBattery);
+
+        var response = await target.GetResponse("examine laser");
+
+        response.Should().NotContain("old battery");
+        response.Should().Contain("new battery");
+    }
+
+    #endregion
+
     #region Wrong Item Tests
 
     [Test]

--- a/Planetfall/Item/Kalamontee/Mech/Laser.cs
+++ b/Planetfall/Item/Kalamontee/Mech/Laser.cs
@@ -101,12 +101,15 @@ public class Laser : ContainerBase, ICanBeTakenAndDropped, ICanBeExamined, ITurn
                 // GenericDescription yields "An old battery" / "A new battery"; lowercase the article
                 // so it reads naturally mid-sentence ("...which contains an old battery.").
                 var contents = battery.GenericDescription(null);
-                contents = char.ToLowerInvariant(contents[0]) + contents[1..];
+                // Guard the empty default: ItemBase.GenericDescription returns "" and nothing forces a
+                // battery subclass to override it, so index into it only when there's something there.
+                if (!string.IsNullOrEmpty(contents))
+                    contents = char.ToLowerInvariant(contents[0]) + contents[1..];
                 return description +
-                       $"There is a depression on the top of the laser which contains {contents}.";
+                       $"There is a depression on the top of the laser which contains {contents}. ";
             }
 
-            return description + "There is an empty depression on the top of the laser.";
+            return description + "There is an empty depression on the top of the laser. ";
         }
     }
 

--- a/Planetfall/Item/Kalamontee/Mech/Laser.cs
+++ b/Planetfall/Item/Kalamontee/Mech/Laser.cs
@@ -83,11 +83,32 @@ public class Laser : ContainerBase, ICanBeTakenAndDropped, ICanBeExamined, ITurn
     
     public int Setting { get; set; } = 5;
 
-    public string ExaminationDescription =>
-        "The laser, though portable, is still fairly heavy. It has a long, slender " +
-        "barrel and a dial with six settings, labelled \"1\" through \"6.\" This " +
-        $"dial is currently on setting {Setting}. There is a depression on the top of the " +
-        "laser which contains an old battery.";
+    public string ExaminationDescription
+    {
+        get
+        {
+            var description =
+                "The laser, though portable, is still fairly heavy. It has a long, slender " +
+                "barrel and a dial with six settings, labelled \"1\" through \"6.\" This " +
+                $"dial is currently on setting {Setting}. ";
+
+            // Issue #434: the depression is the laser's single container slot (Items), so describe
+            // what's ACTUALLY resting in it. The battery clause used to be hardcoded to "an old
+            // battery," which went stale once the player removed the dead battery (empty depression)
+            // or completed the required old->fresh swap (the fresh battery was still called "old").
+            if (Items.FirstOrDefault() is BatteryBase battery)
+            {
+                // GenericDescription yields "An old battery" / "A new battery"; lowercase the article
+                // so it reads naturally mid-sentence ("...which contains an old battery.").
+                var contents = battery.GenericDescription(null);
+                contents = char.ToLowerInvariant(contents[0]) + contents[1..];
+                return description +
+                       $"There is a depression on the top of the laser which contains {contents}.";
+            }
+
+            return description + "There is an empty depression on the top of the laser.";
+        }
+    }
 
     public override string NeverPickedUpDescription(ILocation currentLocation)
     {


### PR DESCRIPTION
## Bug

`examine laser` always reported "There is a depression on the top of the laser which contains an old battery." — regardless of what was actually in the depression. Only the dial `Setting` was interpolated into `ExaminationDescription`; the battery clause was a hardcoded constant.

The laser is a container (`ContainerBase`, `IsTransparent`, `CanOnlyHoldTheseTypes => [BatteryBase]`) whose depression is its single `Items` slot, but examine never consulted `Items`. So the clause went stale:

- **After removing the battery** the depression is empty, yet examine still claimed "an old battery."
- **On the golden path** the endgame requires swapping the dead battery for the fresh one; afterward the depression holds the **fresh** battery but examine still said "old battery."

Firing mechanics were unaffected (they already read `Items.FirstOrDefault()`) — this was purely the examine text.

## Fix

`Planetfall/Item/Kalamontee/Mech/Laser.cs` — derive the battery clause from `Items` instead of hardcoding it:

- If a `BatteryBase` is resting in the slot, describe it via its `GenericDescription` ("an old battery" / "a new battery").
- If the slot is empty, report "There is an empty depression on the top of the laser."

This mirrors how other containers describe their contents and keeps the original wording for the baseline (old-battery) case.

## Tests (TDD)

Added three examine tests in `Planetfall.Tests/LaserTests.cs` using real `Repository` objects with the laser held:

- `ExamineLaser_WithOldBattery_MentionsBatteryInDepression` — baseline (green before and after).
- `ExamineLaser_AfterRemovingBattery_ReportsEmptyDepression` — red before, green after.
- `ExamineLaser_WithFreshBattery_DoesNotCallItOld` — red before, green after.

The two staleness tests failed for the right reason before the fix (examine still said "an old battery") and pass after it.

## Verification

- `dotnet test Planetfall.Tests --filter LaserTests` → 108 passed.
- `dotnet test Planetfall.Tests` → 3104 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015AkTs5xUiB293pfrPMSwb7

---
_Generated by [Claude Code](https://claude.ai/code/session_015AkTs5xUiB293pfrPMSwb7)_