### PR TITLE
Upgrade Swashbuckle to resolve Microsoft.OpenApi vulnerability

### DIFF
--- a/Lambda/src/Lambda/Lambda.csproj
+++ b/Lambda/src/Lambda/Lambda.csproj
@@ -14,8 +14,8 @@
     <ItemGroup>
         <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="9.2.1" />
         <PackageReference Include="DotNetEnv" Version="3.1.1"/>
-        <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="10.1.2" />
-        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.1.2" />
+        <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="10.2.3" />
+        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.2.3" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\..\..\DynamoDb\DynamoDb.csproj"/>

--- a/ZorkWeb.Server/ZorkWeb.Server.csproj
+++ b/ZorkWeb.Server/ZorkWeb.Server.csproj
@@ -15,7 +15,7 @@
         <PackageReference Include="Microsoft.AspNetCore.SpaProxy">
             <Version>10.*-*</Version>
         </PackageReference>
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.0"/>
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3"/>
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Summary

- upgrade the Lambda Swagger and SwaggerGen packages from 10.1.2 to 10.2.3
- upgrade the ZorkWeb.Server Swashbuckle package from 10.1.0 to 10.2.3
- move both dependency graphs from vulnerable Microsoft.OpenApi 2.4.1/2.3.0 to patched 2.7.5

## Why

Microsoft.OpenApi versions through 2.7.4 are affected by GHSA-v5pm-xwqc-g5wc / CVE-2026-49451. A crafted OpenAPI document with circular schema references can terminate a parsing process through stack overflow.

## Verification

- `dotnet list Lambda/src/Lambda/Lambda.csproj package --vulnerable --include-transitive` — no vulnerable packages
- `dotnet list ZorkWeb.Server/ZorkWeb.Server.csproj package --vulnerable --include-transitive` — no vulnerable packages
- `dotnet build Lambda/src/Lambda/Lambda.csproj --no-restore` — passed
- `dotnet test UnitTests --no-restore` — 1,046 passed, 1 skipped
- `dotnet test Planetfall.Tests --no-restore` — 3,137 passed
- `git diff --check` — passed

## Known pre-existing issue

`ZorkWeb.Server` still cannot complete a build because its existing project references to `Azure/Azure.csproj` and `Game/Game.csproj` do not resolve. The restore and vulnerability audit succeed, and the failure is unrelated to this package upgrade.