### PR TITLE
Fix #450: Elevator car description reflects the sliding door's state

### DIFF
--- a/Planetfall.Tests/ElevatorTests.cs
+++ b/Planetfall.Tests/ElevatorTests.cs
@@ -714,6 +714,38 @@ public class ElevatorTests : EngineTestsBase
     }
 
     [Test]
+    public async Task LookWhileMoving_DescribesTheDoorAsClosed_Upper()
+    {
+        var target = GetTarget();
+        StartHere<UpperElevator>().InLobby = true;
+        Take<UpperElevatorAccessCard>();
+
+        await target.GetResponse("slide upper access card through slot");
+        await target.GetResponse("press up button");
+        GetItem<UpperElevatorDoor>().IsOpen.Should().BeFalse();
+
+        var response = await target.GetResponse("look");
+        response.Should().Contain("a sliding door to the south which is closed");
+        response.Should().NotContain("which is open");
+    }
+
+    [Test]
+    public async Task LookWhileMoving_DescribesTheDoorAsClosed_Lower()
+    {
+        var target = GetTarget();
+        StartHere<LowerElevator>().InLobby = true;
+        Take<LowerElevatorAccessCard>();
+
+        await target.GetResponse("slide lower access card through slot");
+        await target.GetResponse("press down button");
+        GetItem<LowerElevatorDoor>().IsOpen.Should().BeFalse();
+
+        var response = await target.GetResponse("look");
+        response.Should().Contain("a sliding door to the north which is closed");
+        response.Should().NotContain("which is open");
+    }
+
+    [Test]
     public async Task UpperElevatorFullTest()
     {
         var target = GetTarget();

--- a/Planetfall/Location/Kalamontee/ElevatorBase.cs
+++ b/Planetfall/Location/Kalamontee/ElevatorBase.cs
@@ -158,8 +158,12 @@ internal abstract class ElevatorBase<TDoor, TSlot, TCard> : FloydSpecialInteract
 
     protected override string GetContextBasedDescription(IContext context)
     {
+        // Interpolate the door's actual state (issue #450). Hardcoding "open" contradicted the
+        // "elevator door slides shut" message from Move() and "examine door" during the ~3 turns
+        // the car is in motion with the door closed. Mirrors RecArea / the #438 Mess Hall fix.
         return
-            $"This is a {Size} room with a sliding door to the {ExitDirection} which is open. " +
+            $"This is a {Size} room with a sliding door to the {ExitDirection} which is " +
+            $"{(GetItem<TDoor>().IsOpen ? "open" : "closed")}. " +
             $"A control panel contains an Up button, a Down button, and a narrow slot. ";
     }
 


### PR DESCRIPTION
Fixes #450.

## What was wrong

`ElevatorBase.GetContextBasedDescription` hardcoded `"which is open"` and never consulted the door's `IsOpen`:

```csharp
$"This is a {Size} room with a sliding door to the {ExitDirection} which is open. "
```

But `Move()` closes the door when the car departs (`GetItem<TDoor>().IsOpen = false`), and it stays closed for the ~3 turns the car is in motion (`ElevatorIsMoving` reopens it at `TurnsSinceMoving == 4`). So `look` inside a moving car printed "…which is open" on the same turn as "The elevator door slides shut.", and disagreed with `examine <door>`, which correctly reported "The door is closed."

Same hardcoded-description-vs-state defect as #438 (Mess Hall), in a different handler. Affects both cars, since they share `ElevatorBase<,,>`.

## The fix

Interpolate the door's actual state, mirroring `RecArea.cs:61` and the #438 Mess Hall fix, with a comment naming the trap so it isn't reintroduced.

## TDD

Per CLAUDE.md, red before green:

1. Added `LookWhileMoving_DescribesTheDoorAsClosed_Upper` / `_Lower` to the existing `ElevatorTests` fixture — enable the car with its access card, press the button, assert `IsOpen == false`, then `look`.
2. Confirmed red **for the right reason**: the `IsOpen.Should().BeFalse()` assertion passed and the failure was the room text — `Expected response "…a sliding door to the south which is open…" to contain "a sliding door to the south which is closed"`.
3. Applied the minimal fix.
4. Green.

Deterministic — no randomness, clock, network, or AI; runs in the normal `dotnet test Planetfall.Tests` command.

## Verification

- `ElevatorTests`: 78/78 pass
- `Planetfall.Tests`: 3113/3113 pass
- `UnitTests`: 1046 pass, 1 skipped

The open-state wording stays covered by the existing `Press_Blue_Enter` / `Press_Red_Enter` tests, which assert the full "…which is open. A control panel contains…" sentence on entering each car.

## Reviewer notes

Cosmetic/state-consistency only — no progression impact. ZIL-independent: the defect is provable from the C# alone (`GetContextBasedDescription` vs `Move()` vs `ElevatorDoorBase.ExaminationDescription`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)