### PR TITLE
Fix #454: Elevator ignores the travel button while already in transit

### DIFF
--- a/Planetfall.Tests/ElevatorTests.cs
+++ b/Planetfall.Tests/ElevatorTests.cs
@@ -714,6 +714,50 @@ public class ElevatorTests : EngineTestsBase
     }
 
     [Test]
+    public async Task PressButtonAgainWhileMoving_DoesNotRestartTheTrip_Upper()
+    {
+        var target = GetTarget();
+        StartHere<UpperElevator>().InLobby = true;
+        Take<UpperElevatorAccessCard>();
+
+        await target.GetResponse("slide upper access card through slot");
+        await target.GetResponse("press up button");
+        GetLocation<UpperElevator>().TurnsSinceMoving.Should().Be(2);
+
+        var response = await target.GetResponse("press up button");
+        response.Should().Contain("Nothing happens");
+        response.Should().NotContain("The elevator door slides shut");
+        GetLocation<UpperElevator>().TurnsSinceMoving.Should().Be(3);
+
+        // The trip still lands on schedule - the second press neither restarted nor extended it.
+        response = await target.GetResponse("wait");
+        response.Should().Contain("The elevator door slides open");
+        GetLocation<UpperElevator>().InLobby.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task PressButtonAgainWhileMoving_DoesNotRestartTheTrip_Lower()
+    {
+        var target = GetTarget();
+        StartHere<LowerElevator>().InLobby = true;
+        Take<LowerElevatorAccessCard>();
+
+        await target.GetResponse("slide lower access card through slot");
+        await target.GetResponse("press down button");
+        GetLocation<LowerElevator>().TurnsSinceMoving.Should().Be(2);
+
+        var response = await target.GetResponse("press down button");
+        response.Should().Contain("Nothing happens");
+        response.Should().NotContain("The elevator door slides shut");
+        GetLocation<LowerElevator>().TurnsSinceMoving.Should().Be(3);
+
+        // The trip still lands on schedule - the second press neither restarted nor extended it.
+        response = await target.GetResponse("wait");
+        response.Should().Contain("The elevator door slides open");
+        GetLocation<LowerElevator>().InLobby.Should().BeFalse();
+    }
+
+    [Test]
     public async Task UpperElevatorFullTest()
     {
         var target = GetTarget();

--- a/Planetfall/Location/Kalamontee/ElevatorBase.cs
+++ b/Planetfall/Location/Kalamontee/ElevatorBase.cs
@@ -107,6 +107,14 @@ internal abstract class ElevatorBase<TDoor, TSlot, TCard> : FloydSpecialInteract
             if (!IsEnabled)
                 return new PositiveInteractionResult("Nothing happens. ");
 
+            // The original gates every travel branch on the car being idle as well as enabled
+            // (compone.zil, ELEVATOR-BUTTON-F: each success arm requires ELEVATOR-IN-TRANSIT to be
+            // false, otherwise it falls through to "Nothing happens."). Without this, a second press
+            // mid-flight re-runs Move(), reprinting the departure message and resetting the trip
+            // timer - the player could stall the elevator indefinitely.
+            if (TurnsSinceMoving > 0)
+                return new PositiveInteractionResult("Nothing happens. ");
+
             if (action.MatchNoun(["up button", "up"]))
                 return GoUp(context);
 
@@ -121,9 +129,11 @@ internal abstract class ElevatorBase<TDoor, TSlot, TCard> : FloydSpecialInteract
     {
         TurnsSinceMoving = 1;
         context.RegisterActor(this);
-        GetItem<TDoor>().IsOpen = false;
-        return new PositiveInteractionResult(
-            "The elevator door slides shut. After a moment, you feel a sensation of vertical movement. ");
+        var door = GetItem<TDoor>();
+        door.IsOpen = false;
+        // Let the door own its own message, as the arrival path already does with NowOpen. The
+        // literal used to be duplicated here, so editing ElevatorDoorBase.NowClosed changed nothing.
+        return new PositiveInteractionResult(door.NowClosed(this));
     }
 
     protected abstract InteractionResult GoDown(IContext context);


### PR DESCRIPTION
Fixes #454. Found while reviewing #453 (the #450 description fix); independent of it, so this branches off `main`.

## What was wrong

The button handler gated only on `IsEnabled`:

```csharp
if (!IsEnabled)
    return new PositiveInteractionResult("Nothing happens. ");

if (action.MatchNoun(["up button", "up"]))
    return GoUp(context);      // no in-transit check
```

`InLobby` does not flip until arrival (`ElevatorIsMoving`), so the direction check inside `GoUp`/`GoDown` still passes while the car is in motion and `Move()` runs a second time — reprinting "The elevator door slides shut. After a moment, you feel a sensation of vertical movement." mid-flight and resetting `TurnsSinceMoving` to 1. Pressing every turn stalls the elevator indefinitely; `IsEnabled` cannot expire in the meantime either, because `Act()` returns on the moving branch before the disable countdown.

## Faithful-to-original evidence

A port divergence. `ELEVATOR-BUTTON-F` requires the car to be idle in **every** success branch — `<EQUAL? ,ELEVATOR-IN-TRANSIT <>>` at `compone.zil:2612`, `:2620`, `:2631`, `:2639` — falling through to `<TELL "Nothing happens." CR>` otherwise. This restores that conjunct.

Deliberately **not** changed: the disable countdown pausing during motion is faithful, per `I-TURNOFF-UPPER-ELEVATOR` / `I-TURNOFF-LOWER-ELEVATOR` re-queueing themselves while `ELEVATOR-IN-TRANSIT` is set (`compone.zil:2652-2665`).

## TDD

1. Added `PressButtonAgainWhileMoving_DoesNotRestartTheTrip_Upper` / `_Lower` to the existing `ElevatorTests` fixture.
2. Confirmed red **for the right reason**: the second press returned the departure message where "Nothing happens" was expected — not a setup error.
3. Applied the guard.
4. Green.

The tests pin all three symptoms: the response is "Nothing happens", the shut message does *not* repeat, `TurnsSinceMoving` advances (3) instead of resetting, and the trip still lands on its original schedule. Deterministic — no randomness, clock, network, or AI.

## Drive-by cleanup

`Move()` inlined the departure sentence verbatim while `ElevatorDoorBase.NowClosed` owned the identical string and was dead for elevator doors — even though the arrival path two methods up already delegates to `door.NowOpen(this)`. Collapsed onto `NowClosed` so the two copies cannot drift.

## Verification

- `ElevatorTests`: 78/78 pass
- `Planetfall.Tests`: 3129/3129 pass
- `UnitTests`: 1046 pass, 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)