### PR TITLE
Fix #463: Comm Room coolant shutdown is now a terminal state

### DIFF
--- a/Planetfall.Tests/CommRoomAndMachineRoomTests.cs
+++ b/Planetfall.Tests/CommRoomAndMachineRoomTests.cs
@@ -456,6 +456,109 @@ public class CommRoomAndMachineRoomTests : EngineTestsBase
         Console.WriteLine(GetLocation<SystemsMonitors>().GetDescriptionForGeneration(target.Context));
     }
 
+    // Issue #463: a wrong-color pour shuts the send console down (SystemIsCritical) and the failure is
+    // described as permanent ("...Shuteeng Down Awl Sistumz... the send console shuts down"). But PourLiquid
+    // branched only on flask color vs CurrentColor, and PermanentlyBroken() left CurrentColor untouched --
+    // so pouring the correct black->gray sequence afterward still ran NextColor()/Fixed(), "repairing" a
+    // console the game declared permanently shut down and awarding +6. Once critical, further pours must be
+    // inert: the console stays down, no points, communications never marked fixed.
+    [Test]
+    public async Task PourLiquid_AfterCriticalShutdown_BlackThenGray_StaysBroken()
+    {
+        var target = GetTarget();
+        Take<Flask>();
+        StartHere<CommRoom>();
+
+        // Round 1 -- wrong color forces the "permanent" shutdown.
+        GetItem<Flask>().LiquidColor = "red";
+        var critical = await target.GetResponse("pour fluid into hole");
+        critical.Should().Contain("the send console shuts down");
+        GetLocation<CommRoom>().SystemIsCritical.Should().BeTrue();
+
+        // Round 2 -- correct black.
+        GetItem<Flask>().LiquidColor = "black";
+        await target.GetResponse("pour fluid into hole");
+
+        // Round 3 -- correct gray.
+        GetItem<Flask>().LiquidColor = "gray";
+        await target.GetResponse("pour fluid into hole");
+
+        // The console declared "shut down" must not have repaired itself and sent the distress call.
+        GetLocation<CommRoom>().IsFixed.Should().BeFalse();
+        GetLocation<CommRoom>().SystemIsCritical.Should().BeTrue();
+        target.Context.Score.Should().Be(0);
+        GetLocation<SystemsMonitors>().Fixed.Should().NotContain("KUMUUNIKAASHUNZ");
+        GetLocation<SystemsMonitors>().Busted.Should().Contain("KUMUUNIKAASHUNZ");
+    }
+
+    // Issue #463: PermanentlyBroken() set SystemIsCritical but wasn't guarded on it, so repeating a wrong
+    // pour re-fired the full "...send console shuts down" message every turn (the #431 "match command, not
+    // state" class). Once shut down, a further pour is inert and does not re-announce the shutdown.
+    [Test]
+    public async Task PourLiquid_WrongColorTwice_DoesNotReAnnounceShutdown()
+    {
+        var target = GetTarget();
+        Take<Flask>();
+        StartHere<CommRoom>();
+
+        GetItem<Flask>().LiquidColor = "red";
+        var first = await target.GetResponse("pour fluid into hole");
+        first.Should().Contain("the send console shuts down");
+
+        GetItem<Flask>().LiquidColor = "red";
+        var second = await target.GetResponse("pour fluid into hole");
+        second.Should().NotContain("the send console shuts down");
+    }
+
+    // Issue #463 guard: the new critical/fixed guards must not block the legitimate repair. The normal
+    // black->gray sequence from a clean state must still fix the console, send the distress call, and score.
+    [Test]
+    public async Task PourLiquid_CleanBlackThenGray_StillFixesAndSends()
+    {
+        var target = GetTarget();
+        Take<Flask>();
+        StartHere<CommRoom>();
+
+        GetItem<Flask>().LiquidColor = "black";
+        await target.GetResponse("pour fluid into hole");
+        GetLocation<CommRoom>().CurrentColor.Should().Be("gray");
+
+        GetItem<Flask>().LiquidColor = "gray";
+        var response = await target.GetResponse("pour fluid into hole");
+
+        response.Should().Contain("message is now being sent.");
+        GetLocation<CommRoom>().IsFixed.Should().BeTrue();
+        target.Context.Score.Should().Be(6);
+    }
+
+    // Issue #463: after the console is fixed and the message is being sent, further pours must be inert.
+    // PourLiquid had no IsFixed guard, and Fixed() nulls CurrentColor -- so any subsequent pour mismatched
+    // CurrentColor and ran PermanentlyBroken(), "shutting down" a console that was already working.
+    [Test]
+    public async Task PourLiquid_AfterFixed_IsInert_AndDoesNotShutDown()
+    {
+        var target = GetTarget();
+        Take<Flask>();
+        StartHere<CommRoom>();
+
+        // Drive the real repair to reach the genuinely fixed state (Fixed() nulls CurrentColor).
+        GetItem<Flask>().LiquidColor = "black";
+        await target.GetResponse("pour fluid into hole");
+        GetItem<Flask>().LiquidColor = "gray";
+        await target.GetResponse("pour fluid into hole");
+        GetLocation<CommRoom>().IsFixed.Should().BeTrue();
+
+        // A further pour into a working, message-sending console must be inert, not "shut it down".
+        GetItem<Flask>().LiquidColor = "black";
+        var response = await target.GetResponse("pour fluid into hole");
+
+        response.Should().NotContain("the send console shuts down");
+        response.Should().NotContain("message is now being sent.");
+        GetLocation<CommRoom>().SystemIsCritical.Should().BeFalse();
+        GetLocation<CommRoom>().IsFixed.Should().BeTrue();
+        target.Context.Score.Should().Be(6); // still only the single +6 from the original fix
+    }
+
     // Issue #412: the Comm Room shows the player a "glowing button marked 'Mesij Plaabak'", and pressing
     // it plays back the Feinstein's cut-off transmission (a real story beat). Every phrasing below is
     // something the room's own text invites the player to type, so each must reach the playback handler.

--- a/Planetfall/Location/Kalamontee/Tower/CommRoom.cs
+++ b/Planetfall/Location/Kalamontee/Tower/CommRoom.cs
@@ -56,6 +56,22 @@ internal class CommRoom : LocationWithNoStartingItems, IFloydDoesNotTalkHere
         var flaskColor = GetItem<Flask>().LiquidColor!;
         GetItem<Flask>().LiquidColor = null;
 
+        // Issue #463: the shut-down (critical) and fixed states are terminal, so guard before touching the
+        // color-progression branches below. PermanentlyBroken() deliberately leaves CurrentColor unchanged,
+        // so without this guard a wrong pour that set SystemIsCritical could be undone by later pouring the
+        // correct black->gray sequence back through NextColor()/Fixed() -- "repairing" a console the game
+        // declared permanently shut down and awarding the points. The IsFixed guard is the mirror image:
+        // Fixed() nulls CurrentColor, so any further pour would otherwise mismatch and run PermanentlyBroken(),
+        // "shutting down" a console that is already working. Gating here also stops the "...send console shuts
+        // down" line re-firing on every repeated wrong pour (the #431 "match command, not state" class).
+        if (SystemIsCritical)
+            return Task.FromResult<InteractionResult?>(new PositiveInteractionResult(
+                "The liquid disappears into the hole, but nothing happens; the send console has shut down. "));
+
+        if (IsFixed)
+            return Task.FromResult<InteractionResult?>(new PositiveInteractionResult(
+                "The liquid disappears into the hole, but nothing happens. "));
+
         if (flaskColor != CurrentColor)
             return PermanentlyBroken();
 


### PR DESCRIPTION
## Problem

At the Planetfall **Comm Room**, pouring a wrong-colored coolant into the hole prints a supposedly **permanent** critical failure (`SystemIsCritical`): *"...Kuulint Sistum Imbalins Kritikul — Shuteeng Down Awl Sistumz... the send console shuts down."* But the shutdown wasn't enforced — pouring the correct **black → gray** sequence afterward still progressed the puzzle, awarded **+6**, and sent the distress call. A console the game declared permanently shut down could be fully repaired and win. (Issue #463, reproduced on prod 2.0.3.)

## Root cause

In `Planetfall/Location/Kalamontee/Tower/CommRoom.cs`, `PourLiquid` branched only on the flask's color vs `CurrentColor` — with no guard on `SystemIsCritical` or `IsFixed`. `PermanentlyBroken()` sets `SystemIsCritical = true` but deliberately leaves `CurrentColor` untouched, so after a wrong pour the color-progression state machine was still intact and pouring black→gray ran `NextColor()`→`Fixed()`.

Two further symptoms of the same missing guard:
- **Re-narration:** repeating a wrong pour re-fired the full "…send console shuts down" message every turn (the #431 "match command, not state" class).
- **Post-fix contradiction:** `Fixed()` nulls `CurrentColor`, so any pour after the fix mismatched and ran `PermanentlyBroken()`, "shutting down" a console that was already working.

## Fix

Guard `PourLiquid` on `SystemIsCritical` and `IsFixed` before the color-progression branches. Once the coolant system is shut down or fixed, both are terminal states and further pours are inert — no resumed repair sequence, no re-awarded points, no re-narrated shutdown.

## Testing (TDD)

Per CLAUDE.md, wrote failing tests first, then the minimal fix. Added to `Planetfall.Tests/CommRoomAndMachineRoomTests.cs`:

- `PourLiquid_AfterCriticalShutdown_BlackThenGray_StaysBroken` — wrong pour → critical, then black then gray must **not** reach `Fixed`/award points (failed before, passes after).
- `PourLiquid_WrongColorTwice_DoesNotReAnnounceShutdown` — a second wrong pour no longer re-announces the shutdown.
- `PourLiquid_AfterFixed_IsInert_AndDoesNotShutDown` — a pour after a genuine fix stays inert and doesn't "shut down" the working console.
- `PourLiquid_CleanBlackThenGray_StillFixesAndSends` — guard: the normal repair from a clean state still fixes it, sends the call, and scores +6.

Deterministic (no randomness/AI/network). All 3170 Planetfall tests pass; full solution builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013oAgDmfYwhKqQgQfh4XkH3)_