### PR TITLE
Add "god mode day <n>" to advance the Planetfall calendar

### DIFF
--- a/GameEngine/StaticCommand/Implementation/GodModeProcessor.cs
+++ b/GameEngine/StaticCommand/Implementation/GodModeProcessor.cs
@@ -58,10 +58,11 @@ public class GodModeProcessor : IGlobalCommand
         // OnLeaveLocation/AfterEnterLocation, so a game-specific location-blind death clock (e.g.
         // Planetfall's Feinstein explosion) never gets the chance to disarm itself. Let the context
         // do that explicitly for a god-mode teleport.
-        if (context is IGodModeTeleportAware teleportAware)
-            teleportAware.OnGodModeTeleport();
+        var teleportNote = context is IGodModeTeleportAware teleportAware
+            ? teleportAware.OnGodModeTeleport()
+            : null;
 
-        return $"Welcome to {location.Name}";
+        return $"Welcome to {location.Name}" + (teleportNote is null ? "" : $". {teleportNote}");
     }
 
     private string Take(string input, IContext context)

--- a/Model/Interface/IGodModeTeleportAware.cs
+++ b/Model/Interface/IGodModeTeleportAware.cs
@@ -13,5 +13,10 @@ namespace Model.Interface;
 /// </summary>
 public interface IGodModeTeleportAware
 {
-    void OnGodModeTeleport();
+    /// <summary>
+    ///     Returns a note to append to the teleport confirmation, or null when there is nothing to say.
+    ///     A game may want to warn that the raw swap has landed the player somewhere its own rules would
+    ///     never allow - god mode still obeys the request, but says so rather than leaving it silent.
+    /// </summary>
+    string? OnGodModeTeleport();
 }

--- a/Planetfall.Tests/DayGodModeTests.cs
+++ b/Planetfall.Tests/DayGodModeTests.cs
@@ -1,44 +1,73 @@
 using FluentAssertions;
+using Model.Interface;
+using Moq;
+using Planetfall.Item.Feinstein;
 using Planetfall.Location.Kalamontee.Dorm;
 using Utilities;
 
 namespace Planetfall.Tests;
 
 /// <summary>
-/// God-mode command to jump the calendar to a given day ("god mode day 5"), a playtesting affordance
+/// God-mode command to advance the calendar to a given day ("god mode day 5"), a playtesting affordance
 /// for day-gated content (sickness escalation, the shrinking carry limit, per-day sleep pressure)
-/// without sleeping through four in-game nights to reach it. The jump lands the player at the START of
-/// the requested day, exactly as waking up would: chronometer at that day's morning, fatigue and
-/// hunger reset, and the disease at the untreated level for that day. Covers the command wiring, each
-/// piece of day-coupled state it drags along, argument validation, and persistence.
+/// without sleeping through the intervening nights. It runs the game's own day-advance transition
+/// (<see cref="SleepEngine.StartNewDay" />) once per day, so every clock that is a function of the day
+/// moves by the real rules - but it does NOT charge the costs of having slept (dropped inventory,
+/// spoiled food), which belong to sleep rather than to the calendar. Covers the command wiring, each
+/// piece of day-coupled state, the boundary with sleep's costs, argument validation, and persistence.
 /// </summary>
 public class DayGodModeTests : EngineTestsBase
 {
+    /// <summary>
+    /// Pins the chronometer's morning jitter so wake times are exact rather than an 80-tick range.
+    /// </summary>
+    private void PinMorningJitter(int jitter)
+    {
+        var mockChooser = new Mock<IRandomChooser>();
+        mockChooser.Setup(r => r.RollDice(Chronometer.MorningJitterTicks)).Returns(jitter);
+        GetItem<Chronometer>().Chooser = mockChooser.Object;
+    }
+
     #region Command wiring
 
     [Test]
-    public async Task GodMode_Day_SetsTheCurrentDay()
+    public async Task GodMode_Day_AdvancesToTheRequestedDay()
     {
         var engine = GetTarget();
         StartHere<DormA>();
 
         var response = await engine.GetResponse("god mode day 5");
 
-        engine.Context.Day.Should().Be(5);
+        Context.Day.Should().Be(5);
         // Confirmation - and proof the day branch ran rather than the generic god-mode error.
         response.Should().Contain("Day 5");
     }
 
     [Test]
-    public async Task GodMode_Day_CanJumpBackwards()
+    public async Task GodMode_Day_RefusesToGoBackwards()
+    {
+        // The calendar only advances: the command replays the real day transition, and there is no
+        // inverse for it (you cannot un-advance the disease).
+        var engine = GetTarget();
+        StartHere<DormA>();
+        Context.Day = 6;
+
+        var response = await engine.GetResponse("god mode day 2");
+
+        Context.Day.Should().Be(6); // unchanged
+        response.Should().Contain("only moves forward");
+    }
+
+    [Test]
+    public async Task GodMode_Day_RefusesToRepeatTheCurrentDay()
     {
         var engine = GetTarget();
         StartHere<DormA>();
-        engine.Context.Day = 6;
+        Context.Day = 4;
 
-        await engine.GetResponse("god mode day 2");
+        var response = await engine.GetResponse("god mode day 4");
 
-        engine.Context.Day.Should().Be(2);
+        response.Should().Contain("only moves forward");
     }
 
     [Test]
@@ -62,62 +91,80 @@ public class DayGodModeTests : EngineTestsBase
     {
         var engine = GetTarget();
         StartHere<DormA>();
+        PinMorningJitter(7);
 
         await engine.GetResponse("god mode day 4");
 
-        // Day 4 wakes between 1950 and 2029 (Chronometer.MorningTimesByDay + up to 80 ticks of jitter).
-        // The god-mode turn's own end-of-turn tick must already be accounted for, so the player reads
-        // the day's morning time on the very next turn rather than 54 ticks past it.
-        engine.Context.CurrentTime.Should().BeInRange(1950, 2029);
+        // Day 4's base morning is 1950. The god-mode turn's own end-of-turn tick is already accounted
+        // for, so the player reads the day's morning time rather than 54 ticks past it.
+        Context.CurrentTime.Should().Be(1957);
     }
 
     [Test]
-    public async Task GodMode_Day_AdvancesTheDiseaseToTheUntreatedLevelForThatDay()
+    public async Task GodMode_Day_AdvancesTheDiseaseOnceForEachDayCrossed()
     {
         var engine = GetTarget();
         StartHere<DormA>();
 
         await engine.GetResponse("god mode day 6");
 
-        // Untreated, the sickness counter tracks the calendar (it starts at 1 == Day 1), so jumping the
-        // day must drag the disease along or the jump would silently cure the player.
-        engine.Context.SicknessCounter.Should().Be(6);
-        engine.Context.EffectiveLoadAllowed.Should().Be(50); // 100 - 10 per sick day past the first
+        // Untreated, the sickness counter tracks the calendar (it starts at 1 == Day 1), so five days
+        // crossed means five advances.
+        Context.SicknessCounter.Should().Be(6);
+        Context.EffectiveLoadAllowed.Should().Be(50); // 100 - 10 per sick day past the first
+    }
+
+    [Test]
+    public async Task GodMode_Day_PreservesMedicineTreatment()
+    {
+        var engine = GetTarget();
+        StartHere<DormA>();
+
+        // A player who drank the experimental medicine on Day 3: Medicine.cs rolls the counter back two
+        // levels, so it now trails the calendar. Advancing the day must ADVANCE that counter, not
+        // reassign it to the day - reassigning would silently undo the cure.
+        Context.Day = 3;
+        Context.SicknessCounter = 1;
+
+        await engine.GetResponse("god mode day 6");
+
+        Context.SicknessCounter.Should().Be(4); // 1 + the three days crossed, not 6
+        Context.EffectiveLoadAllowed.Should().Be(70); // still healthier than an untreated Day 6 player
     }
 
     [Test]
     public async Task GodMode_Day_ResetsFatigueAndTheSleepSchedule()
     {
         var engine = GetTarget();
-        var context = engine.Context;
         StartHere<DormA>();
 
-        context.Tired = TiredLevel.AboutToDrop;
-        context.SleepNotifications.QueueFallAsleep(context.CurrentTime);
+        Context.Tired = TiredLevel.AboutToDrop;
+        Context.SleepNotifications.QueueFallAsleep(Context.CurrentTime);
 
         await engine.GetResponse("god mode day 4");
 
-        context.Tired.Should().Be(TiredLevel.WellRested);
-        context.SleepNotifications.FallAsleepQueued.Should().BeFalse();
+        Context.Tired.Should().Be(TiredLevel.WellRested);
+        Context.SleepNotifications.FallAsleepQueued.Should().BeFalse();
         // Day 4 gets 5200 ticks of wakefulness before the first fatigue warning.
-        context.SleepNotifications.NextWarningAt.Should().Be(context.CurrentTime + 5200);
+        Context.SleepNotifications.NextWarningAt.Should().Be(Context.CurrentTime + 5200);
     }
 
     [Test]
     public async Task GodMode_Day_ResetsHungerAndTheHungerSchedule()
     {
         var engine = GetTarget();
-        var context = engine.Context;
         StartHere<DormA>();
 
-        context.Hunger = HungerLevel.Faint;
+        Context.Hunger = HungerLevel.Faint;
 
         await engine.GetResponse("god mode day 4");
 
-        context.Hunger.Should().Be(HungerLevel.WellFed);
+        Context.Hunger.Should().Be(HungerLevel.WellFed);
         // Rescheduled off the NEW (much earlier) morning time - otherwise the stale warning time from
         // the old day would sit thousands of ticks in the future and hunger would never advance again.
-        context.HungerNotifications.NextWarningAt.Should().Be(context.CurrentTime + 800);
+        // 800 (the fresh timer) rather than 200 (the famished one): the very first day crossed cleared
+        // the hunger, so the player arrives on Day 4 well-fed rather than waking up starving.
+        Context.HungerNotifications.NextWarningAt.Should().Be(Context.CurrentTime + 800);
     }
 
     [Test]
@@ -136,22 +183,39 @@ public class DayGodModeTests : EngineTestsBase
     [Test]
     public async Task GodMode_Day_DoesNotForceSleepOnTheVeryNextTurn()
     {
-        // The jump must leave a coherent clock: an exhausted player who jumps days wakes up rested,
+        // The jump must leave a coherent clock: an exhausted player who advances days wakes up rested,
         // not immediately face-planted by the forced-sleep check.
         var engine = GetTarget();
-        var context = engine.Context;
         StartHere<DormA>();
 
-        context.Tired = TiredLevel.AboutToDrop;
+        Context.Tired = TiredLevel.AboutToDrop;
         // Due on the turn AFTER the god-mode command (the end-of-turn tick advances 54), so the stale
-        // schedule is what the jump has to defuse - not something that fires before it even runs.
-        context.SleepNotifications.NextWarningAt = context.CurrentTime + 1;
+        // schedule is what the advance has to defuse - not something that fires before it even runs.
+        Context.SleepNotifications.NextWarningAt = Context.CurrentTime + 1;
 
         await engine.GetResponse("god mode day 5");
         await engine.GetResponse("wait");
 
-        context.CurrentLocation.Should().BeOfType<DormA>(); // never climbed into a bunk
-        context.Day.Should().Be(5); // and no forced sleep rolled the day over
+        Context.CurrentLocation.Should().BeOfType<DormA>(); // never climbed into a bunk
+        Context.Day.Should().Be(5); // and no forced sleep rolled the day over
+    }
+
+    #endregion
+
+    #region Boundary with sleep's costs
+
+    [Test]
+    public async Task GodMode_Day_DoesNotChargeSleepsCosts()
+    {
+        // The calendar advance replays the day transition, NOT the wake-up routine: a tester who
+        // advances days keeps the kit they were about to test with, instead of finding it on the floor.
+        var engine = GetTarget();
+        StartHere<DormA>();
+        var diary = Take<Diary>();
+
+        await engine.GetResponse("god mode day 5");
+
+        Context.Items.Should().Contain(diary);
     }
 
     #endregion
@@ -166,7 +230,7 @@ public class DayGodModeTests : EngineTestsBase
 
         var response = await engine.GetResponse("god mode day 12");
 
-        engine.Context.Day.Should().Be(1); // unchanged
+        Context.Day.Should().Be(1); // unchanged
         response.Should().Contain("between 1 and 8");
     }
 
@@ -178,8 +242,21 @@ public class DayGodModeTests : EngineTestsBase
 
         var response = await engine.GetResponse("god mode day 0");
 
-        engine.Context.Day.Should().Be(1); // unchanged
+        Context.Day.Should().Be(1); // unchanged
         response.Should().Contain("between 1 and 8");
+    }
+
+    [Test]
+    public async Task GodMode_Day_AcceptsAWordierPhrasing()
+    {
+        // The sibling god-mode subcommands all match loosely on trigger words rather than on position;
+        // the day argument should be just as forgiving.
+        var engine = GetTarget();
+        StartHere<DormA>();
+
+        await engine.GetResponse("god mode set day to 5");
+
+        Context.Day.Should().Be(5);
     }
 
     [Test]
@@ -190,7 +267,7 @@ public class DayGodModeTests : EngineTestsBase
 
         var response = await engine.GetResponse("god mode day");
 
-        engine.Context.Day.Should().Be(1);
+        Context.Day.Should().Be(1);
         response.Should().Contain("Invalid use of God mode");
     }
 
@@ -202,7 +279,7 @@ public class DayGodModeTests : EngineTestsBase
 
         var response = await engine.GetResponse("god mode day tuesday");
 
-        engine.Context.Day.Should().Be(1);
+        Context.Day.Should().Be(1);
         response.Should().Contain("Invalid use of God mode");
     }
 
@@ -215,16 +292,19 @@ public class DayGodModeTests : EngineTestsBase
     {
         var engine = GetTarget();
         StartHere<DormA>();
+        PinMorningJitter(7);
 
         await engine.GetResponse("god mode day 5");
         var saved = engine.SaveGame();
 
-        // Restore into a fresh engine/repository to prove the day round-trips through the save JSON.
+        // Restore into a fresh engine/repository to prove the whole jump round-trips through the save
+        // JSON - the calendar AND the clock it is coupled to, which live in different parts of the save.
         var freshEngine = GetTarget();
         var restored = (PlanetfallContext)freshEngine.RestoreGame(saved);
 
         restored.Day.Should().Be(5);
         restored.SicknessCounter.Should().Be(5);
+        restored.CurrentTime.Should().Be(2157); // Day 5's base morning of 2150, plus the pinned jitter
     }
 
     #endregion

--- a/Planetfall.Tests/DayGodModeTests.cs
+++ b/Planetfall.Tests/DayGodModeTests.cs
@@ -260,6 +260,53 @@ public class DayGodModeTests : EngineTestsBase
     }
 
     [Test]
+    public async Task GodMode_Day_EvacuationRunsTheDestinationsEntryHooks()
+    {
+        // A raw CurrentLocation assignment would leave the destination "never visited", so its
+        // first-visit text and OnFirstTimeEnterLocation side effects would fire later, once the player
+        // walked in normally from somewhere else - after they had already been standing there.
+        var engine = GetTarget();
+        StartHere<Crag>();
+
+        var response = await engine.GetResponse("god mode day 5");
+
+        GetLocation<WindingStair>().VisitCount.Should().Be(1);
+        // Only the room they end up in counts as entered - they were never really on the Balcony the
+        // water swept them through.
+        GetLocation<Balcony>().VisitCount.Should().Be(0);
+        // And they can see where they've been put.
+        response.Should().Contain("steep stairway");
+    }
+
+    [Test]
+    public async Task GodMode_Go_WarnsButObeysWhenTheDestinationIsAlreadyDrowned()
+    {
+        // "god mode go" is an explicit request to be somewhere, and reaching otherwise-unreachable
+        // states is the whole point of god mode - so it is honoured rather than bounced. The calendar
+        // advance evacuates because there the player never asked to move; the ground went out from
+        // under them. What both owe the tester is not being silently left in an impossible state.
+        var engine = GetTarget();
+        StartHere<DormA>();
+        await engine.GetResponse("god mode day 5");
+
+        var response = await engine.GetResponse("god mode go crag");
+
+        Context.CurrentLocation.Should().BeOfType<Crag>();
+        response.Should().Contain("under water");
+    }
+
+    [Test]
+    public async Task GodMode_Go_DoesNotWarnAboutARoomTheWaterHasNotReached()
+    {
+        var engine = GetTarget();
+        StartHere<DormA>();
+
+        var response = await engine.GetResponse("god mode go crag"); // Day 1: the Crag is still dry
+
+        response.Should().NotContain("under water");
+    }
+
+    [Test]
     public async Task GodMode_Day_LeavesThePlayerAloneInARoomTheCalendarDoesNotTouch()
     {
         var engine = GetTarget();

--- a/Planetfall.Tests/DayGodModeTests.cs
+++ b/Planetfall.Tests/DayGodModeTests.cs
@@ -1,0 +1,231 @@
+using FluentAssertions;
+using Planetfall.Location.Kalamontee.Dorm;
+using Utilities;
+
+namespace Planetfall.Tests;
+
+/// <summary>
+/// God-mode command to jump the calendar to a given day ("god mode day 5"), a playtesting affordance
+/// for day-gated content (sickness escalation, the shrinking carry limit, per-day sleep pressure)
+/// without sleeping through four in-game nights to reach it. The jump lands the player at the START of
+/// the requested day, exactly as waking up would: chronometer at that day's morning, fatigue and
+/// hunger reset, and the disease at the untreated level for that day. Covers the command wiring, each
+/// piece of day-coupled state it drags along, argument validation, and persistence.
+/// </summary>
+public class DayGodModeTests : EngineTestsBase
+{
+    #region Command wiring
+
+    [Test]
+    public async Task GodMode_Day_SetsTheCurrentDay()
+    {
+        var engine = GetTarget();
+        StartHere<DormA>();
+
+        var response = await engine.GetResponse("god mode day 5");
+
+        engine.Context.Day.Should().Be(5);
+        // Confirmation - and proof the day branch ran rather than the generic god-mode error.
+        response.Should().Contain("Day 5");
+    }
+
+    [Test]
+    public async Task GodMode_Day_CanJumpBackwards()
+    {
+        var engine = GetTarget();
+        StartHere<DormA>();
+        engine.Context.Day = 6;
+
+        await engine.GetResponse("god mode day 2");
+
+        engine.Context.Day.Should().Be(2);
+    }
+
+    [Test]
+    public async Task GodMode_Day_ReportsTheNewDayInTheScore()
+    {
+        var engine = GetTarget();
+        StartHere<DormA>();
+
+        await engine.GetResponse("god mode day 7");
+        var score = await engine.GetResponse("score");
+
+        score.Should().Contain("It is Day 7");
+    }
+
+    #endregion
+
+    #region Day-coupled state
+
+    [Test]
+    public async Task GodMode_Day_ResetsChronometerToThatDaysMorning()
+    {
+        var engine = GetTarget();
+        StartHere<DormA>();
+
+        await engine.GetResponse("god mode day 4");
+
+        // Day 4 wakes between 1950 and 2029 (Chronometer.MorningTimesByDay + up to 80 ticks of jitter).
+        // The god-mode turn's own end-of-turn tick must already be accounted for, so the player reads
+        // the day's morning time on the very next turn rather than 54 ticks past it.
+        engine.Context.CurrentTime.Should().BeInRange(1950, 2029);
+    }
+
+    [Test]
+    public async Task GodMode_Day_AdvancesTheDiseaseToTheUntreatedLevelForThatDay()
+    {
+        var engine = GetTarget();
+        StartHere<DormA>();
+
+        await engine.GetResponse("god mode day 6");
+
+        // Untreated, the sickness counter tracks the calendar (it starts at 1 == Day 1), so jumping the
+        // day must drag the disease along or the jump would silently cure the player.
+        engine.Context.SicknessCounter.Should().Be(6);
+        engine.Context.EffectiveLoadAllowed.Should().Be(50); // 100 - 10 per sick day past the first
+    }
+
+    [Test]
+    public async Task GodMode_Day_ResetsFatigueAndTheSleepSchedule()
+    {
+        var engine = GetTarget();
+        var context = engine.Context;
+        StartHere<DormA>();
+
+        context.Tired = TiredLevel.AboutToDrop;
+        context.SleepNotifications.QueueFallAsleep(context.CurrentTime);
+
+        await engine.GetResponse("god mode day 4");
+
+        context.Tired.Should().Be(TiredLevel.WellRested);
+        context.SleepNotifications.FallAsleepQueued.Should().BeFalse();
+        // Day 4 gets 5200 ticks of wakefulness before the first fatigue warning.
+        context.SleepNotifications.NextWarningAt.Should().Be(context.CurrentTime + 5200);
+    }
+
+    [Test]
+    public async Task GodMode_Day_ResetsHungerAndTheHungerSchedule()
+    {
+        var engine = GetTarget();
+        var context = engine.Context;
+        StartHere<DormA>();
+
+        context.Hunger = HungerLevel.Faint;
+
+        await engine.GetResponse("god mode day 4");
+
+        context.Hunger.Should().Be(HungerLevel.WellFed);
+        // Rescheduled off the NEW (much earlier) morning time - otherwise the stale warning time from
+        // the old day would sit thousands of ticks in the future and hunger would never advance again.
+        context.HungerNotifications.NextWarningAt.Should().Be(context.CurrentTime + 800);
+    }
+
+    [Test]
+    public async Task GodMode_Day_StillDeliversThatDaysSicknessNotification()
+    {
+        var engine = GetTarget();
+        StartHere<DormA>();
+
+        await engine.GetResponse("god mode day 3");
+        // "wait", not "look" - look is a free command and skips ProcessBeginningOfTurn entirely.
+        var response = await engine.GetResponse("wait");
+
+        response.Should().Contain("unusually weak"); // the Day 3 sickness warning
+    }
+
+    [Test]
+    public async Task GodMode_Day_DoesNotForceSleepOnTheVeryNextTurn()
+    {
+        // The jump must leave a coherent clock: an exhausted player who jumps days wakes up rested,
+        // not immediately face-planted by the forced-sleep check.
+        var engine = GetTarget();
+        var context = engine.Context;
+        StartHere<DormA>();
+
+        context.Tired = TiredLevel.AboutToDrop;
+        // Due on the turn AFTER the god-mode command (the end-of-turn tick advances 54), so the stale
+        // schedule is what the jump has to defuse - not something that fires before it even runs.
+        context.SleepNotifications.NextWarningAt = context.CurrentTime + 1;
+
+        await engine.GetResponse("god mode day 5");
+        await engine.GetResponse("wait");
+
+        context.CurrentLocation.Should().BeOfType<DormA>(); // never climbed into a bunk
+        context.Day.Should().Be(5); // and no forced sleep rolled the day over
+    }
+
+    #endregion
+
+    #region Argument validation
+
+    [Test]
+    public async Task GodMode_Day_RejectsADayPastTheEndOfTheGame()
+    {
+        var engine = GetTarget();
+        StartHere<DormA>();
+
+        var response = await engine.GetResponse("god mode day 12");
+
+        engine.Context.Day.Should().Be(1); // unchanged
+        response.Should().Contain("between 1 and 8");
+    }
+
+    [Test]
+    public async Task GodMode_Day_RejectsADayBeforeTheStartOfTheGame()
+    {
+        var engine = GetTarget();
+        StartHere<DormA>();
+
+        var response = await engine.GetResponse("god mode day 0");
+
+        engine.Context.Day.Should().Be(1); // unchanged
+        response.Should().Contain("between 1 and 8");
+    }
+
+    [Test]
+    public async Task GodMode_Day_WithNoNumber_FallsThroughToTheGenericError()
+    {
+        var engine = GetTarget();
+        StartHere<DormA>();
+
+        var response = await engine.GetResponse("god mode day");
+
+        engine.Context.Day.Should().Be(1);
+        response.Should().Contain("Invalid use of God mode");
+    }
+
+    [Test]
+    public async Task GodMode_Day_WithANonNumber_FallsThroughToTheGenericError()
+    {
+        var engine = GetTarget();
+        StartHere<DormA>();
+
+        var response = await engine.GetResponse("god mode day tuesday");
+
+        engine.Context.Day.Should().Be(1);
+        response.Should().Contain("Invalid use of God mode");
+    }
+
+    #endregion
+
+    #region Persistence
+
+    [Test]
+    public async Task GodMode_Day_SurvivesSaveAndRestore()
+    {
+        var engine = GetTarget();
+        StartHere<DormA>();
+
+        await engine.GetResponse("god mode day 5");
+        var saved = engine.SaveGame();
+
+        // Restore into a fresh engine/repository to prove the day round-trips through the save JSON.
+        var freshEngine = GetTarget();
+        var restored = (PlanetfallContext)freshEngine.RestoreGame(saved);
+
+        restored.Day.Should().Be(5);
+        restored.SicknessCounter.Should().Be(5);
+    }
+
+    #endregion
+}

--- a/Planetfall.Tests/DayGodModeTests.cs
+++ b/Planetfall.Tests/DayGodModeTests.cs
@@ -281,6 +281,39 @@ public class DayGodModeTests : EngineTestsBase
     }
 
     [Test]
+    public async Task GodMode_Day_EvacuationClearsPronounAntecedentsLeftInTheFloodedRoom()
+    {
+        var engine = GetTarget();
+        StartHere<Balcony>();
+
+        await engine.GetResponse("examine plaque");
+        Context.LastNoun.Should().Be("plaque");
+        Context.LastNouns = ["plaque"];
+
+        await engine.GetResponse("god mode day 4");
+
+        Context.CurrentLocation.Should().BeOfType<WindingStair>();
+        Context.LastNoun.Should().BeEmpty();
+        Context.LastNouns.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task GodMode_Day_EvacuationKeepsPronounAntecedentsForCarriedItems()
+    {
+        var engine = GetTarget();
+        StartHere<Balcony>();
+        Take<Diary>();
+        Context.LastNoun = "diary";
+        Context.LastNouns = ["diary"];
+
+        await engine.GetResponse("god mode day 4");
+
+        Context.CurrentLocation.Should().BeOfType<WindingStair>();
+        Context.LastNoun.Should().Be("diary");
+        Context.LastNouns.Should().Equal("diary");
+    }
+
+    [Test]
     public async Task GodMode_Go_WarnsButObeysWhenTheDestinationIsAlreadyDrowned()
     {
         // "god mode go" is an explicit request to be somewhere, and reaching otherwise-unreachable

--- a/Planetfall.Tests/DayGodModeTests.cs
+++ b/Planetfall.Tests/DayGodModeTests.cs
@@ -25,7 +25,9 @@ public class DayGodModeTests : EngineTestsBase
     private void PinMorningJitter(int jitter)
     {
         var mockChooser = new Mock<IRandomChooser>();
-        mockChooser.Setup(r => r.RollDice(Chronometer.MorningJitterTicks)).Returns(jitter);
+        // RollDice is 1-based and ResetToMorning subtracts one, so roll `jitter + 1` to land on the
+        // jitter the caller actually asked for.
+        mockChooser.Setup(r => r.RollDice(Chronometer.MorningJitterTicks)).Returns(jitter + 1);
         GetItem<Chronometer>().Chooser = mockChooser.Object;
     }
 

--- a/Planetfall.Tests/DayGodModeTests.cs
+++ b/Planetfall.Tests/DayGodModeTests.cs
@@ -2,6 +2,7 @@ using FluentAssertions;
 using Model.Interface;
 using Moq;
 using Planetfall.Item.Feinstein;
+using Planetfall.Location.Kalamontee;
 using Planetfall.Location.Kalamontee.Dorm;
 using Utilities;
 
@@ -216,6 +217,58 @@ public class DayGodModeTests : EngineTestsBase
         await engine.GetResponse("god mode day 5");
 
         Context.Items.Should().Contain(diary);
+    }
+
+    [Test]
+    public async Task GodMode_Day_MovesThePlayerOffARoomTheCalendarHasFlooded()
+    {
+        // The Crag is reachable only on Day 1 (Balcony routes Down to Underwater afterwards), and real
+        // play can never strand you there because sleeping on it drowns you. Advancing the calendar
+        // skips that death, so the advance has to spill the player onto higher ground itself - twice
+        // here, since the Balcony it spills onto has also gone under by Day 5.
+        var engine = GetTarget();
+        StartHere<Crag>();
+
+        var response = await engine.GetResponse("god mode day 5");
+
+        Context.CurrentLocation.Should().BeOfType<WindingStair>();
+        response.Should().Contain("rising water");
+    }
+
+    [Test]
+    public async Task GodMode_Day_MovesThePlayerOffTheBalconyOnceItFloods()
+    {
+        var engine = GetTarget();
+        StartHere<Balcony>();
+
+        await engine.GetResponse("god mode day 4"); // the Winding Stair stops reaching the Balcony here
+
+        Context.CurrentLocation.Should().BeOfType<WindingStair>();
+    }
+
+    [Test]
+    public async Task GodMode_Day_LeavesThePlayerOnTheBalconyWhileItIsStillDry()
+    {
+        // Control: the evacuation is day-gated, not a blanket "get off the cliff".
+        var engine = GetTarget();
+        StartHere<Balcony>();
+
+        var response = await engine.GetResponse("god mode day 3");
+
+        Context.CurrentLocation.Should().BeOfType<Balcony>();
+        response.Should().NotContain("rising water");
+    }
+
+    [Test]
+    public async Task GodMode_Day_LeavesThePlayerAloneInARoomTheCalendarDoesNotTouch()
+    {
+        var engine = GetTarget();
+        StartHere<DormA>();
+
+        var response = await engine.GetResponse("god mode day 5");
+
+        Context.CurrentLocation.Should().BeOfType<DormA>();
+        response.Should().NotContain("rising water");
     }
 
     #endregion

--- a/Planetfall.Tests/SleepEngineTests.cs
+++ b/Planetfall.Tests/SleepEngineTests.cs
@@ -526,6 +526,25 @@ public class SleepEngineTests : EngineTestsBase
 
     #region Wake Up Tests
 
+    [TestCase(1, 1950)]  // lowest possible roll wakes the player at the day's exact base time
+    [TestCase(80, 2029)] // highest possible roll wakes them one tick short of the next hundred
+    public void ResetToMorning_SpreadsTheWakeTimeAcrossTheDaysFullWindow(int roll, int expectedTime)
+    {
+        // IRandomChooser.RollDice is 1-based (1..sides) where the Random.Next(80) it replaced was
+        // 0-based (0..79). Without compensating, every wake-up in the game shifts a tick later and the
+        // player can never wake at a day's exact base time - the table's own "~1950-2030" comments stop
+        // describing what the code does.
+        GetTarget();
+        var mockChooser = new Mock<IRandomChooser>();
+        mockChooser.Setup(r => r.RollDice(Chronometer.MorningJitterTicks)).Returns(roll);
+        var chronometer = GetItem<Chronometer>();
+        chronometer.Chooser = mockChooser.Object;
+
+        chronometer.ResetToMorning(4); // Day 4's base morning is 1950
+
+        chronometer.CurrentTime.Should().Be(expectedTime);
+    }
+
     [Test]
     public void WakeUp_InBed_ShowsRefreshedMessage()
     {

--- a/Planetfall/Command/PlanetfallGodModeCommands.cs
+++ b/Planetfall/Command/PlanetfallGodModeCommands.cs
@@ -9,13 +9,30 @@ namespace Planetfall.Command;
 /// </summary>
 public static class PlanetfallGodModeCommands
 {
+    /// <summary>
+    ///     The playable calendar. Day 1 is the crash landing; the disease kills on day 9, and both the
+    ///     chronometer's morning times and the per-day sleep pressure are only defined through day 8.
+    /// </summary>
+    private const int FirstDay = 1;
+
+    private const int LastDay = 8;
+
+    /// <summary>
+    ///     Ticks until the first hunger warning of a freshly-started day, matching the well-fed branch of
+    ///     <see cref="SleepEngine" />'s wake-up routine.
+    /// </summary>
+    private const int FreshDayHungerWarningTicks = 800;
+
     public static string? Handle(PlanetfallContext context, string input)
     {
         var words = input.ToLowerInvariant().Split(' ', StringSplitOptions.RemoveEmptyEntries);
         // Order is deliberate and load-bearing: e.g. "god mode reset sleep clock" must hit ResetClock
         // ("reset" + "clock") before the survival toggle ever sees "sleep". This preserves the branch
         // order these commands had in the engine's GodModeProcessor before they moved here.
-        return ResetClock(words) ?? ToggleSurvivalClocks(context, words) ?? ToggleFloydWandering(context, words);
+        // SetDay sits next to ResetClock because they're both clock surgery - it matches on "day" plus a
+        // number, which none of the other branches' trigger words can collide with.
+        return ResetClock(words) ?? SetDay(context, words) ?? ToggleSurvivalClocks(context, words) ??
+               ToggleFloydWandering(context, words);
     }
 
     /// <summary>
@@ -32,6 +49,61 @@ public static class PlanetfallGodModeCommands
         // God-mode commands still take a Planetfall turn, so compensate for the end-of-turn tick.
         Repository.GetItem<Chronometer>().CurrentTime = walkthroughResetTime - PlanetfallContext.TurnTimeIncrement;
         return $"God mode: chronometer reset to {walkthroughResetTime}.";
+    }
+
+    /// <summary>
+    ///     Recognizes "god mode day &lt;n&gt;" and jumps the calendar to day n, so playtesting can reach
+    ///     day-gated content (the sickness escalation, the shrinking carry limit, the later days' tighter
+    ///     sleep schedule) without sleeping through the intervening nights.
+    ///     The jump lands the player at the START of day n, the same state waking up would leave them in:
+    ///     day-n morning on the chronometer, fatigue and hunger reset and rescheduled off that new time,
+    ///     and the disease at the level an untreated player would have reached. Doing less would leave an
+    ///     incoherent clock - the day-n sickness warning only fires before that day's cutoff time, and a
+    ///     stale hunger/sleep warning time carried over from the old day sits thousands of ticks in the
+    ///     future once the chronometer rolls back to morning. What it deliberately does NOT do is the rest
+    ///     of the wake-up routine (dropping the player's inventory on the floor, spoiling their food):
+    ///     that's sleep's cost, not the calendar's, and a tester jumping days shouldn't pay it.
+    /// </summary>
+    private static string? SetDay(PlanetfallContext context, string[] words)
+    {
+        var index = Array.IndexOf(words, "day");
+        if (index == -1 || index == words.Length - 1)
+            return null;
+
+        // A bare "day" with no number isn't ours - fall through to the engine's generic god-mode error
+        // rather than swallowing something the player meant as a different command.
+        if (!int.TryParse(words[index + 1], out var day))
+            return null;
+
+        if (day < FirstDay || day > LastDay)
+            return $"God mode: day must be between {FirstDay} and {LastDay}. ";
+
+        context.Day = day;
+
+        // Untreated, the disease tracks the calendar (SicknessCounter starts at 1 == day 1 and advances
+        // one level per night). Leaving it behind would silently cure a tester who jumps to day 7.
+        context.SicknessCounter = day;
+
+        var chronometer = Repository.GetItem<Chronometer>();
+        chronometer.ResetToMorning(day);
+        var morningTime = chronometer.CurrentTime;
+
+        context.Tired = TiredLevel.WellRested;
+        context.SleepNotifications.ResetForNewDay(morningTime, day);
+
+        // Mirrors the well-fed branch of the wake-up routine in SleepEngine: a fresh day starts fed,
+        // with the first hunger warning 800 ticks out.
+        context.Hunger = HungerLevel.WellFed;
+        context.HungerNotifications.NextWarningAt = morningTime + FreshDayHungerWarningTicks;
+
+        // Let the new day's sickness warning fire even if the player has already been on this day.
+        context.SicknessNotifications.DaysNotified.Remove(day);
+
+        // God-mode commands still take a Planetfall turn, so back the clock off by one tick and let the
+        // end-of-turn increment land it exactly on the day's morning time.
+        chronometer.CurrentTime = morningTime - PlanetfallContext.TurnTimeIncrement;
+
+        return $"God mode: it is now Day {day}. ";
     }
 
     /// <summary>

--- a/Planetfall/Command/PlanetfallGodModeCommands.cs
+++ b/Planetfall/Command/PlanetfallGodModeCommands.cs
@@ -10,18 +10,12 @@ namespace Planetfall.Command;
 public static class PlanetfallGodModeCommands
 {
     /// <summary>
-    ///     The playable calendar. Day 1 is the crash landing; the disease kills on day 9, and both the
-    ///     chronometer's morning times and the per-day sleep pressure are only defined through day 8.
+    ///     Day 1 is the crash landing. The upper bound is derived from the chronometer's morning-time
+    ///     table rather than restated here, so extending the calendar only means adding data there.
     /// </summary>
     private const int FirstDay = 1;
 
-    private const int LastDay = 8;
-
-    /// <summary>
-    ///     Ticks until the first hunger warning of a freshly-started day, matching the well-fed branch of
-    ///     <see cref="SleepEngine" />'s wake-up routine.
-    /// </summary>
-    private const int FreshDayHungerWarningTicks = 800;
+    private static int LastDay => Chronometer.LastDefinedDay;
 
     public static string? Handle(PlanetfallContext context, string input)
     {
@@ -52,56 +46,55 @@ public static class PlanetfallGodModeCommands
     }
 
     /// <summary>
-    ///     Recognizes "god mode day &lt;n&gt;" and jumps the calendar to day n, so playtesting can reach
+    ///     Recognizes "god mode day &lt;n&gt;" and advances the calendar to day n, so playtesting can reach
     ///     day-gated content (the sickness escalation, the shrinking carry limit, the later days' tighter
     ///     sleep schedule) without sleeping through the intervening nights.
-    ///     The jump lands the player at the START of day n, the same state waking up would leave them in:
-    ///     day-n morning on the chronometer, fatigue and hunger reset and rescheduled off that new time,
-    ///     and the disease at the level an untreated player would have reached. Doing less would leave an
-    ///     incoherent clock - the day-n sickness warning only fires before that day's cutoff time, and a
-    ///     stale hunger/sleep warning time carried over from the old day sits thousands of ticks in the
-    ///     future once the chronometer rolls back to morning. What it deliberately does NOT do is the rest
-    ///     of the wake-up routine (dropping the player's inventory on the floor, spoiling their food):
-    ///     that's sleep's cost, not the calendar's, and a tester jumping days shouldn't pay it.
+    ///     It ADVANCES rather than assigns: it replays the game's own day transition
+    ///     (<see cref="SleepEngine.StartNewDay" />) once per day crossed, so every clock that is a function
+    ///     of the day moves by the real rules and stays in step with each other. Assigning the state
+    ///     directly would mean maintaining a second copy of "what a new day means" that silently drifts
+    ///     from the wake-up routine - and would flatten the disease onto the calendar, undoing the
+    ///     medicine for anyone who had treated themselves.
+    ///     What it deliberately does NOT replay is the price of having slept - dropping the player's
+    ///     inventory on the floor, spoiling their food, the nightly death rolls. That's sleep's cost, not
+    ///     the calendar's, and a tester advancing days shouldn't pay it.
+    ///     The calendar only moves forward: the transition has no inverse, so a request for the current
+    ///     day or an earlier one is refused rather than faked.
     /// </summary>
     private static string? SetDay(PlanetfallContext context, string[] words)
     {
-        var index = Array.IndexOf(words, "day");
-        if (index == -1 || index == words.Length - 1)
+        if (!words.Contains("day"))
             return null;
 
-        // A bare "day" with no number isn't ours - fall through to the engine's generic god-mode error
-        // rather than swallowing something the player meant as a different command.
-        if (!int.TryParse(words[index + 1], out var day))
+        // Take the first number anywhere in the command, so every reasonable phrasing works ("day 5",
+        // "set day to 5"). A "day" with no number at all isn't ours - fall through to the engine's
+        // generic god-mode error rather than swallowing something meant as a different command.
+        var argument = words.Select(w => int.TryParse(w, out var n) ? n : (int?)null)
+            .FirstOrDefault(n => n.HasValue);
+        if (argument is not { } day)
             return null;
 
         if (day < FirstDay || day > LastDay)
             return $"God mode: day must be between {FirstDay} and {LastDay}. ";
 
-        context.Day = day;
+        if (day <= context.Day)
+            return $"God mode: the calendar only moves forward, and it's already Day {context.Day}. ";
 
-        // Untreated, the disease tracks the calendar (SicknessCounter starts at 1 == day 1 and advances
-        // one level per night). Leaving it behind would silently cure a tester who jumps to day 7.
-        context.SicknessCounter = day;
+        while (context.Day < day)
+        {
+            // Unreachable in a consistent game - the sickness counter never leads the calendar, so
+            // advancing to a valid day can't reach the fatal level. Guarded anyway rather than letting
+            // god mode quietly strand a tester at counter 9, which the game considers dead.
+            if (context.SicknessCounter + 1 >= SleepEngine.SicknessDeathLevel)
+                return $"God mode: stopped on Day {context.Day} - one more day and the disease " +
+                       "would have killed you. ";
 
-        var chronometer = Repository.GetItem<Chronometer>();
-        chronometer.ResetToMorning(day);
-        var morningTime = chronometer.CurrentTime;
-
-        context.Tired = TiredLevel.WellRested;
-        context.SleepNotifications.ResetForNewDay(morningTime, day);
-
-        // Mirrors the well-fed branch of the wake-up routine in SleepEngine: a fresh day starts fed,
-        // with the first hunger warning 800 ticks out.
-        context.Hunger = HungerLevel.WellFed;
-        context.HungerNotifications.NextWarningAt = morningTime + FreshDayHungerWarningTicks;
-
-        // Let the new day's sickness warning fire even if the player has already been on this day.
-        context.SicknessNotifications.DaysNotified.Remove(day);
+            SleepEngine.StartNewDay(context);
+        }
 
         // God-mode commands still take a Planetfall turn, so back the clock off by one tick and let the
         // end-of-turn increment land it exactly on the day's morning time.
-        chronometer.CurrentTime = morningTime - PlanetfallContext.TurnTimeIncrement;
+        Repository.GetItem<Chronometer>().CurrentTime -= PlanetfallContext.TurnTimeIncrement;
 
         return $"God mode: it is now Day {day}. ";
     }

--- a/Planetfall/Command/PlanetfallGodModeCommands.cs
+++ b/Planetfall/Command/PlanetfallGodModeCommands.cs
@@ -96,7 +96,9 @@ public static class PlanetfallGodModeCommands
         // end-of-turn increment land it exactly on the day's morning time.
         Repository.GetItem<Chronometer>().CurrentTime -= PlanetfallContext.TurnTimeIncrement;
 
-        return $"God mode: it is now Day {day}. ";
+        // Skipping the night also skipped its hazards, so the world may have moved on without the
+        // player - let the context reconcile where they're standing against the day they're now in.
+        return $"God mode: it is now Day {day}. " + context.OnGodModeCalendarJump();
     }
 
     /// <summary>

--- a/Planetfall/Item/Feinstein/Chronometer.cs
+++ b/Planetfall/Item/Feinstein/Chronometer.cs
@@ -1,3 +1,5 @@
+using Newtonsoft.Json;
+
 namespace Planetfall.Item.Feinstein;
 
 public class Chronometer : ItemBase, ICanBeTakenAndDropped, ICanBeExamined, ICanBeRead, IAmClothing
@@ -20,8 +22,29 @@ public class Chronometer : ItemBase, ICanBeTakenAndDropped, ICanBeExamined, ICan
         { 8, 3200 }   // Day 8: ~3200-3280
     };
 
-    // Start time of the game (random between 4500-4700)
+    /// <summary>
+    /// Spread of the wake-up time past the day's base morning time, so no two mornings land on exactly
+    /// the same tick.
+    /// </summary>
+    public const int MorningJitterTicks = 80;
+
+    /// <summary>
+    /// The last day the morning-time table defines. The playable calendar can't outrun this: waking on
+    /// a day with no entry would leave the chronometer on the previous day's time.
+    /// </summary>
+    public static int LastDefinedDay => MorningTimesByDay.Keys.Max();
+
+    // Start time of the game (random between 4500-4700). This one stays on the raw Random: it's a
+    // property initializer, so it runs before anything could inject a chooser - and no test can pin a
+    // value that is chosen at construction time.
     public int CurrentTime { get; set; } = Random.Next(4500, 4700);
+
+    /// <summary>
+    /// Injectable randomness for the morning jitter, so tests can pin the wake-up time.
+    /// </summary>
+    [UsedImplicitly]
+    [JsonIgnore]
+    public IRandomChooser Chooser { get; set; } = new RandomChooser();
 
     public override string[] NounsForMatching => ["chronometer", "watch", "wrist-watch"];
 
@@ -33,7 +56,7 @@ public class Chronometer : ItemBase, ICanBeTakenAndDropped, ICanBeExamined, ICan
     {
         if (MorningTimesByDay.TryGetValue(day, out var baseTime))
         {
-            CurrentTime = baseTime + Random.Next(80);
+            CurrentTime = baseTime + Chooser.RollDice(MorningJitterTicks);
         }
     }
 

--- a/Planetfall/Item/Feinstein/Chronometer.cs
+++ b/Planetfall/Item/Feinstein/Chronometer.cs
@@ -56,7 +56,9 @@ public class Chronometer : ItemBase, ICanBeTakenAndDropped, ICanBeExamined, ICan
     {
         if (MorningTimesByDay.TryGetValue(day, out var baseTime))
         {
-            CurrentTime = baseTime + Chooser.RollDice(MorningJitterTicks);
+            // RollDice is 1-based (1..sides); subtract one to keep the original 0-based spread, so the
+            // player can still wake at the day's exact base time.
+            CurrentTime = baseTime + Chooser.RollDice(MorningJitterTicks) - 1;
         }
     }
 

--- a/Planetfall/Location/IFloodedOnLaterDays.cs
+++ b/Planetfall/Location/IFloodedOnLaterDays.cs
@@ -1,0 +1,21 @@
+namespace Planetfall.Location;
+
+/// <summary>
+///     A location on the lower cliff that the rising ocean takes away as the calendar advances - the
+///     rooms whose neighbours stop routing to them and start routing to <c>Underwater</c> instead.
+///     Normal play can never strand the player in one: the only way to cross a day is to sleep, and
+///     sleeping down there drowns you. A god-mode calendar advance deliberately skips that death (see
+///     <see cref="SleepEngine.StartNewDay" />), so it has to move the player off the room itself, which
+///     is what this interface is for.
+///     Each room answers for itself rather than a central list deciding on its behalf, so the rule
+///     lives beside the day-conditional <c>Map</c> that already encodes the same flooding.
+/// </summary>
+public interface IFloodedOnLaterDays
+{
+    /// <summary>
+    ///     The room to spill the player into once the given day has put this one under water, or null
+    ///     while it is still dry. The destination must be strictly further from the water, so that
+    ///     following it repeatedly terminates.
+    /// </summary>
+    ILocation? HigherGroundOn(int day);
+}

--- a/Planetfall/Location/Kalamontee/Balcony.cs
+++ b/Planetfall/Location/Kalamontee/Balcony.cs
@@ -5,11 +5,15 @@ namespace Planetfall.Location.Kalamontee;
 
 // TODO: Sleep here on day three and die. 
 
-public class Balcony : LocationBase
+public class Balcony : LocationBase, IFloodedOnLaterDays
 {
     public override string Name => "Balcony";
 
     public override string[] NounsForMatching => ["terrace"];
+
+    // Underwater from Day 4 on - the Winding Stair above only routes Down to here while Day < 4, and
+    // the Day 3 description already has the ocean lapping at the base.
+    public ILocation? HigherGroundOn(int day) => day >= 4 ? Repository.GetLocation<WindingStair>() : null;
 
     public string DeathDescription =>
         "Suddenly, in the middle of the night, a wave of water washes over you. Before you can quite get your bearings, you drown. ";

--- a/Planetfall/Location/Kalamontee/Crag.cs
+++ b/Planetfall/Location/Kalamontee/Crag.cs
@@ -4,11 +4,15 @@ namespace Planetfall.Location.Kalamontee;
 
 // TODO: Sleep here and die. 
 
-public class Crag : LocationWithNoStartingItems
+public class Crag : LocationWithNoStartingItems, IFloodedOnLaterDays
 {
     public override string Name => "Crag";
 
     public override string[] NounsForMatching => ["ledge", "cleft", "cliff"];
+
+    // Underwater from Day 2 on - the Balcony above only routes Down to here while it is Day 1, and its
+    // own Day 2 description says so outright ("The crag where you landed yesterday is now underwater!").
+    public ILocation? HigherGroundOn(int day) => day > 1 ? Repository.GetLocation<Balcony>() : null;
 
     public string DeathDescription =>
         "Suddenly, in the middle of the night, a wave of water washes over you. Before you can quite get your bearings, you drown. ";

--- a/Planetfall/PlanetfallContext.cs
+++ b/Planetfall/PlanetfallContext.cs
@@ -323,13 +323,31 @@ public class PlanetfallContext : Context<PlanetfallGame>, ITimeBasedContext, IGo
     ///     EscapePod's own sinking timer is disarmed unless the destination is EscapePod itself, so a
     ///     tester can still teleport in to observe that sequence.
     /// </summary>
-    public void OnGodModeTeleport()
+    public string? OnGodModeTeleport()
     {
         if (CurrentLocation is not DeckNine)
             RemoveActor<ExplosionCoordinator>();
 
         if (CurrentLocation is not EscapePod)
             RemoveActor<EscapePod>();
+
+        // Unlike a calendar advance, this is an explicit request to be somewhere, and reaching states
+        // the game's own rules make unreachable is the entire point of god mode - so we obey it and
+        // only warn. See OnGodModeCalendarJump for the case where the player never asked to move.
+        return DrownedRoomWarning();
+    }
+
+    /// <summary>
+    ///     Warns when the player is standing in a room the rising ocean has already taken on the current
+    ///     day - a state normal play cannot produce, since the only way to cross a day is to sleep and
+    ///     sleeping down there drowns you.
+    /// </summary>
+    private string? DrownedRoomWarning()
+    {
+        return CurrentLocation is IFloodedOnLaterDays flooded && flooded.HigherGroundOn(Day) is not null
+            ? $"Note that the {CurrentLocation.Name} is under water on Day {Day} - god mode has put you " +
+              "somewhere the game itself can no longer reach. "
+            : null;
     }
 
     /// <summary>
@@ -347,19 +365,31 @@ public class PlanetfallContext : Context<PlanetfallGame>, ITimeBasedContext, IGo
     {
         var startedAt = CurrentLocation;
 
-        // Guard against a mis-implemented HigherGroundOn pointing back at a room we already left; the
-        // interface requires strictly higher ground, but a cycle here would hang the game.
-        var visited = new HashSet<ILocation> { CurrentLocation };
+        // Walk the chain to the final destination BEFORE moving anyone. The player is swept straight to
+        // dry ground - they were never really in the rooms the water carried them through, so those must
+        // not count as visited (which would spend their first-visit text and points on a room they never
+        // saw). Guard against a mis-implemented HigherGroundOn cycling back: the interface requires
+        // strictly higher ground, but a cycle here would hang the game.
+        var destination = startedAt;
+        var visited = new HashSet<ILocation> { destination };
 
-        while (CurrentLocation is IFloodedOnLaterDays flooded &&
+        while (destination is IFloodedOnLaterDays flooded &&
                flooded.HigherGroundOn(Day) is { } higherGround &&
                visited.Add(higherGround))
-            CurrentLocation = higherGround;
+            destination = higherGround;
 
-        return ReferenceEquals(startedAt, CurrentLocation)
-            ? null
-            : $"The rising water has taken the {startedAt.Name}; you've been moved up to " +
-              $"the {CurrentLocation.Name}. ";
+        if (ReferenceEquals(destination, startedAt))
+            return null;
+
+        // Move them the way the game moves anyone, so the destination's entry hooks run and they can
+        // see where they've been put. AfterEnterLocation is the one part we can't run - it's async and
+        // needs a generation client this hook has no access to - and it's narrative flavour, not state.
+        startedAt.OnLeaveLocation(this, destination, startedAt);
+        CurrentLocation = destination;
+        var enteringText = destination.BeforeEnterLocation(this, startedAt);
+
+        return $"The rising water has taken the {startedAt.Name}; you've been moved up to " +
+               $"the {destination.Name}.\n\n" + enteringText + destination.GetDescription(this);
     }
 
     /// <summary>

--- a/Planetfall/PlanetfallContext.cs
+++ b/Planetfall/PlanetfallContext.cs
@@ -381,6 +381,12 @@ public class PlanetfallContext : Context<PlanetfallGame>, ITimeBasedContext, IGo
         if (ReferenceEquals(destination, startedAt))
             return null;
 
+        // Match normal movement's pronoun cleanup: antecedents for objects left in the flooded room
+        // must not follow the player uphill, while carried objects remain valid after the move.
+        if (!HasMatchingNoun(LastNoun).HasItem)
+            LastNoun = "";
+        LastNouns = LastNouns.Where(noun => HasMatchingNoun(noun).HasItem).ToList();
+
         // Move them the way the game moves anyone, so the destination's entry hooks run and they can
         // see where they've been put. AfterEnterLocation is the one part we can't run - it's async and
         // needs a generation client this hook has no access to - and it's narrative flavour, not state.

--- a/Planetfall/PlanetfallContext.cs
+++ b/Planetfall/PlanetfallContext.cs
@@ -2,6 +2,7 @@ using Model.AIGeneration.Requests;
 using Newtonsoft.Json;
 using Planetfall.Command;
 using Planetfall.Item.Kalamontee.Mech.FloydPart;
+using Planetfall.Location;
 using Planetfall.Location.Kalamontee;
 using Utilities;
 
@@ -329,6 +330,36 @@ public class PlanetfallContext : Context<PlanetfallGame>, ITimeBasedContext, IGo
 
         if (CurrentLocation is not EscapePod)
             RemoveActor<EscapePod>();
+    }
+
+    /// <summary>
+    ///     The calendar counterpart of <see cref="OnGodModeTeleport" />. "god mode day &lt;n&gt;" is a raw
+    ///     time swap: it advances the calendar without the sleep that normally carries the player across a
+    ///     night, and therefore without sleep's death rolls. The lower cliff is the one place that matters
+    ///     for - the Crag and the Balcony go under as the days pass, and real play can never strand you
+    ///     there precisely because sleeping down there drowns you. So after a calendar jump we spill the
+    ///     player onto higher ground ourselves, repeating until they are dry (the Crag's refuge is the
+    ///     Balcony, which on a later day has gone under too).
+    ///     Returns a note for the player, or null when nothing had to move. Each room decides for itself
+    ///     via <see cref="IFloodedOnLaterDays" />, so adding another drowned room needs no change here.
+    /// </summary>
+    public string? OnGodModeCalendarJump()
+    {
+        var startedAt = CurrentLocation;
+
+        // Guard against a mis-implemented HigherGroundOn pointing back at a room we already left; the
+        // interface requires strictly higher ground, but a cycle here would hang the game.
+        var visited = new HashSet<ILocation> { CurrentLocation };
+
+        while (CurrentLocation is IFloodedOnLaterDays flooded &&
+               flooded.HigherGroundOn(Day) is { } higherGround &&
+               visited.Add(higherGround))
+            CurrentLocation = higherGround;
+
+        return ReferenceEquals(startedAt, CurrentLocation)
+            ? null
+            : $"The rising water has taken the {startedAt.Name}; you've been moved up to " +
+              $"the {CurrentLocation.Name}. ";
     }
 
     /// <summary>

--- a/Planetfall/SleepEngine.cs
+++ b/Planetfall/SleepEngine.cs
@@ -42,6 +42,20 @@ public class SleepEngine
     public static IRandomChooser Chooser { get; set; } = new RandomChooser();
 
     /// <summary>
+    /// What a day rolling over left behind, for the caller to narrate.
+    /// </summary>
+    /// <param name="Survived">
+    /// False when the disease reached <see cref="SicknessDeathLevel" />, leaving the caller to run the
+    /// death - the counters are already advanced at that point, exactly as before.
+    /// </param>
+    /// <param name="WokeFamished">
+    /// Whether the player crossed into the new day hungry. This is the same reading that chose the
+    /// shorter hunger timer, handed back rather than left for the caller to re-derive, so the timer and
+    /// the sentence explaining it can never disagree.
+    /// </param>
+    internal readonly record struct DayTransition(bool Survived, bool WokeFamished);
+
+    /// <summary>
     /// Advances the calendar one day and re-establishes everything that is a function of the day: the
     /// disease level, the chronometer's morning time, fatigue, and the sleep/hunger warning schedules.
     /// This is the "it is now a new day" half of waking up. The costs of having SLEPT - dropping what
@@ -49,10 +63,8 @@ public class SleepEngine
     /// <see cref="ProcessWakeUp" />, because they are sleep's price and not the calendar's; that split
     /// is what lets the god-mode day command replay the real transition without confiscating a
     /// tester's inventory.
-    /// Returns false when the disease has reached <see cref="SicknessDeathLevel" />, leaving the caller
-    /// to run the death - the counters are already advanced at that point, exactly as before.
     /// </summary>
-    internal static bool StartNewDay(PlanetfallContext context)
+    internal static DayTransition StartNewDay(PlanetfallContext context)
     {
         context.Day++;
 
@@ -62,10 +74,9 @@ public class SleepEngine
         // Untreated, the counter tracks the day and the player still dies on the original day-9 schedule.
         context.SicknessCounter++;
         if (context.SicknessCounter >= SicknessDeathLevel)
-            return false;
+            return new DayTransition(false, false);
 
-        // Was the player hungry when the day turned over? Read this BEFORE the reset below clears it -
-        // it decides both the shorter hunger timer and the caller's "incredibly famished" line.
+        // Was the player hungry when the day turned over? Read this BEFORE the reset below clears it.
         var wokeFamished = context.Hunger > HungerLevel.WellFed;
 
         // Reset chronometer to morning time for the new day
@@ -88,7 +99,7 @@ public class SleepEngine
         context.HungerNotifications.NextWarningAt = context.CurrentTime +
             (wokeFamished ? FamishedHungerWarningTicks : FreshHungerWarningTicks);
 
-        return true;
+        return new DayTransition(true, wokeFamished);
     }
 
     /// <summary>
@@ -196,12 +207,10 @@ public class SleepEngine
     /// </summary>
     private static string ProcessWakeUp(PlanetfallContext context)
     {
-        // Read this before StartNewDay clears it - it decides the "incredibly famished" line below.
-        var wokeFamished = context.Hunger > HungerLevel.WellFed;
-
         // Advance the calendar and every clock derived from it. Everything from here down is the price
         // of having SLEPT, which is why it lives here rather than in the shared transition.
-        if (!StartNewDay(context))
+        var transition = StartNewDay(context);
+        if (!transition.Survived)
             return new DeathProcessor().Process(
                 "You finally succumb to the ravages of your illness and collapse.",
                 context).InteractionMessage;
@@ -254,8 +263,9 @@ public class SleepEngine
                 message += "You wake feeling weak and worn-out. It will be an effort just to stand up. ";
         }
 
-        // Hunger itself was reset and rescheduled by StartNewDay; only the narration belongs here.
-        if (wokeFamished)
+        // Hunger itself was reset and rescheduled by StartNewDay; only the narration belongs here, and
+        // it reads the same decision the timer used rather than re-deriving it.
+        if (transition.WokeFamished)
             message += "You are also incredibly famished. Better get some breakfast! ";
 
         // Floyd greeting (if present and active)

--- a/Planetfall/SleepEngine.cs
+++ b/Planetfall/SleepEngine.cs
@@ -24,9 +24,72 @@ public class SleepEngine
     };
 
     /// <summary>
+    /// Sickness level at which the disease is fatal (mirrors the original's SICKNESS-LEVEL 9).
+    /// </summary>
+    internal const int SicknessDeathLevel = 9;
+
+    /// <summary>
+    /// Ticks until the first hunger warning of a new day, depending on whether the player ended the
+    /// previous day hungry.
+    /// </summary>
+    private const int FamishedHungerWarningTicks = 200;
+
+    private const int FreshHungerWarningTicks = 800;
+
+    /// <summary>
     /// Injectable random chooser for deterministic testing.
     /// </summary>
     public static IRandomChooser Chooser { get; set; } = new RandomChooser();
+
+    /// <summary>
+    /// Advances the calendar one day and re-establishes everything that is a function of the day: the
+    /// disease level, the chronometer's morning time, fatigue, and the sleep/hunger warning schedules.
+    /// This is the "it is now a new day" half of waking up. The costs of having SLEPT - dropping what
+    /// you were carrying, spoiling food, the wake-up narration - deliberately stay in
+    /// <see cref="ProcessWakeUp" />, because they are sleep's price and not the calendar's; that split
+    /// is what lets the god-mode day command replay the real transition without confiscating a
+    /// tester's inventory.
+    /// Returns false when the disease has reached <see cref="SicknessDeathLevel" />, leaving the caller
+    /// to run the death - the counters are already advanced at that point, exactly as before.
+    /// </summary>
+    internal static bool StartNewDay(PlanetfallContext context)
+    {
+        context.Day++;
+
+        // Issue #116: advance the disease one level per day (mirrors the I-SICKNESS-WARNINGS daemon's
+        // once-per-day SICKNESS-LEVEL increment, globals.zil:2330). Death is tied to the sickness counter,
+        // not the calendar - so treating the illness (which lowers the counter) actually postpones death.
+        // Untreated, the counter tracks the day and the player still dies on the original day-9 schedule.
+        context.SicknessCounter++;
+        if (context.SicknessCounter >= SicknessDeathLevel)
+            return false;
+
+        // Was the player hungry when the day turned over? Read this BEFORE the reset below clears it -
+        // it decides both the shorter hunger timer and the caller's "incredibly famished" line.
+        var wokeFamished = context.Hunger > HungerLevel.WellFed;
+
+        // Reset chronometer to morning time for the new day
+        // (Per SLEEP_MECHANICS.md reset_time routine - each day starts at progressively later time)
+        Repository.GetItem<Chronometer>().ResetToMorning(context.Day);
+
+        // Reset fatigue
+        context.Tired = TiredLevel.WellRested;
+
+        // Reset sleep timer for new day (must be after chronometer reset since it uses CurrentTime)
+        context.SleepNotifications.ResetForNewDay(context.CurrentTime, context.Day);
+
+        // Enable next sickness check
+        context.SicknessNotifications.DaysNotified.Remove(context.Day);
+
+        // Original game set HUNGER_LEVEL = 4 (AboutToPassOut) with 100 tick delay - very punishing
+        // Override: Reset to WellFed with shorter initial timer, giving player ~31 turns to find food
+        // This is more forgiving while still creating urgency via the warning message
+        context.Hunger = HungerLevel.WellFed;
+        context.HungerNotifications.NextWarningAt = context.CurrentTime +
+            (wokeFamished ? FamishedHungerWarningTicks : FreshHungerWarningTicks);
+
+        return true;
+    }
 
     /// <summary>
     /// Processes voluntary sleep (player enters bed while tired).
@@ -133,31 +196,15 @@ public class SleepEngine
     /// </summary>
     private static string ProcessWakeUp(PlanetfallContext context)
     {
-        // Advance day
-        context.Day++;
+        // Read this before StartNewDay clears it - it decides the "incredibly famished" line below.
+        var wokeFamished = context.Hunger > HungerLevel.WellFed;
 
-        // Issue #116: advance the disease one level per day (mirrors the I-SICKNESS-WARNINGS daemon's
-        // once-per-day SICKNESS-LEVEL increment, globals.zil:2330). Death is tied to the sickness counter,
-        // not the calendar - so treating the illness (which lowers the counter) actually postpones death.
-        // Untreated, the counter tracks the day and the player still dies on the original day-9 schedule.
-        context.SicknessCounter++;
-        if (context.SicknessCounter >= 9)
+        // Advance the calendar and every clock derived from it. Everything from here down is the price
+        // of having SLEPT, which is why it lives here rather than in the shared transition.
+        if (!StartNewDay(context))
             return new DeathProcessor().Process(
                 "You finally succumb to the ravages of your illness and collapse.",
                 context).InteractionMessage;
-
-        // Reset chronometer to morning time for the new day
-        // (Per SLEEP_MECHANICS.md reset_time routine - each day starts at progressively later time)
-        Repository.GetItem<Chronometer>().ResetToMorning(context.Day);
-
-        // Reset fatigue
-        context.Tired = TiredLevel.WellRested;
-
-        // Reset sleep timer for new day (must be after chronometer reset since it uses CurrentTime)
-        context.SleepNotifications.ResetForNewDay(context.CurrentTime, context.Day);
-
-        // Enable next sickness check
-        context.SicknessNotifications.DaysNotified.Remove(context.Day);
 
         // Drop non-worn inventory items to the floor
         // If in bed, drop to parent location (dormitory floor), otherwise drop to current location
@@ -207,20 +254,9 @@ public class SleepEngine
                 message += "You wake feeling weak and worn-out. It will be an effort just to stand up. ";
         }
 
-        // Hunger adjustment
-        // Original game set HUNGER_LEVEL = 4 (AboutToPassOut) with 100 tick delay - very punishing
-        // Override: Reset to WellFed with shorter initial timer, giving player ~31 turns to find food
-        // This is more forgiving while still creating urgency via the warning message
-        if (context.Hunger > HungerLevel.WellFed)
-        {
-            context.Hunger = HungerLevel.WellFed;
-            context.HungerNotifications.NextWarningAt = context.CurrentTime + 200;
+        // Hunger itself was reset and rescheduled by StartNewDay; only the narration belongs here.
+        if (wokeFamished)
             message += "You are also incredibly famished. Better get some breakfast! ";
-        }
-        else
-        {
-            context.HungerNotifications.NextWarningAt = context.CurrentTime + 800;
-        }
 
         // Floyd greeting (if present and active)
         var floyd = Repository.GetItem<Floyd>();


### PR DESCRIPTION
Closes #458.

## What

Adds a Planetfall god-mode subcommand, `god mode day <n>`, that advances the calendar to day *n*.

## Why

Day-gated content — the sickness escalation, the shrinking carry limit (`EffectiveLoadAllowed`), the later days' progressively tighter sleep schedule, the flooding of the lower cliff — previously required sleeping through every intervening night to reach. There was no way to drop straight into day 6 and test what happens there.

## How it works

It **advances** rather than assigns. `SleepEngine.StartNewDay` is extracted from `ProcessWakeUp` and replayed once per day crossed, so every clock that is a function of the day moves by the game's own rules and stays in step with the others:

- `Day` and `SicknessCounter` both increment
- chronometer reset to that day's morning time
- fatigue reset, sleep schedule re-armed with that day's interval
- hunger reset and rescheduled off the new time
- that day's sickness notification re-armed

Assigning this state directly — the first draft of this PR — meant maintaining a second copy of "what a new day means" that would silently drift from the wake-up routine. It also flattened the disease onto the calendar: setting `SicknessCounter = day` undid the experimental medicine for anyone who had treated themselves. Incrementing preserves the treatment, which is the behavior the game actually specifies.

**What it deliberately does not replay** is the price of having *slept*: dropping the player's inventory on the floor, spoiling food, the nightly death rolls. Those are sleep's cost, not the calendar's, and a tester advancing days shouldn't pay them. That split is exactly where `StartNewDay` was cut.

**The calendar only moves forward.** The transition has no inverse, so a request for the current day or an earlier one is refused rather than faked.

**Rooms the calendar floods evacuate the player.** Because the advance skips sleep's hazards, it could otherwise produce a state normal play cannot: standing dry on the Crag on Day 5. The Crag is reachable only on Day 1 (the Balcony routes `Down` to `Underwater` afterwards), and the only reason you can never be stranded there is that sleeping on it drowns you — the hazard the advance skips. New `IFloodedOnLaterDays` lets a room say when the rising ocean has taken it and name the higher ground to spill into; `Crag` and `Balcony` implement it beside the day-conditional `Map` that already encodes the same flooding, so no central list decides on their behalf. `PlanetfallContext.OnGodModeCalendarJump` walks that chain until the player is dry — from the Crag on Day 5 that means two hops, since the Balcony has gone under too — and reports the move. It is the calendar counterpart of the existing `OnGodModeTeleport` hook, which exists for the same reason: a raw god-mode state swap needs the game, not the engine, to reconcile what the swap skipped.

## Divergence from the issue

#458 suggests `SetDay` "sets `PlanetfallContext.Day` directly". This advances instead, for two reasons found while building it: assigning the state means a second copy of the day transition that drifts from `ProcessWakeUp`, and `SicknessCounter = day` silently undoes the medicine for a treated player. The issue's actual goal — reach day-gated content without sleeping through the nights — is met either way.

One consequence worth flagging to the issue author: because the transition has no inverse, the calendar only moves forward. The issue's worked example (`god mode day 5` → sleep at the Winding Stair → `god mode day 6`) still works, since it only ever moves forward. Going *back* to re-check an earlier day now means a fresh game.

That example also motivated the flood handling: `god mode go` into a drowned room is honoured, not bounced, precisely because deliberately inspecting unreachable states is what the issue wants god mode for.

## Command surface

`god mode day 5`, or any phrasing carrying "day" and a number (`god mode set day to 5`). The upper bound derives from `Chronometer.MorningTimesByDay` rather than restating the game's length, so extending the calendar means adding data in one place. Out-of-range days are refused with `God mode: day must be between 1 and 8.`; a bare `god mode day` or `god mode day tuesday` falls through to the engine's generic god-mode error rather than swallowing a command meant as something else.

Following the existing pattern in `PlanetfallGodModeCommands` — loose word matching, reached through `IGodModeCommandHandler` — so no Planetfall concepts leak into the engine's `GodModeProcessor`.

## Also in here

`Chronometer.ResetToMorning` now uses the injected `IRandomChooser` instead of a raw `Random`, per the repo's randomness rule, so the wake time can be pinned and asserted exactly rather than as an 80-tick range. The construction-time start time keeps its raw `Random`: a property initializer runs before anything could inject a chooser, and no test can pin a value chosen at construction.

## Testing (TDD)

`Planetfall.Tests/DayGodModeTests.cs`, 25 tests: command wiring, each piece of day-coupled state, the boundary with sleep's costs (the tester keeps their inventory), flood evacuation with both controls (the Balcony stays put on Day 3, an untouched room never sees the message), argument validation, and save/restore persistence of both the calendar and the clock it is coupled to.

Every behavioral test was confirmed red before its implementation — for the first commit by unwiring the branch and re-running, for the later ones by writing the test first.

The existing sleep and sickness suites passing untouched is the regression proof for the `ProcessWakeUp` extraction.

- `Planetfall.Tests` — 3136 passed
- `UnitTests` — 1046 passed, 1 skipped
- `ZorkOne.Tests` — 1781 passed

## Known gaps, deliberately left

- **Day 8's sickness warning is unreachable.** Its cutoff is 3000 but Day 8 wakes at 3200+, so `SicknessNotifications.GetNotification` never matches. This is true in normal play too — a pre-existing data bug, not this PR's, and worth checking `I-SICKNESS-WARNINGS` in the ZIL before deciding whether the cutoff or the comparison is wrong. Tracked separately.
- **A forced sleep on the same turn swallows the command.** `GameEngine.cs:506` returns early on `TurnConsumedByForcedEvent` and discards the input, so an exhausted tester typing this command can lose it. Engine-level and out of scope; `god mode no sleep` is the workaround. Note for anyone tempted to fix it by making god mode a free command: the `-TurnTimeIncrement` compensation in both `ResetClock` and `SetDay` is correct only because god mode currently takes a turn.

## Reviewer note

Flood evacuation moves the player silently upward and tells them, rather than refusing the advance while they're standing somewhere it would flood. The former keeps the command always-works; the latter is more conservative. Easy to flip if you'd prefer the refusal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
