### PR TITLE
Fix #456: Elevator entrances check which floor the car is on

### DIFF
--- a/Planetfall.Tests/ElevatorTests.cs
+++ b/Planetfall.Tests/ElevatorTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using Planetfall.Item.Kalamontee.Admin;
 using Planetfall.Location.Kalamontee;
+using Planetfall.Location.Shuttle;
 
 namespace Planetfall.Tests;
 
@@ -138,6 +139,71 @@ public class ElevatorTests : EngineTestsBase
 
         var response = await target.GetResponse("n");
         response.Should().Contain("is closed");
+    }
+
+    [Test]
+    public async Task Enter_FromWaitingArea_DoorClosed()
+    {
+        var target = GetTarget();
+        StartHere<WaitingArea>();
+        GetLocation<LowerElevator>().InLobby = false;
+        GetItem<LowerElevatorDoor>().IsOpen = false;
+
+        var response = await target.GetResponse("s");
+        response.Should().Contain("The door is closed");
+        response.Should().NotContain("Lower Elevator");
+    }
+
+    [Test]
+    public async Task Enter_FromWaitingArea_CarIsUpAtTheLobby()
+    {
+        var target = GetTarget();
+        StartHere<WaitingArea>();
+        // The car is up at the lobby with its door open at that end - there is nothing to step into here.
+        GetLocation<LowerElevator>().InLobby = true;
+        GetItem<LowerElevatorDoor>().IsOpen = true;
+
+        var response = await target.GetResponse("s");
+        response.Should().Contain("The door is closed");
+        response.Should().NotContain("Lower Elevator");
+    }
+
+    [Test]
+    public async Task Enter_FromWaitingArea_CarIsHere()
+    {
+        var target = GetTarget();
+        StartHere<WaitingArea>();
+        GetLocation<LowerElevator>().InLobby = false;
+        GetItem<LowerElevatorDoor>().IsOpen = true;
+
+        var response = await target.GetResponse("s");
+        response.Should().Contain("Lower Elevator");
+    }
+
+    [Test]
+    public async Task Enter_FromLobby_Upper_CarIsAwayAtTheTower()
+    {
+        var target = GetTarget();
+        StartHere<ElevatorLobby>();
+        GetLocation<UpperElevator>().InLobby = false;
+        GetItem<UpperElevatorDoor>().IsOpen = true;
+
+        var response = await target.GetResponse("n");
+        response.Should().Contain("The door is closed");
+        response.Should().NotContain("Upper Elevator");
+    }
+
+    [Test]
+    public async Task Enter_FromLobby_Lower_CarIsAwayAtTheWaitingArea()
+    {
+        var target = GetTarget();
+        StartHere<ElevatorLobby>();
+        GetLocation<LowerElevator>().InLobby = false;
+        GetItem<LowerElevatorDoor>().IsOpen = true;
+
+        var response = await target.GetResponse("s");
+        response.Should().Contain("The door is closed");
+        response.Should().NotContain("Lower Elevator");
     }
 
     [Test]
@@ -607,6 +673,44 @@ public class ElevatorTests : EngineTestsBase
         response.Should().Contain("The elevator door slides shut. After a moment, you feel a sensation of vertical movement");
         GetLocation<LowerElevator>().TurnsSinceMoving.Should().Be(2);
         GetItem<LowerElevatorDoor>().IsOpen.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task LowerElevator_RoundTripToTheWaitingArea()
+    {
+        var target = GetTarget();
+        StartHere<ElevatorLobby>();
+        Take<LowerElevatorAccessCard>();
+
+        await target.GetResponse("press red button");
+        await target.GetResponse("wait");
+        await target.GetResponse("wait");
+        await target.GetResponse("wait");
+        var response = await target.GetResponse("south");
+        response.Should().Contain("Lower Elevator");
+
+        await target.GetResponse("slide lower access card through slot");
+        await target.GetResponse("press down button");
+        await target.GetResponse("wait");
+        response = await target.GetResponse("wait");
+        response.Should().Contain("The elevator door slides open");
+
+        response = await target.GetResponse("north");
+        response.Should().Contain("Waiting Area");
+        GetLocation<LowerElevator>().InLobby.Should().BeFalse();
+
+        // The car is standing right here, so the gated entrance lets us back in.
+        response = await target.GetResponse("south");
+        response.Should().Contain("Lower Elevator");
+
+        await target.GetResponse("slide lower access card through slot");
+        await target.GetResponse("press up button");
+        await target.GetResponse("wait");
+        response = await target.GetResponse("wait");
+        response.Should().Contain("The elevator door slides open");
+
+        response = await target.GetResponse("north");
+        response.Should().Contain("Elevator Lobby");
     }
 
     [Test]

--- a/Planetfall/Location/Kalamontee/ElevatorLobby.cs
+++ b/Planetfall/Location/Kalamontee/ElevatorLobby.cs
@@ -20,11 +20,15 @@ internal class ElevatorLobby : LocationBase
         {
             { Direction.E, Go<BoothTwo>() },
             { Direction.W, Go<CorridorJunction>() },
+            // Both entrances need the car to be standing at the lobby as well as the door being open
+            // (compone.zil, ELEVATOR-ENTER-F tests *-ELEVATOR-UP alongside OPENBIT). The door flag is
+            // shared by both ends of the shaft, so on its own it cannot say which floor the car is on.
             {
                 Direction.S,
                 new MovementParameters
                 {
-                    CanGo = _ => GetItem<LowerElevatorDoor>().IsOpen, CustomFailureMessage = "The door is closed.",
+                    CanGo = _ => GetItem<LowerElevatorDoor>().IsOpen && GetLocation<LowerElevator>().InLobby,
+                    CustomFailureMessage = "The door is closed.",
                     Location = GetLocation<LowerElevator>()
                 }
             },
@@ -32,7 +36,8 @@ internal class ElevatorLobby : LocationBase
                 Direction.N,
                 new MovementParameters
                 {
-                    CanGo = _ => GetItem<UpperElevatorDoor>().IsOpen, CustomFailureMessage = "The door is closed.",
+                    CanGo = _ => GetItem<UpperElevatorDoor>().IsOpen && GetLocation<UpperElevator>().InLobby,
+                    CustomFailureMessage = "The door is closed.",
                     Location = GetLocation<UpperElevator>()
                 }
             }

--- a/Planetfall/Location/Shuttle/WaitingArea.cs
+++ b/Planetfall/Location/Shuttle/WaitingArea.cs
@@ -1,4 +1,6 @@
 using GameEngine.Location;
+using Planetfall.Item.Kalamontee.Admin;
+using Planetfall.Location.Kalamontee;
 
 namespace Planetfall.Location.Shuttle;
 
@@ -7,11 +9,26 @@ public class WaitingArea : LocationWithNoStartingItems
     public override string Name => "Waiting Area";
 
     public override string[] NounsForMatching => ["waiting room", "lounge"];
+
+    private LowerElevatorDoor Door => Repository.GetItem<LowerElevatorDoor>();
+
     protected override Dictionary<Direction, MovementParameters> Map(IContext context)
     {
+        // The original gates this entrance on the door being open *and* the car actually being at
+        // this end of the shaft (compone.zil, OTHER-ELEVATOR-ENTER-F, which also makes the door the
+        // implicit "it" - hence GatingItem). A bare Go<LowerElevator>() let you walk into a car
+        // parked up at the lobby, and then be sealed in, since the car's own exits gate on the door.
+        var intoTheCar = new MovementParameters
+        {
+            GatingItem = Door,
+            CanGo = _ => Door.IsOpen && !GetLocation<LowerElevator>().InLobby,
+            Location = GetLocation<LowerElevator>(),
+            CustomFailureMessage = "The door is closed. "
+        };
+
         return new Dictionary<Direction, MovementParameters>
         {
-            { Direction.S, Go<LowerElevator>() },
+            { Direction.S, intoTheCar },
             { Direction.E, Go<KalamonteePlatform>() }
         };
     }


### PR DESCRIPTION
Fixes #456. Found while reviewing #454; independent of both open elevator PRs, so this branches off `main`.

## What was wrong

Two separate gaps in the same mechanism:

```csharp
// WaitingArea.cs:14 - no condition at all
{ Direction.S, Go<LowerElevator>() },

// ElevatorLobby.cs:23-38 - the door, but never the car's position
CanGo = _ => GetItem<LowerElevatorDoor>().IsOpen,
```

`IsOpen` is one flag shared by both ends of the shaft, so it cannot distinguish "the door is open here" from "the door is open at the other floor". The player could walk into a car parked elsewhere — and then be sealed in, because the car's own exits gate on that same door.

The port already tracks the car's position as `ElevatorBase.InLobby`. Neither entrance consulted it.

## Faithful-to-original evidence

Both are divergences; the original gates on position *and* `OPENBIT`.

**Waiting Area** — `compone.zil:3163-3164` routes south and in through `OTHER-ELEVATOR-ENTER-F` (`compone.zil:3169-3176`), which requires `<FSET? ,LOWER-ELEVATOR-DOOR ,OPENBIT>` **and** `<NOT ,LOWER-ELEVATOR-UP>`, else `<DOOR-CLOSED>` plus `<THIS-IS-IT ,LOWER-ELEVATOR-DOOR>`.

**Elevator Lobby** — `ELEVATOR-ENTER-F` (`compone.zil:2441-2455`) tests `<EQUAL? ,UPPER-ELEVATOR-UP <>>` going north and `<EQUAL? ,LOWER-ELEVATOR-UP T>` going south, alongside `OPENBIT`.

`<DOOR-CLOSED>` is "The door is closed." (`compone.zil:2529-2530`) — the message the port already uses here.

The Waiting Area passage also gets a `GatingItem`, which is how this codebase expresses the original's `(IN PER OTHER-ELEVATOR-ENTER-F)` / `<THIS-IS-IT>` so "enter door" resolves to the exit (the RecArea pattern from #262).

## Deliberately not changed

**Tower Core's north exit stays ungated.** `compone.zil:2733` defines `TOWER-CORE` with a plain `(NORTH TO UPPER-ELEVATOR)`; Infocom left that side open and the port matches. My first pass through the review flagged it alongside the Waiting Area — the ZIL says otherwise, so gating it would introduce a divergence rather than fix one.

## TDD

1. Added five tests to `ElevatorTests`: Waiting Area with the door shut, Waiting Area with the car up at the lobby, each lobby entrance with its car away, plus the positive car-is-here case.
2. Confirmed red **for the right reason** — all four negative cases walked straight into the car, with "Lower Elevator"/"Upper Elevator" in a response that should have been a refusal. The positive case passed from the start, showing the harness reaches the car legitimately.
3. Applied the position conjunct to the three entrances.
4. Green.

Also added `LowerElevator_RoundTripToTheWaitingArea`: summon, ride down, step out to the Waiting Area, step back in, ride up, step out to the lobby. There was no lower-car walkthrough test (only `UpperElevatorFullTest`, which never visits the Waiting Area), and it is the direct regression guard for a change that makes entrances *harder* to pass. Deterministic — no randomness, clock, network, or AI.

## Verification

- `ElevatorTests`: 82/82 pass
- `Planetfall.Tests`: 3133/3133 pass
- `UnitTests`: 1046 pass, 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)