### PR TITLE
Increase unit test coverage across web and service boundaries

### DIFF
--- a/DynamoDb/DynamoDbRepositoryBase.cs
+++ b/DynamoDb/DynamoDbRepositoryBase.cs
@@ -5,10 +5,16 @@ namespace DynamoDb;
 
 public abstract class DynamoDbRepositoryBase
 {
-    protected readonly AmazonDynamoDBClient Client;
+    protected readonly IAmazonDynamoDB Client;
 
-    protected DynamoDbRepositoryBase()
+    protected DynamoDbRepositoryBase(IAmazonDynamoDB? client = null)
     {
+        if (client is not null)
+        {
+            Client = client;
+            return;
+        }
+
         var clientConfig = new AmazonDynamoDBConfig
         {
             // TODO: Read from env vars or config

--- a/DynamoDb/DynamoDbSavedGameRepository.cs
+++ b/DynamoDb/DynamoDbSavedGameRepository.cs
@@ -1,3 +1,4 @@
+using Amazon.DynamoDBv2;
 using Amazon.DynamoDBv2.Model;
 using Model.Interface;
 
@@ -5,6 +6,17 @@ namespace DynamoDb;
 
 public class DynamoDbSavedGameRepository : DynamoDbRepositoryBase, ISavedGameRepository
 {
+    private readonly Func<Guid> _newId;
+
+    public DynamoDbSavedGameRepository() : this(null)
+    {
+    }
+
+    public DynamoDbSavedGameRepository(IAmazonDynamoDB? client, Func<Guid>? newId = null) : base(client)
+    {
+        _newId = newId ?? Guid.NewGuid;
+    }
+
     public async Task<string?> GetSavedGame(string id, string sessionId, string tableName)
     {
         var request = new GetItemRequest
@@ -25,7 +37,7 @@ public class DynamoDbSavedGameRepository : DynamoDbRepositoryBase, ISavedGameRep
 
     public async Task<string> SaveGame(string? id, string clientId, string name, string gameData, string tableName)
     {
-        id ??= Guid.NewGuid().ToString();
+        id ??= _newId().ToString();
         var item = new Dictionary<string, AttributeValue>
         {
             { "id", new AttributeValue(id) },
@@ -35,7 +47,7 @@ public class DynamoDbSavedGameRepository : DynamoDbRepositoryBase, ISavedGameRep
             { "date", new AttributeValue(DateTime.UtcNow.Ticks.ToString()) }
         };
 
-        await Client.PutItemAsync(tableName, item);
+        await Client.PutItemAsync(new PutItemRequest { TableName = tableName, Item = item });
         return id;
     }
 

--- a/DynamoDb/DynamoDbSessionRepository.cs
+++ b/DynamoDb/DynamoDbSessionRepository.cs
@@ -1,4 +1,4 @@
-﻿using Amazon.DynamoDBv2.DocumentModel;
+﻿using Amazon.DynamoDBv2;
 using Amazon.DynamoDBv2.Model;
 using Model.Interface;
 
@@ -6,27 +6,26 @@ namespace DynamoDb;
 
 public class DynamoDbSessionRepository : DynamoDbRepositoryBase, ISessionRepository
 {
+    public DynamoDbSessionRepository() : this(null)
+    {
+    }
+
+    public DynamoDbSessionRepository(IAmazonDynamoDB? client) : base(client)
+    {
+    }
+
     public async Task<string?> GetSessionState(string sessionId, string tableName)
     {
-        // Define the TableConfig for your session table
-        var tableConfig = new TableConfig(tableName)
+        var response = await Client.GetItemAsync(new GetItemRequest
         {
-            // The TableConfig is primarily used for the table name,
-            // the KeySchema is typically handled through the TableBuilder.
-        };
+            TableName = tableName,
+            Key = new Dictionary<string, AttributeValue>
+            {
+                { "session_id", new AttributeValue(sessionId) }
+            }
+        });
 
-        // Create the Table object using TableBuilder
-        // This is the correct way to initialize the Table object.
-        var table = new TableBuilder(Client, tableConfig)
-            .AddHashKey("session_id", DynamoDBEntryType.String) // Specify the hash key and its type
-            .Build();
-
-        var result = await table.GetItemAsync(sessionId);
-
-        if (result is null)
-            return null;
-
-        return result["gameData"];
+        return response.Item.TryGetValue("gameData", out var gameData) ? gameData.S : null;
     }
 
     public async Task WriteSessionState(string sessionId, string gameData, string tableName)
@@ -37,7 +36,7 @@ public class DynamoDbSessionRepository : DynamoDbRepositoryBase, ISessionReposit
             { "gameData", new AttributeValue(gameData) }
         };
 
-        await Client.PutItemAsync(tableName, item);
+        await Client.PutItemAsync(new PutItemRequest { TableName = tableName, Item = item });
     }
 
     public async Task WriteSessionStep(string sessionId, long turnIndex, string input, string output, string tableName)
@@ -50,7 +49,7 @@ public class DynamoDbSessionRepository : DynamoDbRepositoryBase, ISessionReposit
             { "output", new AttributeValue(output) }
         };
 
-        await Client.PutItemAsync(tableName, item);
+        await Client.PutItemAsync(new PutItemRequest { TableName = tableName, Item = item });
     }
 
     public async Task<string> GetSessionStepsAsText(string sessionId, string tableName)

--- a/DynamoDb/DynamoDbSessionRepository.cs
+++ b/DynamoDb/DynamoDbSessionRepository.cs
@@ -25,7 +25,10 @@ public class DynamoDbSessionRepository : DynamoDbRepositoryBase, ISessionReposit
             }
         });
 
-        return response.Item.TryGetValue("gameData", out var gameData) ? gameData.S : null;
+        // AWS SDK v4 leaves Item null when no row exists; a missing session is a normal first-run case.
+        return response.Item is not null && response.Item.TryGetValue("gameData", out var gameData)
+            ? gameData.S
+            : null;
     }
 
     public async Task WriteSessionState(string sessionId, string gameData, string tableName)

--- a/Planetfall.Tests/ExplosionTests.cs
+++ b/Planetfall.Tests/ExplosionTests.cs
@@ -872,5 +872,76 @@ public class ExplosionTests : EngineTestsBase
             Repository.GetItem<SurvivalKit>().CurrentLocation.Should().Be(pod);
             target.Context.Actors.Should().NotContain(pod);
         }
+
+        // TurnsSinceExplosion == 4 is the Feinstein blowing apart - the one landing branch the timeline
+        // tests above skip, and the only place the pod consults its IRandomChooser. Outside the web the
+        // player is thrown against the bulkhead: a 20% instant "head first" death (a RollDiceSuccess(5)
+        // hit, PROB 20 in the original), otherwise a survivable bruising. Mocking the chooser pins each
+        // side of that dice branch deterministically (see the Randomness Pattern in CLAUDE.md).
+        [Test]
+        public async Task ExplosionOutsideTheWeb_OnAFatalRoll_ThrowsThePlayerHeadFirst()
+        {
+            var target = GetTarget();
+            var pod = Repository.GetLocation<EscapePod>();
+            target.Context.CurrentLocation = pod;
+            pod.SubLocation = null;
+            pod.TurnsSinceExplosion = 3; // Act advances it to 4
+            target.Context.RegisterActor(pod);
+
+            var chooser = new Mock<IRandomChooser>();
+            chooser.Setup(c => c.RollDiceSuccess(5)).Returns(true);
+            pod.Chooser = chooser.Object;
+
+            var response = await pod.Act(target.Context, Mock.Of<IGenerationClient>());
+
+            response.Should().Contain("head first");
+            response.Should().Contain("You have died");
+            target.Context.DeathCounter.Should().Be(1);
+        }
+
+        [Test]
+        public async Task ExplosionOutsideTheWeb_OnASurvivableRoll_BruisesButDoesNotKill()
+        {
+            var target = GetTarget();
+            var pod = Repository.GetLocation<EscapePod>();
+            target.Context.CurrentLocation = pod;
+            pod.SubLocation = null;
+            pod.TurnsSinceExplosion = 3;
+            target.Context.RegisterActor(pod);
+
+            var chooser = new Mock<IRandomChooser>();
+            chooser.Setup(c => c.RollDiceSuccess(5)).Returns(false);
+            pod.Chooser = chooser.Object;
+
+            var response = await pod.Act(target.Context, Mock.Of<IGenerationClient>());
+
+            response.Should().Contain("bruising a few limbs");
+            response.Should().NotContain("head first");
+            target.Context.DeathCounter.Should().Be(0);
+        }
+
+        // In the web the throw never happens, so the fatal roll must not even be consulted - the pod
+        // rider takes no bruise and no death. Verifying the chooser is untouched pins the short-circuit
+        // (`!inWeb && ...`) that keeps a webbed player safe regardless of the dice.
+        [Test]
+        public async Task ExplosionInsideTheWeb_RidesItOutUnharmed_WithoutConsultingTheDice()
+        {
+            var target = GetTarget();
+            var pod = Repository.GetLocation<EscapePod>();
+            target.Context.CurrentLocation = pod;
+            pod.SubLocation = Repository.GetItem<SafetyWeb>();
+            pod.TurnsSinceExplosion = 3;
+            target.Context.RegisterActor(pod);
+
+            var chooser = new Mock<IRandomChooser>();
+            pod.Chooser = chooser.Object;
+
+            var response = await pod.Act(target.Context, Mock.Of<IGenerationClient>());
+
+            response.Should().NotContain("bruising");
+            response.Should().NotContain("head first");
+            target.Context.DeathCounter.Should().Be(0);
+            chooser.Verify(c => c.RollDiceSuccess(It.IsAny<int>()), Times.Never);
+        }
     }
 }

--- a/Planetfall.Tests/ExplosionTests.cs
+++ b/Planetfall.Tests/ExplosionTests.cs
@@ -800,4 +800,77 @@ public class ExplosionTests : EngineTestsBase
             pod.TurnsAfterStanding.Should().Be(0);
         }
     }
+
+    [TestFixture]
+    public class EscapePodTimelineTests : EngineTestsBase
+    {
+        [Test]
+        public async Task ClosedPodSinking_ProgressesThroughWarningsAndDeath()
+        {
+            var target = GetTarget();
+            var pod = Repository.GetLocation<EscapePod>();
+            target.Context.CurrentLocation = pod;
+            pod.TurnsAfterStanding = 1;
+            Repository.GetItem<BulkheadDoor>().IsOpen = false;
+
+            (await pod.Act(target.Context, Mock.Of<IGenerationClient>())).Should().Be("\n\n");
+            (await pod.Act(target.Context, Mock.Of<IGenerationClient>())).Should().Contain("completely submerged");
+            (await pod.Act(target.Context, Mock.Of<IGenerationClient>())).Should().Contain("creaks ominously");
+            (await pod.Act(target.Context, Mock.Of<IGenerationClient>())).Should().Contain("pod splits open");
+            target.Context.DeathCounter.Should().Be(1);
+        }
+
+        [Test]
+        public async Task OpenPodSinking_UsesTheOpenDoorDeathNarration()
+        {
+            var target = GetTarget();
+            var pod = Repository.GetLocation<EscapePod>();
+            target.Context.CurrentLocation = pod;
+            pod.TurnsAfterStanding = 4;
+            Repository.GetItem<BulkheadDoor>().IsOpen = true;
+
+            var response = await pod.Act(target.Context, Mock.Of<IGenerationClient>());
+
+            response.Should().Contain("curtains for you");
+            response.Should().Contain("left the pod a bit sooner");
+            target.Context.DeathCounter.Should().Be(1);
+        }
+
+        [Test]
+        public async Task LandingOutsideTheSafetyWeb_KillsThePlayer()
+        {
+            var target = GetTarget();
+            var pod = Repository.GetLocation<EscapePod>();
+            target.Context.CurrentLocation = pod;
+            pod.SubLocation = null;
+            pod.TurnsSinceExplosion = 13;
+            target.Context.RegisterActor(pod);
+
+            var response = await pod.Act(target.Context, Mock.Of<IGenerationClient>());
+
+            response.Should().Contain("sharper corners of the control panel");
+            response.Should().Contain("You have died");
+            target.Context.DeathCounter.Should().Be(1);
+        }
+
+        [Test]
+        public async Task LandingInTheSafetyWeb_AddsSuppliesAndRetargetsTheDoor()
+        {
+            var target = GetTarget();
+            var pod = Repository.GetLocation<EscapePod>();
+            target.Context.CurrentLocation = pod;
+            pod.SubLocation = Repository.GetItem<SafetyWeb>();
+            pod.TurnsSinceExplosion = 13;
+            target.Context.RegisterActor(pod);
+
+            var response = await pod.Act(target.Context, Mock.Of<IGenerationClient>());
+
+            response.Should().Contain("pod lands with a thud");
+            pod.LandedSafely.Should().BeTrue();
+            pod.WhereDoesTheDoorLead.Should().BeOfType<Underwater>();
+            Repository.GetItem<Towel>().CurrentLocation.Should().Be(pod);
+            Repository.GetItem<SurvivalKit>().CurrentLocation.Should().Be(pod);
+            target.Context.Actors.Should().NotContain(pod);
+        }
+    }
 }

--- a/UnitTests/AWS/DynamoDbRepositoryBehaviorTests.cs
+++ b/UnitTests/AWS/DynamoDbRepositoryBehaviorTests.cs
@@ -1,0 +1,195 @@
+using Amazon.DynamoDBv2;
+using Amazon.DynamoDBv2.Model;
+using DynamoDb;
+
+namespace UnitTests.AWS;
+
+[TestFixture]
+public class DynamoDbSavedGameRepositoryBehaviorTests
+{
+    private Mock<IAmazonDynamoDB> _client = null!;
+    private DynamoDbSavedGameRepository _target = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _client = new Mock<IAmazonDynamoDB>();
+        _target = new DynamoDbSavedGameRepository(_client.Object,
+            () => Guid.Parse("11111111-1111-1111-1111-111111111111"));
+    }
+
+    [Test]
+    public async Task SaveGame_WritesAllFields_AndUsesInjectedIdFactory()
+    {
+        PutItemRequest? captured = null;
+        _client.Setup(c => c.PutItemAsync(It.IsAny<PutItemRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<PutItemRequest, CancellationToken>((request, _) => captured = request)
+            .ReturnsAsync(new PutItemResponse());
+
+        var id = await _target.SaveGame(null, "client-1", "Before the door", "encoded", "saves");
+
+        id.Should().Be("11111111-1111-1111-1111-111111111111");
+        captured.Should().NotBeNull();
+        captured!.TableName.Should().Be("saves");
+        captured.Item["id"].S.Should().Be(id);
+        captured.Item["session_id"].S.Should().Be("client-1");
+        captured.Item["name"].S.Should().Be("Before the door");
+        captured.Item["gameData"].S.Should().Be("encoded");
+        long.TryParse(captured.Item["date"].S, out _).Should().BeTrue();
+    }
+
+    [Test]
+    public async Task SaveGame_PreservesProvidedId()
+    {
+        _client.Setup(c => c.PutItemAsync(It.IsAny<PutItemRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PutItemResponse());
+
+        await _target.SaveGame("existing", "client", "name", "data", "saves");
+
+        _client.Verify(c => c.PutItemAsync(It.Is<PutItemRequest>(r => r.Item["id"].S == "existing"),
+            It.IsAny<CancellationToken>()));
+    }
+
+    [Test]
+    public async Task GetSavedGame_UsesCompositeKey_AndReturnsGameData()
+    {
+        _client.Setup(c => c.GetItemAsync(It.IsAny<GetItemRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GetItemResponse
+            {
+                Item = new Dictionary<string, AttributeValue> { { "gameData", new AttributeValue("encoded") } }
+            });
+
+        var result = await _target.GetSavedGame("save-1", "client-1", "saves");
+        result.Should().Be("encoded");
+        _client.Verify(c => c.GetItemAsync(It.Is<GetItemRequest>(r =>
+                r.TableName == "saves" && r.Key["id"].S == "save-1" && r.Key["session_id"].S == "client-1"),
+            It.IsAny<CancellationToken>()));
+    }
+
+    [Test]
+    public async Task GetSavedGames_QueriesSessionIndex_AndMapsRows()
+    {
+        var savedOn = new DateTime(2026, 7, 22, 12, 0, 0, DateTimeKind.Utc);
+        _client.Setup(c => c.QueryAsync(It.IsAny<QueryRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new QueryResponse
+            {
+                Items =
+                [
+                    new Dictionary<string, AttributeValue>
+                    {
+                        { "id", new AttributeValue("save-1") },
+                        { "name", new AttributeValue("At the pod") },
+                        { "date", new AttributeValue(savedOn.Ticks.ToString()) }
+                    }
+                ]
+            });
+
+        var result = await _target.GetSavedGames("client-1", "saves");
+
+        result.Should().ContainSingle().Which.Should().Be(("save-1", "At the pod", new DateTime(savedOn.Ticks)));
+        _client.Verify(c => c.QueryAsync(It.Is<QueryRequest>(r => r.TableName == "saves" &&
+            r.IndexName == "session_id-index" && r.ExpressionAttributeValues[":sessionIdVal"].S == "client-1"),
+            It.IsAny<CancellationToken>()));
+    }
+
+    [Test]
+    public async Task DeleteSavedGame_UsesCompositeKey()
+    {
+        _client.Setup(c => c.DeleteItemAsync(It.IsAny<DeleteItemRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new DeleteItemResponse());
+
+        await _target.DeleteSavedGameAsync("save-1", "client-1", "saves");
+
+        _client.Verify(c => c.DeleteItemAsync(It.Is<DeleteItemRequest>(r => r.TableName == "saves" &&
+            r.Key["id"].S == "save-1" && r.Key["session_id"].S == "client-1"), It.IsAny<CancellationToken>()));
+    }
+}
+
+[TestFixture]
+public class DynamoDbSessionRepositoryBehaviorTests
+{
+    private Mock<IAmazonDynamoDB> _client = null!;
+    private DynamoDbSessionRepository _target = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _client = new Mock<IAmazonDynamoDB>();
+        _target = new DynamoDbSessionRepository(_client.Object);
+    }
+
+    [Test]
+    public async Task GetSessionState_ReturnsData_WhenItemExists()
+    {
+        _client.Setup(c => c.GetItemAsync(It.IsAny<GetItemRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GetItemResponse
+            {
+                Item = new Dictionary<string, AttributeValue> { { "gameData", new AttributeValue("state") } }
+            });
+
+        var result = await _target.GetSessionState("session-1", "sessions");
+        result.Should().Be("state");
+        _client.Verify(c => c.GetItemAsync(It.Is<GetItemRequest>(r => r.TableName == "sessions" &&
+            r.Key["session_id"].S == "session-1"), It.IsAny<CancellationToken>()));
+    }
+
+    [Test]
+    public async Task GetSessionState_ReturnsNull_WhenItemDoesNotExist()
+    {
+        _client.Setup(c => c.GetItemAsync(It.IsAny<GetItemRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GetItemResponse { Item = new Dictionary<string, AttributeValue>() });
+
+        var result = await _target.GetSessionState("missing", "sessions");
+        result.Should().BeNull();
+    }
+
+    [Test]
+    public async Task WriteSessionState_WritesSessionAndGameData()
+    {
+        _client.Setup(c => c.PutItemAsync(It.IsAny<PutItemRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PutItemResponse());
+
+        await _target.WriteSessionState("session-1", "state", "sessions");
+
+        _client.Verify(c => c.PutItemAsync(It.Is<PutItemRequest>(r => r.TableName == "sessions" &&
+            r.Item["session_id"].S == "session-1" && r.Item["gameData"].S == "state"),
+            It.IsAny<CancellationToken>()));
+    }
+
+    [Test]
+    public async Task WriteSessionStep_WritesNumericTurnAndTranscriptFields()
+    {
+        _client.Setup(c => c.PutItemAsync(It.IsAny<PutItemRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PutItemResponse());
+
+        await _target.WriteSessionStep("session-1", 42, "look", "A room.", "steps");
+
+        _client.Verify(c => c.PutItemAsync(It.Is<PutItemRequest>(r => r.TableName == "steps" &&
+            r.Item["session_id"].S == "session-1" && r.Item["ts"].N == "42" &&
+            r.Item["input"].S == "look" && r.Item["output"].S == "A room."),
+            It.IsAny<CancellationToken>()));
+    }
+
+    [Test]
+    public async Task GetSessionStepsAsText_RequestsChronologicalRows_AndFormatsTranscript()
+    {
+        _client.Setup(c => c.QueryAsync(It.IsAny<QueryRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new QueryResponse
+            {
+                Items =
+                [
+                    new Dictionary<string, AttributeValue>
+                        { { "input", new AttributeValue("look") }, { "output", new AttributeValue("A room.") } },
+                    new Dictionary<string, AttributeValue>
+                        { { "input", new AttributeValue("north") }, { "output", new AttributeValue("You move.") } }
+                ]
+            });
+
+        var result = await _target.GetSessionStepsAsText("session-1", "steps");
+
+        result.Should().Be("> look\nA room.\n> north\nYou move.");
+        _client.Verify(c => c.QueryAsync(It.Is<QueryRequest>(r => r.TableName == "steps" &&
+            r.ScanIndexForward == true && r.ExpressionAttributeValues[":sid"].S == "session-1"),
+            It.IsAny<CancellationToken>()));
+    }
+}

--- a/UnitTests/AWS/DynamoDbRepositoryBehaviorTests.cs
+++ b/UnitTests/AWS/DynamoDbRepositoryBehaviorTests.cs
@@ -137,7 +137,7 @@ public class DynamoDbSessionRepositoryBehaviorTests
     public async Task GetSessionState_ReturnsNull_WhenItemDoesNotExist()
     {
         _client.Setup(c => c.GetItemAsync(It.IsAny<GetItemRequest>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new GetItemResponse { Item = new Dictionary<string, AttributeValue>() });
+            .ReturnsAsync(new GetItemResponse());
 
         var result = await _target.GetSessionState("missing", "sessions");
         result.Should().BeNull();

--- a/UnitTests/OpenAIClientBehaviorTests.cs
+++ b/UnitTests/OpenAIClientBehaviorTests.cs
@@ -1,0 +1,258 @@
+using Microsoft.Extensions.Logging;
+using Model.AIGeneration.Requests;
+using Model.Hints;
+using Model.Intent;
+using Model.Movement;
+using OpenAI.Chat;
+using ZorkAI.OpenAI;
+
+namespace UnitTests;
+
+[TestFixture]
+public class ChatGPTClientBehaviorTests
+{
+    [Test]
+    public async Task GenerateNarration_WhenDisabled_ReturnsFallbackWithoutCallingOpenAI()
+    {
+        var completion = new Mock<IChatCompletionClient>();
+        var target = new ChatGPTClient(null, completion.Object) { IsDisabled = true };
+
+        var result = await target.GenerateNarration(new EmptyRequest(), string.Empty);
+
+        result.Should().Be("This action or command has no effect on the game. ");
+        completion.VerifyNoOtherCalls();
+    }
+
+    [Test]
+    public async Task GenerateNarration_BuildsContextAndInvokesCallback()
+    {
+        IReadOnlyList<ChatMessage>? messages = null;
+        ChatCompletionOptions? options = null;
+        var completion = new Mock<IChatCompletionClient>();
+        completion.Setup(c => c.CompleteChatAsync(It.IsAny<IReadOnlyList<ChatMessage>>(),
+                It.IsAny<ChatCompletionOptions>()))
+            .Callback<IReadOnlyList<ChatMessage>, ChatCompletionOptions>((m, o) =>
+            {
+                messages = m;
+                options = o;
+            })
+            .ReturnsAsync("A dry narrator response.");
+        var generated = false;
+        var target = new ChatGPTClient(null, completion.Object)
+        {
+            SystemPrompt = "Narrate.",
+            LastFiveInputOutputs = [("look", "A room.", false), ("north", "You move.", false)],
+            OnGenerate = () => generated = true
+        };
+
+        var result = await target.GenerateNarration(new CannotGoThatWayRequest("Kitchen", "west"), " Stay terse.");
+
+        result.Should().Be("A dry narrator response.");
+        generated.Should().BeTrue();
+        messages.Should().HaveCount(3);
+        MessageText(messages![0]).Should().Contain("Narrate. Stay terse.");
+        MessageText(messages[1]).Should().Contain("Input: north. Output: You move.")
+            .And.Contain("Input: look. Output: A room.");
+        options!.Temperature.Should().Be(0.4f);
+    }
+
+    [Test]
+    public async Task GenerateNarration_WhenProviderIsSilent_ReturnsNarratorFallback()
+    {
+        var completion = CompletionReturning(string.Empty);
+        var target = new ChatGPTClient(null, completion.Object);
+
+        var result = await target.GenerateNarration(new EmptyRequest(), string.Empty);
+
+        result.Should().Be("The narrator is silent. ");
+    }
+
+    [Test]
+    public async Task GenerateCompanionSpeech_WhenCompanionFails_FallsBackAndNormalizesQuotes()
+    {
+        var narrator = CompletionReturning("“Careful,” Floyd says.");
+        var companion = new Mock<IChatCompletionClient>();
+        companion.Setup(c => c.CompleteChatAsync(It.IsAny<IReadOnlyList<ChatMessage>>(),
+                It.IsAny<ChatCompletionOptions>()))
+            .ThrowsAsync(new InvalidOperationException("model unavailable"));
+        var target = new ChatGPTClient(Mock.Of<ILogger>(), narrator.Object, companion.Object);
+
+        var result = await target.GenerateCompanionSpeech(new CompanionRequest("React.", "You are Floyd."));
+
+        result.Should().Be("\"Careful,\" Floyd says.");
+        companion.Verify(c => c.CompleteChatAsync(It.IsAny<IReadOnlyList<ChatMessage>>(),
+            It.IsAny<ChatCompletionOptions>()), Times.Once);
+        narrator.Verify(c => c.CompleteChatAsync(It.IsAny<IReadOnlyList<ChatMessage>>(),
+            It.IsAny<ChatCompletionOptions>()), Times.Once);
+    }
+
+    private static Mock<IChatCompletionClient> CompletionReturning(string response)
+    {
+        var completion = new Mock<IChatCompletionClient>();
+        completion.Setup(c => c.CompleteChatAsync(It.IsAny<IReadOnlyList<ChatMessage>>(),
+                It.IsAny<ChatCompletionOptions>()))
+            .ReturnsAsync(response);
+        return completion;
+    }
+
+    private static string MessageText(ChatMessage message) => message.Content[0].Text;
+}
+
+[TestFixture]
+public class PronounResolverBehaviorTests
+{
+    [Test]
+    public async Task ResolvePronouns_SkipsProvider_WhenThereIsNoPronoun()
+    {
+        var completion = new Mock<IChatCompletionClient>();
+        var target = new PronounResolver(null, completion.Object);
+
+        var result = await target.ResolvePronouns("take lamp", "look", "A lamp is here.");
+
+        result.Should().BeNull();
+        completion.VerifyNoOtherCalls();
+    }
+
+    [Test]
+    public async Task ResolvePronouns_SkipsProvider_WhenThereIsNoContext()
+    {
+        var completion = new Mock<IChatCompletionClient>();
+        var target = new PronounResolver(null, completion.Object);
+
+        var result = await target.ResolvePronouns("take it", null, "  ");
+
+        result.Should().BeNull();
+        completion.VerifyNoOtherCalls();
+    }
+
+    [Test]
+    public async Task ResolvePronouns_BuildsContextAndCleansProviderResponse()
+    {
+        IReadOnlyList<ChatMessage>? messages = null;
+        ChatCompletionOptions? options = null;
+        var completion = new Mock<IChatCompletionClient>();
+        completion.Setup(c => c.CompleteChatAsync(It.IsAny<IReadOnlyList<ChatMessage>>(),
+                It.IsAny<ChatCompletionOptions>()))
+            .Callback<IReadOnlyList<ChatMessage>, ChatCompletionOptions>((m, o) =>
+            {
+                messages = m;
+                options = o;
+            })
+            .ReturnsAsync("  \"turn brass lamp on\"  ");
+        var target = new PronounResolver(null, completion.Object);
+
+        var result = await target.ResolvePronouns("turn it on", "take brass lamp", "Taken.");
+
+        result.Should().Be("turn brass lamp on");
+        MessageText(messages![1]).Should().Contain("Last player command: \"take brass lamp\"")
+            .And.Contain("Game response: \"Taken.\"")
+            .And.Contain("Current command: turn it on");
+        options!.Temperature.Should().Be(0f);
+    }
+
+    [Test]
+    public async Task ResolvePronouns_WhenProviderFails_ReturnsNull()
+    {
+        var completion = new Mock<IChatCompletionClient>();
+        completion.Setup(c => c.CompleteChatAsync(It.IsAny<IReadOnlyList<ChatMessage>>(),
+                It.IsAny<ChatCompletionOptions>()))
+            .ThrowsAsync(new InvalidOperationException("offline"));
+        var target = new PronounResolver(Mock.Of<ILogger>(), completion.Object);
+
+        var result = await target.ResolvePronouns("open it", "examine door", "It is locked.");
+
+        result.Should().BeNull();
+    }
+
+    private static string MessageText(ChatMessage message) => message.Content[0].Text;
+}
+
+[TestFixture]
+public class OpenAIParsingBehaviorTests
+{
+    [Test]
+    public async Task Parser_ConvertsTaggedCompletionToIntent()
+    {
+        var completion = CompletionReturning("<intent>move</intent><direction>north</direction>");
+        var target = new OpenAIParser(null, completion.Object);
+
+        var result = await target.AskTheAIParser("head north", "A corridor", "session");
+
+        result.Should().BeOfType<MoveIntent>().Which.Direction.Should().Be(Direction.N);
+    }
+
+    [Test]
+    public async Task TakeAndDropParser_DeserializesItemsAndBuildsTheCorrectPrompt()
+    {
+        IReadOnlyList<ChatMessage>? messages = null;
+        var completion = new Mock<IChatCompletionClient>();
+        completion.Setup(c => c.CompleteChatAsync(It.IsAny<IReadOnlyList<ChatMessage>>(),
+                It.IsAny<ChatCompletionOptions>()))
+            .Callback<IReadOnlyList<ChatMessage>, ChatCompletionOptions>((m, _) => messages = m)
+            .ReturnsAsync("{\"items\":[\"brass lantern\",\"sword\"]}");
+        var target = new OpenAITakeAndDropListParser(null, completion.Object);
+
+        var result = await target.GetListOfItemsToTake("grab both", "A brass lantern and sword are here.");
+
+        result.Should().Equal("brass lantern", "sword");
+        messages.Should().ContainSingle();
+        messages![0].Content[0].Text.Should().Contain("A brass lantern and sword are here.")
+            .And.Contain("grab both");
+    }
+
+    [Test]
+    public async Task TakeAndDropParser_WhenItemsAreMissing_ReturnsEmptyList()
+    {
+        var target = new OpenAITakeAndDropListParser(null, CompletionReturning("{}").Object);
+
+        var result = await target.GetListOfItemsToDrop("drop nothing", "Empty");
+
+        result.Should().BeEmpty();
+    }
+
+    private static Mock<IChatCompletionClient> CompletionReturning(string response)
+    {
+        var completion = new Mock<IChatCompletionClient>();
+        completion.Setup(c => c.CompleteChatAsync(It.IsAny<IReadOnlyList<ChatMessage>>(),
+                It.IsAny<ChatCompletionOptions>()))
+            .ReturnsAsync(response);
+        return completion;
+    }
+}
+
+[TestFixture]
+public class OpenAiHintLanguageModelBehaviorTests
+{
+    [Test]
+    public async Task Solve_IncludesKnowledgeContextHistoryAndQuestion()
+    {
+        IReadOnlyList<ChatMessage>? messages = null;
+        var completion = new Mock<IChatCompletionClient>();
+        completion.Setup(c => c.CompleteChatAsync(It.IsAny<IReadOnlyList<ChatMessage>>(),
+                It.IsAny<ChatCompletionOptions>()))
+            .Callback<IReadOnlyList<ChatMessage>, ChatCompletionOptions>((m, _) => messages = m)
+            .ReturnsAsync("Use the ladder.");
+        var target = new OpenAiHintLanguageModel(null, completion.Object);
+
+        var result = await target.Solve("ladder docs", "at the rift",
+            [new HintExchange("Where next?", "Look around.")], "How do I cross?", new HintPersona("Be dry."));
+
+        result.Should().Be("Use the ladder.");
+        messages![1].Content[0].Text.Should().Contain("ladder docs").And.Contain("at the rift")
+            .And.Contain("Where next?").And.Contain("How do I cross?");
+    }
+
+    [Test]
+    public async Task Reveal_WhenProviderFails_ReturnsCompleteSolution()
+    {
+        var completion = new Mock<IChatCompletionClient>();
+        completion.Setup(c => c.CompleteChatAsync(It.IsAny<IReadOnlyList<ChatMessage>>(),
+                It.IsAny<ChatCompletionOptions>()))
+            .ThrowsAsync(new InvalidOperationException("offline"));
+        var target = new OpenAiHintLanguageModel(Mock.Of<ILogger>(), completion.Object);
+
+        var result = await target.Reveal("at the rift", "Use the ladder", [], "More?", new HintPersona("Be dry."));
+
+        result.Should().Be("Use the ladder");
+    }
+}

--- a/ZorkAI.OpenAI/ChatGPTClient.cs
+++ b/ZorkAI.OpenAI/ChatGPTClient.cs
@@ -11,8 +11,18 @@ namespace ZorkAI.OpenAI;
 /// <summary>
 ///     Represents a client for interacting with ZorkAI.OpenAI API to generate text.
 /// </summary>
-public class ChatGPTClient(ILogger? logger) : OpenAIClientBase(logger), IGenerationClient
+public class ChatGPTClient : OpenAIClientBase, IGenerationClient
 {
+    public ChatGPTClient(ILogger? logger) : base(logger)
+    {
+    }
+
+    public ChatGPTClient(ILogger? logger, IChatCompletionClient client,
+        IChatCompletionClient? companionClient = null) : base(logger, clientOverride: client)
+    {
+        _companionClient = companionClient;
+    }
+
     protected override string ModelName => "gpt-4o";
 
     // Companion speech (Floyd's chatter) runs on a cheaper, equally-fast model. It is a short,
@@ -21,10 +31,12 @@ public class ChatGPTClient(ILogger? logger) : OpenAIClientBase(logger), IGenerat
     // NOTE: confirm this id is enabled on the account before deploying.
     private const string CompanionModelName = "gpt-5.4-mini";
 
-    private ChatClient? _companionClient;
+    private IChatCompletionClient? _companionClient;
 
-    private ChatClient? CompanionClient =>
-        _companionClient ??= ApiKey is null ? null : new ChatClient(model: CompanionModelName, apiKey: ApiKey);
+    private IChatCompletionClient? CompanionClient =>
+        _companionClient ??= ApiKey is null
+            ? null
+            : new OpenAIChatCompletionClient(new ChatClient(model: CompanionModelName, apiKey: ApiKey));
 
     public Action? OnGenerate { get; set; }
 
@@ -78,8 +90,7 @@ public class ChatGPTClient(ILogger? logger) : OpenAIClientBase(logger), IGenerat
             Temperature = request.Temperature
         };
 
-        ChatCompletion completion = await Client!.CompleteChatAsync(messages, options);
-        var responseContent = completion.Content[0].Text;
+        var responseContent = await Client!.CompleteChatAsync(messages, options);
 
         if (string.IsNullOrEmpty(responseContent))
             return "The narrator is silent. ";
@@ -123,19 +134,17 @@ public class ChatGPTClient(ILogger? logger) : OpenAIClientBase(logger), IGenerat
         // Companion speech runs on a cheaper model. If that model is unavailable or misconfigured,
         // degrade gracefully to the narrator's model rather than throwing - keeping with the codebase's
         // "graceful degradation when AI services unavailable" principle.
-        ChatCompletion completion;
+        string responseContent;
         try
         {
-            completion = await (CompanionClient ?? Client)!.CompleteChatAsync(messages, options);
+            responseContent = await (CompanionClient ?? Client)!.CompleteChatAsync(messages, options);
         }
         catch (Exception ex) when (CompanionClient is not null && Client is not null)
         {
             Logger?.LogWarning(ex,
                 "Companion model '{Model}' failed; falling back to the narrator model.", CompanionModelName);
-            completion = await Client.CompleteChatAsync(messages, options);
+            responseContent = await Client.CompleteChatAsync(messages, options);
         }
-
-        var responseContent = completion.Content[0].Text;
 
         if (string.IsNullOrEmpty(responseContent))
             return "Your companion says nothing. ";

--- a/ZorkAI.OpenAI/IChatCompletionClient.cs
+++ b/ZorkAI.OpenAI/IChatCompletionClient.cs
@@ -1,0 +1,21 @@
+using OpenAI.Chat;
+
+namespace ZorkAI.OpenAI;
+
+/// <summary>
+/// Small seam around the OpenAI SDK so prompt construction and fallback behavior can be tested
+/// without credentials or network calls.
+/// </summary>
+public interface IChatCompletionClient
+{
+    Task<string> CompleteChatAsync(IReadOnlyList<ChatMessage> messages, ChatCompletionOptions options);
+}
+
+internal sealed class OpenAIChatCompletionClient(ChatClient client) : IChatCompletionClient
+{
+    public async Task<string> CompleteChatAsync(IReadOnlyList<ChatMessage> messages, ChatCompletionOptions options)
+    {
+        ChatCompletion completion = await client.CompleteChatAsync(messages, options);
+        return completion.Content[0].Text;
+    }
+}

--- a/ZorkAI.OpenAI/OpenAIClientBase.cs
+++ b/ZorkAI.OpenAI/OpenAIClientBase.cs
@@ -5,7 +5,7 @@ namespace ZorkAI.OpenAI;
 
 public abstract class OpenAIClientBase
 {
-    protected readonly ChatClient? Client;
+    protected readonly IChatCompletionClient? Client;
     protected readonly ILogger? Logger;
     protected readonly bool HasApiKey;
 
@@ -13,9 +13,18 @@ public abstract class OpenAIClientBase
     // (e.g. ChatGPTClient runs Floyd's companion speech on a cheaper, faster model).
     protected readonly string? ApiKey;
 
-    protected OpenAIClientBase(ILogger? logger, bool requireApiKey = true, string? modelOverride = null)
+    protected OpenAIClientBase(ILogger? logger, bool requireApiKey = true, string? modelOverride = null,
+        IChatCompletionClient? clientOverride = null)
     {
         Logger = logger;
+
+        if (clientOverride is not null)
+        {
+            HasApiKey = true;
+            Client = clientOverride;
+            return;
+        }
+
         var key = Environment.GetEnvironmentVariable("OPEN_AI_KEY");
 
         if (string.IsNullOrEmpty(key))
@@ -33,7 +42,7 @@ public abstract class OpenAIClientBase
             // modelOverride lets a subclass whose model is constructor-selectable build the base Client
             // with the right model directly, avoiding a virtual ModelName call before the subclass's
             // fields are initialized (and avoiding a second, unused client).
-            Client = new ChatClient(model: modelOverride ?? ModelName, apiKey: key);
+            Client = new OpenAIChatCompletionClient(new ChatClient(model: modelOverride ?? ModelName, apiKey: key));
         }
     }
 

--- a/ZorkAI.OpenAI/OpenAIClientBase.cs
+++ b/ZorkAI.OpenAI/OpenAIClientBase.cs
@@ -20,6 +20,10 @@ public abstract class OpenAIClientBase
 
         if (clientOverride is not null)
         {
+            // An injected client means we have a working generation seam, so HasApiKey is true - but
+            // ApiKey stays null on purpose. ApiKey only exists to let a subclass build a *second*
+            // real ChatClient on another model (Floyd's companion speech); there is no raw key behind
+            // an injected seam, and any subclass that needs a companion client injects that too.
             HasApiKey = true;
             Client = clientOverride;
             return;

--- a/ZorkAI.OpenAI/OpenAIParser.cs
+++ b/ZorkAI.OpenAI/OpenAIParser.cs
@@ -6,8 +6,16 @@ using OpenAI.Chat;
 
 namespace ZorkAI.OpenAI;
 
-public class OpenAIParser(ILogger? logger) : OpenAIClientBase(logger), IAIParser
+public class OpenAIParser : OpenAIClientBase, IAIParser
 {
+    public OpenAIParser(ILogger? logger) : base(logger)
+    {
+    }
+
+    public OpenAIParser(ILogger? logger, IChatCompletionClient client) : base(logger, clientOverride: client)
+    {
+    }
+
     protected override string ModelName => "gpt-4o";
 
     public async Task<IntentBase> AskTheAIParser(string input, string locationDescription, string sessionId)
@@ -24,8 +32,7 @@ public class OpenAIParser(ILogger? logger) : OpenAIClientBase(logger), IAIParser
             Temperature = 0f
         };
 
-        ChatCompletion completion = await Client!.CompleteChatAsync(messages, options);
-        var responseContent = completion.Content[0].Text;
+        var responseContent = await Client!.CompleteChatAsync(messages, options);
         return ParsingHelper.GetIntent(input, responseContent, Logger);
     }
 

--- a/ZorkAI.OpenAI/OpenAITakeAndDropListParser.cs
+++ b/ZorkAI.OpenAI/OpenAITakeAndDropListParser.cs
@@ -6,8 +6,17 @@ using OpenAI.Chat;
 
 namespace ZorkAI.OpenAI;
 
-public class OpenAITakeAndDropListParser(ILogger? logger) : OpenAIClientBase(logger), IAITakeAndAndDropParser
+public class OpenAITakeAndDropListParser : OpenAIClientBase, IAITakeAndAndDropParser
 {
+    public OpenAITakeAndDropListParser(ILogger? logger) : base(logger)
+    {
+    }
+
+    public OpenAITakeAndDropListParser(ILogger? logger, IChatCompletionClient client)
+        : base(logger, clientOverride: client)
+    {
+    }
+
     protected override string ModelName => "gpt-4o-mini";
 
     public async Task<string[]> GetListOfItemsToTake(string input, string locationDescription)
@@ -35,8 +44,8 @@ public class OpenAITakeAndDropListParser(ILogger? logger) : OpenAIClientBase(log
             ResponseFormat = ChatResponseFormat.CreateJsonObjectFormat()
         };
 
-        ChatCompletion completion = await Client!.CompleteChatAsync(messages, options);
-        var result = JsonConvert.DeserializeObject<ItemsResponse>(completion.Content[0].Text);
+        var response = await Client!.CompleteChatAsync(messages, options);
+        var result = JsonConvert.DeserializeObject<ItemsResponse>(response);
         return result?.Items ?? [];
     }
 

--- a/ZorkAI.OpenAI/OpenAiHintLanguageModel.cs
+++ b/ZorkAI.OpenAI/OpenAiHintLanguageModel.cs
@@ -22,6 +22,11 @@ public sealed class OpenAiHintLanguageModel : OpenAIClientBase, IHintLanguageMod
     {
     }
 
+    public OpenAiHintLanguageModel(ILogger? logger, IChatCompletionClient client)
+        : base(logger, requireApiKey: false, clientOverride: client)
+    {
+    }
+
     public async Task<string> Solve(string docs, string playerContext, IReadOnlyList<HintExchange> history,
         string question, HintPersona persona)
     {
@@ -92,9 +97,8 @@ public sealed class OpenAiHintLanguageModel : OpenAIClientBase, IHintLanguageMod
         var messages = new List<ChatMessage> { new SystemChatMessage(system), new UserChatMessage(user) };
         try
         {
-            ChatCompletion completion = await Client!.CompleteChatAsync(messages,
+            return await Client!.CompleteChatAsync(messages,
                 new ChatCompletionOptions { Temperature = temperature });
-            return completion.Content[0].Text;
         }
         catch (Exception e)
         {

--- a/ZorkAI.OpenAI/PronounResolver.cs
+++ b/ZorkAI.OpenAI/PronounResolver.cs
@@ -10,8 +10,17 @@ namespace ZorkAI.OpenAI;
 /// The resolution process utilizes a language model for improved accuracy, where available, and can gracefully degrade
 /// when no API key is provided for interaction with the model.
 /// </summary>
-public class PronounResolver(ILogger? logger = null) : OpenAIClientBase(logger, requireApiKey: false), IPronounResolver
+public class PronounResolver : OpenAIClientBase, IPronounResolver
 {
+    public PronounResolver(ILogger? logger = null) : base(logger, requireApiKey: false)
+    {
+    }
+
+    public PronounResolver(ILogger? logger, IChatCompletionClient client)
+        : base(logger, requireApiKey: false, clientOverride: client)
+    {
+    }
+
     protected override string ModelName => "gpt-4o-mini"; // Cheaper model for pronoun resolution
 
     // Pronouns we want to resolve
@@ -112,8 +121,7 @@ Rewritten command:";
             Temperature = 0f // Deterministic for pronoun resolution
         };
 
-        ChatCompletion completion = await Client!.CompleteChatAsync(messages, options);
-        var result = completion.Content[0].Text;
+        var result = await Client!.CompleteChatAsync(messages, options);
 
         // Clean up response (remove quotes, trim)
         result = result.Trim().Trim('"').Trim('\'');

--- a/planetfallweb.client/jest.config.ts
+++ b/planetfallweb.client/jest.config.ts
@@ -14,6 +14,12 @@ export default {
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   testMatch: ['<rootDir>/src/**/__tests__/**/*.{ts,tsx}', '<rootDir>/src/**/*.{spec,test}.{ts,tsx}'],
   testPathIgnorePatterns: ['<rootDir>/node_modules/', '<rootDir>/src/__skipped_tests__/'],
+  collectCoverageFrom: [
+    '<rootDir>/src/**/*.{ts,tsx}',
+    '!<rootDir>/src/**/*.d.ts',
+    '!<rootDir>/src/main.tsx',
+    '!<rootDir>/src/__mocks__/**',
+  ],
   transform: {
     '^.+\\.(ts|tsx)$': ['ts-jest', {
       tsconfig: 'tsconfig.json',

--- a/planetfallweb.client/src/__tests__/App.test.tsx
+++ b/planetfallweb.client/src/__tests__/App.test.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import {fireEvent, render, screen, waitFor} from '@testing-library/react';
+import {DialogType, ReleaseNotesServer, useGameContext} from '@zork-ai/shared-types';
+import App from '../App';
+import Server from '../Server';
+
+jest.mock('../Game', () => () => <div data-testid="game"/>);
+jest.mock('../Server');
+jest.mock('../menu/GameMenu', () => (props: {latestVersion: string}) =>
+    <div data-testid="game-menu">{props.latestVersion}</div>);
+jest.mock('../modal/WelcomeModal', () => (props: {open: boolean}) =>
+    <div data-testid="welcome-modal" data-open={props.open}/>);
+jest.mock('@zork-ai/shared-types', () => {
+    const actual = jest.requireActual('@zork-ai/shared-types');
+    const modal = (testId: string) => (props: {open: boolean; games?: unknown[]; onConfirm?: () => void}) =>
+        <div data-testid={testId} data-open={props.open} data-games={props.games?.length ?? 0}>
+            {props.onConfirm && <button onClick={props.onConfirm}>confirm</button>}
+        </div>;
+    return {
+        ...actual,
+        useGameContext: jest.fn(),
+        SessionHandler: jest.fn().mockImplementation(() => ({getClientId: () => 'client-1'})),
+        ReleaseNotesServer: jest.fn(),
+        Mixpanel: {track: jest.fn()},
+        SaveModal: modal('save-modal'),
+        RestoreModal: modal('restore-modal'),
+        RestartConfirmDialog: modal('restart-modal'),
+        VideoDialog: modal('video-modal'),
+        ReleaseNotesModal: modal('release-notes-modal'),
+    };
+});
+
+describe('App', () => {
+    const server = {getSavedGames: jest.fn()};
+    const context = {
+        dialogToOpen: undefined as DialogType | undefined,
+        setDialogToOpen: jest.fn(),
+        setRestartGame: jest.fn(),
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        context.dialogToOpen = undefined;
+        (useGameContext as jest.Mock).mockReturnValue(context);
+        (Server as jest.MockedClass<typeof Server>).mockImplementation(() => server as unknown as Server);
+        (ReleaseNotesServer as jest.Mock).mockResolvedValue([
+            {date: '2026-07-22', name: 'v2.0', notes: 'More tests'}
+        ]);
+        server.getSavedGames.mockResolvedValue([{id: 'save-1'}]);
+    });
+
+    test('loads the latest release name on mount', async () => {
+        render(<App/>);
+
+        expect(await screen.findByTestId('game-menu')).toHaveTextContent('v2.0');
+        expect(screen.getByTestId('game')).toBeInTheDocument();
+    });
+
+    test.each([
+        [DialogType.Save, 'save-modal'],
+        [DialogType.Restore, 'restore-modal'],
+    ])('loads saved games before opening the %s dialog', async (dialog, testId) => {
+        context.dialogToOpen = dialog;
+        render(<App/>);
+
+        await waitFor(() => expect(server.getSavedGames).toHaveBeenCalledWith('client-1'));
+        expect(screen.getByTestId(testId)).toHaveAttribute('data-open', 'true');
+        expect(screen.getByTestId(testId)).toHaveAttribute('data-games', '1');
+        expect(context.setDialogToOpen).toHaveBeenCalledWith(undefined);
+    });
+
+    test.each([
+        [DialogType.Video, 'video-modal'],
+        [DialogType.Welcome, 'welcome-modal'],
+        [DialogType.ReleaseNotes, 'release-notes-modal'],
+    ])('opens the %s dialog without loading saves', async (dialog, testId) => {
+        context.dialogToOpen = dialog;
+        render(<App/>);
+
+        await waitFor(() => expect(screen.getByTestId(testId)).toHaveAttribute('data-open', 'true'));
+        expect(server.getSavedGames).not.toHaveBeenCalled();
+    });
+
+    test('confirms a restart through context', async () => {
+        context.dialogToOpen = DialogType.Restart;
+        render(<App/>);
+
+        await waitFor(() => expect(screen.getByTestId('restart-modal')).toHaveAttribute('data-open', 'true'));
+        fireEvent.click(screen.getByText('confirm'));
+        expect(context.setRestartGame).toHaveBeenCalledWith(true);
+    });
+});

--- a/planetfallweb.client/src/__tests__/Game.test.tsx
+++ b/planetfallweb.client/src/__tests__/Game.test.tsx
@@ -1,0 +1,123 @@
+import React from 'react';
+import {act, fireEvent, render, screen, waitFor} from '@testing-library/react';
+import {DialogType, SessionHandler, useGameContext} from '@zork-ai/shared-types';
+import {useMutation} from '@tanstack/react-query';
+import Game from '../Game';
+import Server from '../Server';
+
+jest.mock('@tanstack/react-query', () => ({useMutation: jest.fn()}));
+jest.mock('@fontsource/roboto', () => ({}));
+jest.mock('../Server');
+jest.mock('../components/GameInput', () => (props: {
+    playerInput: string;
+    setInput: (value: string) => void;
+    handleKeyDown: (event: React.KeyboardEvent<HTMLInputElement>) => void;
+}) => <input data-testid="game-input" value={props.playerInput}
+            onChange={(event) => props.setInput(event.target.value)} onKeyDown={props.handleKeyDown}/>);
+jest.mock('@zork-ai/shared-types', () => {
+    const actual = jest.requireActual('@zork-ai/shared-types');
+    return {
+        ...actual,
+        useGameContext: jest.fn(),
+        SessionHandler: jest.fn(),
+        Mixpanel: {track: jest.fn()},
+    };
+});
+
+describe('Game', () => {
+    const mutate = jest.fn();
+    const session = {
+        getSessionId: jest.fn(() => ['session-1', false]),
+        getClientId: jest.fn(() => 'client-1'),
+        regenerate: jest.fn(),
+    };
+    const server = {
+        gameInit: jest.fn(),
+        gameInput: jest.fn(),
+        saveGame: jest.fn(),
+        gameRestore: jest.fn(),
+        deleteSavedGame: jest.fn(),
+    };
+    const context = {
+        setDialogToOpen: jest.fn(),
+        restartGame: false,
+        setRestartGame: jest.fn(),
+        saveGameRequest: undefined,
+        setSaveGameRequest: jest.fn(),
+        restoreGameRequest: undefined,
+        setRestoreGameRequest: jest.fn(),
+        deleteGameRequest: undefined,
+        setDeleteGameRequest: jest.fn(),
+        setCopyGameTranscript: jest.fn(),
+    };
+    let mutationOptions: {onSuccess: (response: unknown) => void};
+
+    const response = (text: string) => ({
+        response: text,
+        locationName: 'Escape Pod (A)',
+        score: 7,
+        moves: 3,
+        time: 845,
+        inventory: ['towel'],
+        exits: ['0'],
+        actionsAvailableFromInventory: {towel: ['take towel']},
+        actionsAvailableFromLocation: {webbing: ['enter webbing']},
+    });
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        Object.assign(context, {
+            restartGame: false,
+            saveGameRequest: undefined,
+            restoreGameRequest: undefined,
+            deleteGameRequest: undefined,
+        });
+        (SessionHandler as jest.Mock).mockImplementation(() => session);
+        (Server as jest.MockedClass<typeof Server>).mockImplementation(() => server as unknown as Server);
+        (useGameContext as jest.Mock).mockReturnValue(context);
+        (useMutation as jest.Mock).mockImplementation((options) => {
+            mutationOptions = options;
+            return {mutate, isPending: false, isError: false};
+        });
+        server.gameInit.mockResolvedValue(response('Escape Pod (A)\n  Safety webbing fills the pod.'));
+    });
+
+    test('loads and formats the initial game state', async () => {
+        render(<Game/>);
+
+        await waitFor(() => expect(screen.getByTestId('header-location')).toHaveTextContent('Escape Pod (A)'));
+        const rendered = screen.getAllByTestId('game-response').at(-1)!;
+        expect(rendered.innerHTML).toContain('<span class="room-header">Escape Pod (A)</span>Safety webbing fills the pod.');
+        expect(screen.getByTestId('inventory-button')).toBeInTheDocument();
+    });
+
+    test('submits trimmed input with the active session and records successful output', async () => {
+        render(<Game/>);
+        await waitFor(() => expect(server.gameInit).toHaveBeenCalled());
+
+        fireEvent.change(screen.getByTestId('game-input'), {target: {value: '  north  '}});
+        fireEvent.click(screen.getByTestId('go-button'));
+        expect(mutate).toHaveBeenCalledWith(expect.objectContaining({input: 'north', sessionId: 'session-1'}));
+
+        act(() => mutationOptions.onSuccess(response('You go north.')));
+        expect(screen.getAllByTestId('game-response').at(-1)!.innerHTML).toContain('&gt;   north  ');
+    });
+
+    test.each([
+        ['<Save>', DialogType.Save],
+        ['<Restore>', DialogType.Restore],
+        ['<Restart>', DialogType.Restart],
+    ])('routes the %s response to its dialog', async (marker, dialog) => {
+        server.gameInit.mockResolvedValue(response(marker));
+        render(<Game/>);
+
+        await waitFor(() => expect(context.setDialogToOpen).toHaveBeenCalledWith(dialog));
+    });
+
+    test('shows request failures from the mutation', async () => {
+        (useMutation as jest.Mock).mockReturnValue({mutate, isPending: false, isError: true});
+        render(<Game/>);
+
+        expect(await screen.findByText(/Something went wrong/)).toBeInTheDocument();
+    });
+});

--- a/planetfallweb.client/src/__tests__/Server.test.ts
+++ b/planetfallweb.client/src/__tests__/Server.test.ts
@@ -1,0 +1,91 @@
+import axios from 'axios';
+import {Mixpanel} from '@zork-ai/shared-types';
+import Server from '../Server';
+
+jest.mock('axios');
+jest.mock('@zork-ai/shared-types', () => {
+    const actual = jest.requireActual('@zork-ai/shared-types');
+    return {
+        ...actual,
+        Mixpanel: {track: jest.fn()},
+        SessionHandler: jest.fn().mockImplementation(() => ({getClientId: () => 'client-123'})),
+    };
+});
+
+describe('Server', () => {
+    const client = {
+        get: jest.fn(),
+        post: jest.fn(),
+        delete: jest.fn(),
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        (axios.create as jest.Mock).mockReturnValue(client);
+    });
+
+    test('posts a turn and records the returned game state', async () => {
+        const data = {response: 'Taken.', score: 5, moves: 2, locationName: 'Escape Pod'};
+        client.post.mockResolvedValue({data});
+
+        const result = await new Server().gameInput({input: 'take towel', sessionId: 'session-1'});
+
+        expect(client.post).toHaveBeenCalledWith('', {input: 'take towel', sessionId: 'session-1'}, {
+            headers: {Accept: 'application/json'},
+        });
+        expect(Mixpanel.track).toHaveBeenCalledWith('Played a Turn', expect.objectContaining({
+            input: 'take towel', output: 'Taken.', clientId: 'client-123',
+        }));
+        expect(result).toBe(data);
+    });
+
+    test('loads the current session using the expected query parameter', async () => {
+        const data = {response: 'Escape Pod'};
+        client.get.mockResolvedValue({data});
+
+        await expect(new Server().gameInit('session-1')).resolves.toBe(data);
+        expect(client.get).toHaveBeenCalledWith('', {
+            params: {sessionId: 'session-1'},
+            headers: {Accept: 'application/json'},
+        });
+    });
+
+    test('lists saved games and records their count', async () => {
+        const games = [{id: 'one'}, {id: 'two'}];
+        client.get.mockResolvedValue({data: games});
+
+        await expect(new Server().getSavedGames('client-1')).resolves.toBe(games);
+        expect(client.get).toHaveBeenCalledWith('saveGame', {params: {sessionId: 'client-1'}});
+        expect(Mixpanel.track).toHaveBeenCalledWith('Listed Saved Games', {
+            clientId: 'client-1', gameCount: 2,
+        });
+    });
+
+    test('rethrows saved-game listing failures', async () => {
+        const error = new Error('offline');
+        client.get.mockRejectedValue(error);
+        jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+        await expect(new Server().getSavedGames('client-1')).rejects.toBe(error);
+    });
+
+    test('saves, restores, and deletes using the API contract', async () => {
+        client.post.mockResolvedValueOnce({data: 'Saved.'}).mockResolvedValueOnce({data: {response: 'Restored.'}});
+        client.delete.mockResolvedValue({});
+        const server = new Server();
+        const saveRequest = {id: 'save-1', clientId: 'client-1', sessionId: 'session-1', name: 'My save'};
+
+        await expect(server.saveGame(saveRequest)).resolves.toBe('Saved.');
+        await expect(server.gameRestore('save-1', 'client-1', 'session-2')).resolves.toEqual({response: 'Restored.'});
+        await server.deleteSavedGame('save-1', 'session-2');
+
+        expect(client.post).toHaveBeenNthCalledWith(1, 'saveGame', saveRequest, {
+            headers: {Accept: 'application/json'},
+        });
+        expect(client.post).toHaveBeenNthCalledWith(2, 'restoreGame', expect.objectContaining({
+            id: 'save-1', clientId: 'client-1', sessionId: 'session-2',
+        }), {headers: {Accept: 'application/json'}});
+        expect(client.delete).toHaveBeenCalledWith('saveGame/save-1', {params: {sessionId: 'session-2'}});
+        expect(Mixpanel.track).toHaveBeenCalledWith('Delete Saved Game', expect.objectContaining({gameId: 'save-1'}));
+    });
+});

--- a/zorkweb.client/jest.config.ts
+++ b/zorkweb.client/jest.config.ts
@@ -14,6 +14,12 @@ export default {
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   testMatch: ['<rootDir>/src/**/__tests__/**/*.{ts,tsx}', '<rootDir>/src/**/*.{spec,test}.{ts,tsx}'],
   testPathIgnorePatterns: ['<rootDir>/node_modules/', '<rootDir>/src/__skipped_tests__/'],
+  collectCoverageFrom: [
+    '<rootDir>/src/**/*.{ts,tsx}',
+    '!<rootDir>/src/**/*.d.ts',
+    '!<rootDir>/src/main.tsx',
+    '!<rootDir>/src/__mocks__/**',
+  ],
   transform: {
     '^.+\\.(ts|tsx)$': ['ts-jest', {
       tsconfig: 'tsconfig.json',

--- a/zorkweb.client/src/__tests__/App.test.tsx
+++ b/zorkweb.client/src/__tests__/App.test.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import {fireEvent, render, screen, waitFor} from '@testing-library/react';
+import {DialogType, ReleaseNotesServer, useGameContext} from '@zork-ai/shared-types';
+import App from '../App';
+import Server from '../Server';
+
+jest.mock('../Game', () => () => <div data-testid="game"/>);
+jest.mock('../Server');
+jest.mock('../menu/GameMenu', () => (props: {latestVersion: string}) =>
+    <div data-testid="game-menu">{props.latestVersion}</div>);
+jest.mock('../modal/WelcomeModal', () => (props: {open: boolean}) =>
+    <div data-testid="welcome-modal" data-open={props.open}/>);
+jest.mock('@zork-ai/shared-types', () => {
+    const actual = jest.requireActual('@zork-ai/shared-types');
+    const modal = (testId: string) => (props: {open: boolean; games?: unknown[]; onConfirm?: () => void}) =>
+        <div data-testid={testId} data-open={props.open} data-games={props.games?.length ?? 0}>
+            {props.onConfirm && <button onClick={props.onConfirm}>confirm</button>}
+        </div>;
+    return {
+        ...actual,
+        useGameContext: jest.fn(),
+        SessionHandler: jest.fn().mockImplementation(() => ({getClientId: () => 'client-1'})),
+        ReleaseNotesServer: jest.fn(),
+        Mixpanel: {track: jest.fn()},
+        SaveModal: modal('save-modal'),
+        RestoreModal: modal('restore-modal'),
+        RestartConfirmDialog: modal('restart-modal'),
+        VideoDialog: modal('video-modal'),
+        ReleaseNotesModal: modal('release-notes-modal'),
+    };
+});
+
+describe('App', () => {
+    const server = {getSavedGames: jest.fn()};
+    const context = {
+        dialogToOpen: undefined as DialogType | undefined,
+        setDialogToOpen: jest.fn(),
+        setRestartGame: jest.fn(),
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        context.dialogToOpen = undefined;
+        (useGameContext as jest.Mock).mockReturnValue(context);
+        (Server as jest.MockedClass<typeof Server>).mockImplementation(() => server as unknown as Server);
+        (ReleaseNotesServer as jest.Mock).mockResolvedValue([
+            {date: '2026-07-22', name: 'v2.0', notes: 'More tests'}
+        ]);
+        server.getSavedGames.mockResolvedValue([{id: 'save-1'}]);
+    });
+
+    test('loads the latest release name on mount', async () => {
+        render(<App/>);
+
+        expect(await screen.findByTestId('game-menu')).toHaveTextContent('v2.0');
+        expect(screen.getByTestId('game')).toBeInTheDocument();
+    });
+
+    test.each([
+        [DialogType.Save, 'save-modal'],
+        [DialogType.Restore, 'restore-modal'],
+    ])('loads saved games before opening the %s dialog', async (dialog, testId) => {
+        context.dialogToOpen = dialog;
+        render(<App/>);
+
+        await waitFor(() => expect(server.getSavedGames).toHaveBeenCalledWith('client-1'));
+        expect(screen.getByTestId(testId)).toHaveAttribute('data-open', 'true');
+        expect(screen.getByTestId(testId)).toHaveAttribute('data-games', '1');
+        expect(context.setDialogToOpen).toHaveBeenCalledWith(undefined);
+    });
+
+    test.each([
+        [DialogType.Video, 'video-modal'],
+        [DialogType.Welcome, 'welcome-modal'],
+        [DialogType.ReleaseNotes, 'release-notes-modal'],
+    ])('opens the %s dialog without loading saves', async (dialog, testId) => {
+        context.dialogToOpen = dialog;
+        render(<App/>);
+
+        await waitFor(() => expect(screen.getByTestId(testId)).toHaveAttribute('data-open', 'true'));
+        expect(server.getSavedGames).not.toHaveBeenCalled();
+    });
+
+    test('confirms a restart through context', async () => {
+        context.dialogToOpen = DialogType.Restart;
+        render(<App/>);
+
+        await waitFor(() => expect(screen.getByTestId('restart-modal')).toHaveAttribute('data-open', 'true'));
+        fireEvent.click(screen.getByText('confirm'));
+        expect(context.setRestartGame).toHaveBeenCalledWith(true);
+    });
+});

--- a/zorkweb.client/src/__tests__/Game.test.tsx
+++ b/zorkweb.client/src/__tests__/Game.test.tsx
@@ -1,0 +1,122 @@
+import React from 'react';
+import {act, fireEvent, render, screen, waitFor} from '@testing-library/react';
+import {DialogType, SessionHandler, useGameContext} from '@zork-ai/shared-types';
+import {useMutation} from '@tanstack/react-query';
+import Game from '../Game';
+import Server from '../Server';
+
+jest.mock('@tanstack/react-query', () => ({useMutation: jest.fn()}));
+jest.mock('@fontsource/roboto', () => ({}));
+jest.mock('../Server');
+jest.mock('../components/GameInput', () => (props: {
+    playerInput: string;
+    setInput: (value: string) => void;
+    handleKeyDown: (event: React.KeyboardEvent<HTMLInputElement>) => void;
+}) => <input data-testid="game-input" value={props.playerInput}
+            onChange={(event) => props.setInput(event.target.value)} onKeyDown={props.handleKeyDown}/>);
+jest.mock('@zork-ai/shared-types', () => {
+    const actual = jest.requireActual('@zork-ai/shared-types');
+    return {
+        ...actual,
+        useGameContext: jest.fn(),
+        SessionHandler: jest.fn(),
+        Mixpanel: {track: jest.fn()},
+    };
+});
+
+describe('Game', () => {
+    const mutate = jest.fn();
+    const session = {
+        getSessionId: jest.fn(() => ['session-1', false]),
+        getClientId: jest.fn(() => 'client-1'),
+        regenerate: jest.fn(),
+    };
+    const server = {
+        gameInit: jest.fn(),
+        gameInput: jest.fn(),
+        saveGame: jest.fn(),
+        gameRestore: jest.fn(),
+        deleteSavedGame: jest.fn(),
+    };
+    const context = {
+        setDialogToOpen: jest.fn(),
+        restartGame: false,
+        setRestartGame: jest.fn(),
+        saveGameRequest: undefined,
+        setSaveGameRequest: jest.fn(),
+        restoreGameRequest: undefined,
+        setRestoreGameRequest: jest.fn(),
+        deleteGameRequest: undefined,
+        setDeleteGameRequest: jest.fn(),
+        setCopyGameTranscript: jest.fn(),
+    };
+    let mutationOptions: {onSuccess: (response: unknown) => void};
+
+    const response = (text: string) => ({
+        response: text,
+        locationName: 'Hall (North)',
+        score: 7,
+        moves: 3,
+        inventory: ['lamp'],
+        exits: ['0'],
+        actionsAvailableFromInventory: {lamp: ['light lamp']},
+        actionsAvailableFromLocation: {door: ['open door']},
+    });
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        Object.assign(context, {
+            restartGame: false,
+            saveGameRequest: undefined,
+            restoreGameRequest: undefined,
+            deleteGameRequest: undefined,
+        });
+        (SessionHandler as jest.Mock).mockImplementation(() => session);
+        (Server as jest.MockedClass<typeof Server>).mockImplementation(() => server as unknown as Server);
+        (useGameContext as jest.Mock).mockReturnValue(context);
+        (useMutation as jest.Mock).mockImplementation((options) => {
+            mutationOptions = options;
+            return {mutate, isPending: false, isError: false};
+        });
+        server.gameInit.mockResolvedValue(response('Hall (North)\n  A brass lamp is here.'));
+    });
+
+    test('loads and formats the initial game state', async () => {
+        render(<Game/>);
+
+        await waitFor(() => expect(screen.getByTestId('header-location')).toHaveTextContent('Hall (North)'));
+        const rendered = screen.getAllByTestId('game-response').at(-1)!;
+        expect(rendered.innerHTML).toContain('<span class="room-header">Hall (North)</span>A brass lamp is here.');
+        expect(screen.getByTestId('inventory-button')).toBeInTheDocument();
+    });
+
+    test('submits trimmed input with the active session and records successful output', async () => {
+        render(<Game/>);
+        await waitFor(() => expect(server.gameInit).toHaveBeenCalled());
+
+        fireEvent.change(screen.getByTestId('game-input'), {target: {value: '  north  '}});
+        fireEvent.click(screen.getByTestId('go-button'));
+        expect(mutate).toHaveBeenCalledWith(expect.objectContaining({input: 'north', sessionId: 'session-1'}));
+
+        act(() => mutationOptions.onSuccess(response('You go north.')));
+        expect(screen.getAllByTestId('game-response').at(-1)!.innerHTML).toContain('&gt;   north  ');
+    });
+
+    test.each([
+        ['<Save>', DialogType.Save],
+        ['<Restore>', DialogType.Restore],
+        ['<Restart>', DialogType.Restart],
+    ])('routes the %s response to its dialog', async (marker, dialog) => {
+        server.gameInit.mockResolvedValue(response(marker));
+        render(<Game/>);
+
+        await waitFor(() => expect(context.setDialogToOpen).toHaveBeenCalledWith(dialog));
+    });
+
+    test('shows request failures from the mutation', async () => {
+        (useMutation as jest.Mock).mockReturnValue({mutate, isPending: false, isError: true});
+        render(<Game/>);
+
+        expect(await screen.findByText(/Something went wrong/)).toBeInTheDocument();
+    });
+});

--- a/zorkweb.client/src/__tests__/Server.test.ts
+++ b/zorkweb.client/src/__tests__/Server.test.ts
@@ -1,0 +1,91 @@
+import axios from 'axios';
+import {Mixpanel} from '@zork-ai/shared-types';
+import Server from '../Server';
+
+jest.mock('axios');
+jest.mock('@zork-ai/shared-types', () => {
+    const actual = jest.requireActual('@zork-ai/shared-types');
+    return {
+        ...actual,
+        Mixpanel: {track: jest.fn()},
+        SessionHandler: jest.fn().mockImplementation(() => ({getClientId: () => 'client-123'})),
+    };
+});
+
+describe('Server', () => {
+    const client = {
+        get: jest.fn(),
+        post: jest.fn(),
+        delete: jest.fn(),
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        (axios.create as jest.Mock).mockReturnValue(client);
+    });
+
+    test('posts a turn and records the returned game state', async () => {
+        const data = {response: 'Taken.', score: 5, moves: 2, locationName: 'Kitchen'};
+        client.post.mockResolvedValue({data});
+
+        const result = await new Server().gameInput({input: 'take lamp', sessionId: 'session-1'});
+
+        expect(client.post).toHaveBeenCalledWith('', {input: 'take lamp', sessionId: 'session-1'}, {
+            headers: {Accept: 'application/json'},
+        });
+        expect(Mixpanel.track).toHaveBeenCalledWith('Played a Turn', expect.objectContaining({
+            input: 'take lamp', output: 'Taken.', clientId: 'client-123',
+        }));
+        expect(result).toBe(data);
+    });
+
+    test('loads the current session using the expected query parameter', async () => {
+        const data = {response: 'West of House'};
+        client.get.mockResolvedValue({data});
+
+        await expect(new Server().gameInit('session-1')).resolves.toBe(data);
+        expect(client.get).toHaveBeenCalledWith('', {
+            params: {sessionId: 'session-1'},
+            headers: {Accept: 'application/json'},
+        });
+    });
+
+    test('lists saved games and records their count', async () => {
+        const games = [{id: 'one'}, {id: 'two'}];
+        client.get.mockResolvedValue({data: games});
+
+        await expect(new Server().getSavedGames('client-1')).resolves.toBe(games);
+        expect(client.get).toHaveBeenCalledWith('saveGame', {params: {sessionId: 'client-1'}});
+        expect(Mixpanel.track).toHaveBeenCalledWith('Listed Saved Games', {
+            clientId: 'client-1', gameCount: 2,
+        });
+    });
+
+    test('rethrows saved-game listing failures', async () => {
+        const error = new Error('offline');
+        client.get.mockRejectedValue(error);
+        jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+        await expect(new Server().getSavedGames('client-1')).rejects.toBe(error);
+    });
+
+    test('saves, restores, and deletes using the API contract', async () => {
+        client.post.mockResolvedValueOnce({data: 'Saved.'}).mockResolvedValueOnce({data: {response: 'Restored.'}});
+        client.delete.mockResolvedValue({});
+        const server = new Server();
+        const saveRequest = {id: 'save-1', clientId: 'client-1', sessionId: 'session-1', name: 'My save'};
+
+        await expect(server.saveGame(saveRequest)).resolves.toBe('Saved.');
+        await expect(server.gameRestore('save-1', 'client-1', 'session-2')).resolves.toEqual({response: 'Restored.'});
+        await server.deleteSavedGame('save-1', 'session-2');
+
+        expect(client.post).toHaveBeenNthCalledWith(1, 'saveGame', saveRequest, {
+            headers: {Accept: 'application/json'},
+        });
+        expect(client.post).toHaveBeenNthCalledWith(2, 'restoreGame', expect.objectContaining({
+            id: 'save-1', clientId: 'client-1', sessionId: 'session-2',
+        }), {headers: {Accept: 'application/json'}});
+        expect(client.delete).toHaveBeenCalledWith('saveGame/save-1', {params: {sessionId: 'session-2'}});
+        expect(Mixpanel.track).toHaveBeenCalledWith('Delete Saved Game', expect.objectContaining({gameId: 'save-1'}));
+    });
+});


### PR DESCRIPTION
## Summary

- make Jest coverage include all client source files and add direct App, Game, and Server tests for both web clients
- inject DynamoDB and OpenAI client seams so production request construction, response mapping, prompt generation, and fallbacks run in normal unit tests
- cover the Planetfall escape-pod sinking and landing state-machine branches

## Impact

The web clients now report honest whole-source coverage (72.9% for Zork and 73.0% for Planetfall), instead of excluding App, Game, and Server. Credential-free unit coverage reaches 90.8% line / 75.0% branch for DynamoDB and 94.6% line / 67.1% branch for ZorkAI.OpenAI.

## Validation

- `dotnet build Zork.sln`
- `dotnet test UnitTests/UnitTests.csproj --no-restore` (1,069 passed)
- `dotnet test Planetfall.Tests/Planetfall.Tests.csproj --no-restore` (3,139 passed)
- `dotnet test ZorkOne.Tests/ZorkOne.Tests.csproj` (1,781 passed)
- Zork web Jest coverage: 18 suites, 119 tests passed
- Planetfall web Jest coverage: 17 suites, 112 tests passed
- ESLint passed for both web clients

The build still reports the repository's existing `Microsoft.OpenApi` advisory and existing nullable warnings in `MicrobeTests`; there are no build errors.