### PR TITLE
Fix #448: safety web gates on its noun, not the sit/get/leave verb alone

### DIFF
--- a/Planetfall.Tests/ExplosionTests.cs
+++ b/Planetfall.Tests/ExplosionTests.cs
@@ -684,4 +684,120 @@ public class ExplosionTests : EngineTestsBase
             result!.InteractionMessage.Should().Contain("You're not in the safety web.");
         }
     }
+
+    // Issue #448 follow-up: the same handler gated each verb list on SubLocation, so each list could
+    // only ever produce its *complaint* - the seated branch only ever reached GetIn's "You're already
+    // in the safety web", the standing branch only ever reached GetOut's "You're not in the safety
+    // web". Naming the webbing in the OTHER state matched no branch at all and fell through to base,
+    // where no processor handles sit/leave on the web: a blank line. GetIn/GetOut each already answer
+    // their own wrong-state case, so the state gates were never needed.
+    [TestFixture]
+    public class SafetyWebWrongStateTests : EngineTestsBase
+    {
+        private static EscapePod Pod(GameEngine<PlanetfallGame, PlanetfallContext> target, bool seated)
+        {
+            var pod = Repository.GetLocation<EscapePod>();
+            pod.Init(); // place BulkheadDoor and SafetyWeb in the pod's scope
+            target.Context.CurrentLocation = pod;
+            pod.SubLocation = seated ? Repository.GetItem<SafetyWeb>() : null;
+            return pod;
+        }
+
+        [Test]
+        public async Task SitOnTheWebbing_WhileStanding_PutsYouInTheWeb()
+        {
+            var target = GetTarget();
+            var pod = Pod(target, seated: false);
+
+            var response = await target.GetResponse("sit on the webbing");
+
+            response.Should().Contain("You are now safely cushioned within the web.");
+            pod.SubLocation.Should().BeOfType<SafetyWeb>();
+        }
+
+        // "leave the webbing"/"exit webbing" are caught upstream as raw phrases by
+        // EscapePod.RespondToSpecificLocationInteraction; the bare noun "web" is the phrasing that
+        // reaches this handler as a SimpleIntent, and it used to answer with nothing at all.
+        [Test]
+        public async Task LeaveWeb_WhileSeated_StandsYouUp()
+        {
+            var target = GetTarget();
+            var pod = Pod(target, seated: true);
+
+            var response = await target.GetResponse("leave web");
+
+            response.Should().Contain("You are standing again.");
+            pod.SubLocation.Should().BeNull();
+        }
+
+        // The "exit" verb takes the same branch as "leave". Called directly because the test parser
+        // doesn't carry "exit" as a verb, so the phrasing can't reach the handler through the engine.
+        [Test]
+        public async Task ExitWeb_WhileSeated_StandsYouUp()
+        {
+            var target = GetTarget();
+            var pod = Pod(target, seated: true);
+
+            var action = new SimpleIntent { Verb = "exit", Noun = "web" };
+            var result = await Repository.GetItem<SafetyWeb>().RespondToSimpleInteraction(action, target.Context,
+                Mock.Of<IGenerationClient>(), new ItemProcessorFactory(Mock.Of<IAITakeAndAndDropParser>()));
+
+            result.Should().BeOfType<PositiveInteractionResult>();
+            result!.InteractionMessage.Should().Contain("You are standing again.");
+            pod.SubLocation.Should().BeNull();
+        }
+
+        // Standing up in the landed pod is what starts it sinking. Leaving the webbing by name must
+        // behave exactly like the bare "stand" - the hazard can't be dodged by phrasing. Two fresh
+        // games so no state leaks between the two commands.
+        [Test]
+        public async Task LeaveWeb_InTheLandedPod_StartsThePodSinking_ExactlyLikeStanding()
+        {
+            var standTarget = GetTarget();
+            var standPod = Pod(standTarget, seated: true);
+            standPod.LandedSafely = true;
+            var standResponse = await standTarget.GetResponse("stand");
+
+            var leaveTarget = GetTarget();
+            var leavePod = Pod(leaveTarget, seated: true);
+            leavePod.LandedSafely = true;
+            var leaveResponse = await leaveTarget.GetResponse("leave web");
+
+            standResponse.Should().Contain("you see water rising past the viewport");
+            leaveResponse.Should().Be(standResponse);
+            leavePod.TurnsAfterStanding.Should().Be(standPod.TurnsAfterStanding).And.BeGreaterThan(0);
+        }
+
+        [Test]
+        public async Task GetWeb_WhileStanding_PutsYouInTheWeb()
+        {
+            var target = GetTarget();
+            var pod = Pod(target, seated: false);
+
+            // Previously answered "You're not in the safety web." - a nonsense reply to a request to
+            // get INTO it.
+            var response = await target.GetResponse("get web");
+
+            response.Should().Contain("You are now safely cushioned within the web.");
+            pod.SubLocation.Should().BeOfType<SafetyWeb>();
+        }
+
+        // Deliberate asymmetry: "get" is the one verb in both directions ("get in"/"get out" with the
+        // preposition lost), so it must never be read as *leaving*. Standing up in the landed pod
+        // starts an unrecoverable sinking clock, and an ambiguous verb must not trigger that - only an
+        // explicit leave/exit/stand may. Seated, "get web" says so and changes nothing.
+        [Test]
+        public async Task GetWeb_WhileSeated_DoesNotStandYouUp()
+        {
+            var target = GetTarget();
+            var pod = Pod(target, seated: true);
+            pod.LandedSafely = true;
+
+            var response = await target.GetResponse("get web");
+
+            response.Should().Contain("You're already in the safety web.");
+            pod.SubLocation.Should().BeOfType<SafetyWeb>();
+            pod.TurnsAfterStanding.Should().Be(0);
+        }
+    }
 }

--- a/Planetfall.Tests/ExplosionTests.cs
+++ b/Planetfall.Tests/ExplosionTests.cs
@@ -1,6 +1,10 @@
 using FluentAssertions;
 using GameEngine;
+using GameEngine.Item;
+using Model.AIGeneration;
 using Model.AIParsing;
+using Model.Intent;
+using Model.Interaction;
 using Model.Interface;
 using Moq;
 using OpenAI;
@@ -567,6 +571,117 @@ public class ExplosionTests : EngineTestsBase
 
             response.Should().Contain("You are now safely cushioned within the web.");
             pod.SubLocation.Should().BeOfType<SafetyWeb>();
+        }
+    }
+
+    // Issue #448: SafetyWeb.RespondToSimpleInteraction matched on the VERB alone, with no check that
+    // the noun was the webbing. Because the web is seeded into the pod's Items (issue #376),
+    // LocationBase.RespondToSimpleInteraction runs its handler for every command in the room, so any
+    // sit/get/rest (while seated) or leave/exit/get (while standing) command was hijacked regardless
+    // of its object: "sit on the control panel" answered "You're already in the safety web."
+    [TestFixture]
+    public class SafetyWebNounGuardTests : EngineTestsBase
+    {
+        private static EscapePod PodWithPlayerInTheWeb(GameEngine<PlanetfallGame, PlanetfallContext> target)
+        {
+            var pod = Repository.GetLocation<EscapePod>();
+            pod.Init(); // place BulkheadDoor and SafetyWeb in the pod's scope
+            target.Context.CurrentLocation = pod;
+            pod.SubLocation = Repository.GetItem<SafetyWeb>();
+            return pod;
+        }
+
+        [Test]
+        public async Task SitOnControlPanel_WhileInTheWeb_DoesNotClaimYoureAlreadyInTheWeb()
+        {
+            var target = GetTarget();
+            PodWithPlayerInTheWeb(target);
+
+            var response = await target.GetResponse("sit on the control panel");
+
+            response.Should().NotContain("already in the safety web");
+        }
+
+        [Test]
+        public async Task SitOnUnrelatedNoun_WhileInTheWeb_DoesNotClaimYoureAlreadyInTheWeb()
+        {
+            var target = GetTarget();
+            PodWithPlayerInTheWeb(target);
+
+            // "rug" is about as far from the webbing as a noun gets, and it isn't in the pod at all.
+            var response = await target.GetResponse("sit on rug");
+
+            response.Should().NotContain("already in the safety web");
+        }
+
+        [Test]
+        public async Task SitOnTheWebbing_WhileInTheWeb_StillRoutesToTheWeb()
+        {
+            var target = GetTarget();
+            PodWithPlayerInTheWeb(target);
+
+            var response = await target.GetResponse("sit on the webbing");
+
+            response.Should().Contain("You're already in the safety web.");
+        }
+
+        [Test]
+        public async Task BareSit_WhileInTheWeb_StillRoutesToTheWeb()
+        {
+            var target = GetTarget();
+            PodWithPlayerInTheWeb(target);
+
+            var response = await target.GetResponse("sit");
+
+            response.Should().Contain("You're already in the safety web.");
+        }
+
+        [Test]
+        public async Task BareSit_WhileStanding_StillPutsYouInTheWeb()
+        {
+            var target = GetTarget();
+            var pod = Repository.GetLocation<EscapePod>();
+            pod.Init();
+            target.Context.CurrentLocation = pod;
+
+            var response = await target.GetResponse("sit");
+
+            response.Should().Contain("You are now safely cushioned within the web.");
+            pod.SubLocation.Should().BeOfType<SafetyWeb>();
+        }
+
+        // The standing-side branch (leave/exit/get) has the identical defect and must be guarded too.
+        [Test]
+        public async Task LeaveUnrelatedNoun_WhileStanding_DoesNotClaimYoureNotInTheWeb()
+        {
+            var target = GetTarget();
+            var pod = Repository.GetLocation<EscapePod>();
+            pod.Init();
+            target.Context.CurrentLocation = pod;
+
+            var action = new SimpleIntent { Verb = "leave", Noun = "control panel" };
+            var result = await Repository.GetItem<SafetyWeb>().RespondToSimpleInteraction(action, target.Context,
+                Mock.Of<IGenerationClient>(), new ItemProcessorFactory(Mock.Of<IAITakeAndAndDropParser>()));
+
+            // Before the fix this was a PositiveInteractionResult carrying "You're not in the safety
+            // web."; the noun guard now lets an unrelated noun fall through to the narrator.
+            result.Should().BeOfType<NoNounMatchInteractionResult>();
+        }
+
+        [Test]
+        public async Task LeaveTheWebbing_WhileStanding_StillAnswersForTheWeb()
+        {
+            var target = GetTarget();
+            var pod = Repository.GetLocation<EscapePod>();
+            pod.Init();
+            target.Context.CurrentLocation = pod;
+
+            var action = new SimpleIntent { Verb = "leave", Noun = "webbing" };
+            var result = await Repository.GetItem<SafetyWeb>().RespondToSimpleInteraction(action, target.Context,
+                Mock.Of<IGenerationClient>(), new ItemProcessorFactory(Mock.Of<IAITakeAndAndDropParser>()));
+
+            result.Should().BeOfType<PositiveInteractionResult>();
+            result!.InteractionMessage.Should().Contain("You're not in the safety web.");
         }
     }
 }

--- a/Planetfall/Location/Feinstein/EscapePod.cs
+++ b/Planetfall/Location/Feinstein/EscapePod.cs
@@ -47,6 +47,17 @@ internal class SafetyWeb : ItemBase, ISubLocation, ICanBeExamined
     public override async Task<InteractionResult?> RespondToSimpleInteraction(SimpleIntent action, IContext context,
         IGenerationClient client, IItemProcessorFactory itemProcessorFactory)
     {
+        // Issue #448: both branches below used to match on the VERB alone. The web is seeded into the
+        // pod's Items (issue #376), so LocationBase runs this handler for every command in the room -
+        // which meant any sit/get/rest (seated) or leave/exit/get (standing) command was answered for
+        // the webbing no matter what it was actually aimed at: "sit on the control panel" came back
+        // "You're already in the safety web." Only claim the command when it names the webbing (or
+        // names nothing at all, as the bare "sit"/"get in" phrasings do - those are normally caught
+        // earlier by EscapePod.RespondToSpecificLocationInteraction, but this keeps them working if
+        // one ever reaches here). Anything else falls through to base -> the real noun.
+        if (!NamesTheWebbing(action))
+            return await base.RespondToSimpleInteraction(action, context, client, itemProcessorFactory);
+
         if (context.CurrentLocation.SubLocation != null && action.MatchVerb(["get", "rest", "sit"]))
             return new PositiveInteractionResult(GetIn(context));
 
@@ -54,6 +65,12 @@ internal class SafetyWeb : ItemBase, ISubLocation, ICanBeExamined
             return new PositiveInteractionResult(GetOut(context));
 
         return await base.RespondToSimpleInteraction(action, context, client, itemProcessorFactory);
+    }
+
+    private bool NamesTheWebbing(SimpleIntent action)
+    {
+        return string.IsNullOrWhiteSpace(action.Noun) ||
+               HasMatchingNounAndAdjective(action.Noun, action.Adjective).HasItem;
     }
 }
 

--- a/Planetfall/Location/Feinstein/EscapePod.cs
+++ b/Planetfall/Location/Feinstein/EscapePod.cs
@@ -58,10 +58,18 @@ internal class SafetyWeb : ItemBase, ISubLocation, ICanBeExamined
         if (!NamesTheWebbing(action))
             return await base.RespondToSimpleInteraction(action, context, client, itemProcessorFactory);
 
-        if (context.CurrentLocation.SubLocation != null && action.MatchVerb(["get", "rest", "sit"]))
+        // Each verb list used to be gated on SubLocation as well, which meant each could only ever
+        // reach its own *complaint* - naming the webbing in the other state matched no branch and fell
+        // through to base, where nothing handles sit/leave on the web, so the player got a blank line.
+        // GetIn/GetOut each already answer their own wrong-state case, so no state gate is needed here.
+        if (action.MatchVerb(["sit", "rest", "get"]))
             return new PositiveInteractionResult(GetIn(context));
 
-        if (context.CurrentLocation.SubLocation == null && action.MatchVerb(["leave", "exit", "get"]))
+        // "get" is deliberately absent here. It's the one verb that reads in both directions ("get
+        // in"/"get out" with the preposition lost), and standing up in the landed pod arms an
+        // unrecoverable sinking clock - a hazard an ambiguous verb must never trigger. Only an explicit
+        // leave/exit (or the raw "stand", handled by RespondToSpecificLocationInteraction) may unseat.
+        if (action.MatchVerb(["leave", "exit"]))
             return new PositiveInteractionResult(GetOut(context));
 
         return await base.RespondToSimpleInteraction(action, context, client, itemProcessorFactory);

--- a/UnitTests/IntentMappings/base-mappings.json
+++ b/UnitTests/IntentMappings/base-mappings.json
@@ -71,6 +71,8 @@
     { "inputs": ["drop the access card"], "verb": "drop", "noun": "access card" },
 
     { "inputs": ["sit on rug"], "verb": "sit", "noun": "rug", "originalInput": "sit on rug" },
+    { "inputs": ["sit on the control panel", "sit on control panel"], "verb": "sit", "noun": "control panel", "originalInput": "sit on the control panel" },
+    { "inputs": ["sit on the webbing", "sit on webbing"], "verb": "sit", "noun": "webbing", "originalInput": "sit on the webbing" },
     { "inputs": ["look under rug"], "verb": "look", "noun": "rug", "originalInput": "look under rug" },
     { "inputs": ["look under table"], "verb": "look", "noun": "table", "originalInput": "look under table" },
 


### PR DESCRIPTION
Fixes #448, plus the closely-related wrong-state hole it exposed.

## 1. The reported bug: no noun guard

`SafetyWeb.RespondToSimpleInteraction` matched on the **verb alone**, with no check that the noun was the webbing. The web is seeded into the escape pod's `Items` (issue #376), so `LocationBase.RespondToSimpleInteraction` runs its handler for every command in the room — meaning any `sit`/`get`/`rest` (while seated) or `leave`/`exit`/`get` (while standing) command was answered for the webbing no matter what it was actually aimed at:

```
> sit on the control panel
You're already in the safety web.
```

This is the verb-only-firing / no-noun-guard anti-pattern from CLAUDE.md's engine-port list, same shape as #433 and #430.

**Fix:** one noun guard in front of both branches — the handler only claims the command when it names the webbing (via the item's own `HasMatchingNounAndAdjective`, so `NounsForMatching` stays the single source of truth) or names nothing at all. Anything else falls through to `base` → the real noun.

## 2. What that exposed: the state gates made every branch a dead end

With the noun guard in place the second defect is plain. Each verb list was **also** gated on `SubLocation`, so each could only ever reach its own *complaint*: the sit/rest list only ever reached `GetIn`'s "You're already in the safety web", the leave/exit list only ever reached `GetOut`'s "You're not in the safety web". Neither branch could ever actually seat or unseat anybody — and naming the webbing in the **other** state matched no branch at all, fell through to `base`, where no processor handles sit/leave on the web, and the player got a **blank line**:

```
> sit on the webbing      (while standing)     [nothing]
> leave web               (while seated)       [nothing]
> get web                 (while standing)     You're not in the safety web.
```

`GetIn`/`GetOut` each already answer their own wrong-state case, so the state gates were never needed. Dropping them makes all six phrasings behave.

**One deliberate asymmetry:** `get` maps to `GetIn` only, never `GetOut`. It's the one verb that reads in both directions ("get in"/"get out" with the preposition lost), and standing up in the landed pod arms an unrecoverable sinking clock — a hazard an ambiguous verb must never trigger. Only an explicit `leave`/`exit` (or the raw `stand`, handled upstream in `RespondToSpecificLocationInteraction`) may unseat you. A test pins this.

Both changes are in [EscapePod.cs](Planetfall/Location/Feinstein/EscapePod.cs:47).

## TDD

Two fixtures in [ExplosionTests.cs](Planetfall.Tests/ExplosionTests.cs), next to the existing `EnterWebTests`. Deterministic — no AI, no randomness. Each was confirmed red for the right reason before its fix and green after (the second fixture re-verified by stashing the production change).

- `SafetyWebNounGuardTests` (7) — 3 red: `sit on the control panel` and `sit on rug` returned the web string; `leave <unrelated noun>` while standing returned a `PositiveInteractionResult` carrying "You're not in the safety web." Companions pin what must survive: `sit on the webbing` while seated still complains, bare `sit` still seats you and still complains when already seated, `leave webbing` while standing still answers for the web.
- `SafetyWebWrongStateTests` (6) — 5 red: four blank responses and one inverted message. Includes a parity test asserting `leave web` in the landed pod produces the *identical* response and sinking state as the bare `stand`, so the hazard can't be dodged by phrasing, and `GetWeb_WhileSeated_DoesNotStandYouUp` guarding the `get` asymmetry above (this one was green before the fix — it exists to keep it that way).

Two test-parser mappings added to `base-mappings.json` for the `sit on the control panel` / `sit on the webbing` phrasings (the fallback parser doesn't know `sit` as a verb). Tests for `leave`/`exit` on an unrelated noun, and for the `exit` verb, call the item directly — the test parser carries no `exit` verb — mirroring the pattern used for #433's `press wall`.

## Verification

- `dotnet test Planetfall.Tests` — 3124 passed, 0 failed
- `dotnet test UnitTests` — 1046 passed, 0 failed
- `dotnet test ZorkOne.Tests` — 1781 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)