### PR TITLE
Fix #462: cap the Course Control cube to a single bedistor socket

### DIFF
--- a/Planetfall.Tests/CourseControlTests.cs
+++ b/Planetfall.Tests/CourseControlTests.cs
@@ -438,6 +438,53 @@ public class CourseControlTests : EngineTestsBase
     }
 
     [Test]
+    public async Task PutGoodBedistorInCube_WhileFusedStillInside_IsRefused()
+    {
+        // Issue #462: the cube is a SINGLE bedistor socket. It ships holding the fused (broken)
+        // bedistor, and without a capacity cap ContainerBase.SpaceForItems defaults to 2 - so a
+        // good bedistor (Size 1) dropped in ALONGSIDE the fused one (Size 1) fit (1 + 1 <= 2),
+        // "fixing" Course Control with the broken part still socketed and skipping the
+        // pliers-removal sub-puzzle entirely. Capping to one slot forces the fused bedistor to be
+        // removed first. Mirrors the laser depression (#437) and FromitzAccessPanel capping.
+        var target = GetTarget();
+        StartHere<CourseControl>();
+        GetItem<LargeMetalCube>().IsOpen = true; // fused bedistor is shipped inside
+        Take<GoodBedistor>();
+
+        var response = await target.GetResponse("put good in cube");
+
+        // Refused: the good bedistor stays in inventory, the cube keeps only the fused one, and
+        // Course Control is NOT reported fixed and no points are awarded.
+        response.Should().NotContain("The warning lights go out");
+        GetItem<LargeMetalCube>().HasItem<GoodBedistor>().Should().BeFalse();
+        GetItem<LargeMetalCube>().HasItem<FusedBedistor>().Should().BeTrue();
+        GetItem<LargeMetalCube>().Items.Count.Should().Be(1);
+        target.Context.HasItem<GoodBedistor>().Should().BeTrue();
+        GetLocation<CourseControl>().Fixed.Should().BeFalse();
+        target.Score.Should().Be(0);
+    }
+
+    [Test]
+    public async Task PutGoodBedistorInCube_AfterFusedRemoved_FixesCourseControl()
+    {
+        // Issue #462 guard: once the fused bedistor is out of the single socket, the good bedistor
+        // is accepted and fixes Course Control as intended - the cap only blocks the second one.
+        var target = GetTarget();
+        StartHere<CourseControl>();
+        var cube = GetItem<LargeMetalCube>();
+        cube.IsOpen = true;
+        cube.RemoveItem(GetItem<FusedBedistor>()); // pliers-removal already done
+        Take<GoodBedistor>();
+
+        var response = await target.GetResponse("put good in cube");
+
+        response.Should().Contain("The warning lights go out");
+        cube.HasItem<GoodBedistor>().Should().BeTrue();
+        GetLocation<CourseControl>().Fixed.Should().BeTrue();
+        target.Score.Should().Be(6);
+    }
+
+    [Test]
     public async Task PutWrongItemInCube_GetsAuthoredRefusal()
     {
         // The original cube ends its "put" handler with a refusal naming the item (CUBE-F,

--- a/Planetfall/Item/Lawanda/LargeMetalCube.cs
+++ b/Planetfall/Item/Lawanda/LargeMetalCube.cs
@@ -12,6 +12,22 @@ public class LargeMetalCube : OpenAndCloseContainerBase
     // "is open" and hid the contents.
     public override Type[] CanOnlyHoldTheseTypes => [typeof(BedistorBase)];
 
+    // Issue #462: the cube is a SINGLE bedistor socket. ContainerBase.SpaceForItems defaults to 2
+    // and each bedistor is Size 1, so without this override the cube silently admitted a good
+    // bedistor ALONGSIDE the shipped fused one (1 + 1 <= 2) - "fixing" Course Control with the
+    // broken part still socketed and skipping the pliers-removal sub-puzzle. One slot forces the
+    // correct swap (pry the fused bedistor out first, then socket the good one). Mirrors the laser
+    // depression (#437) and FromitzAccessPanel capping.
+    protected override int SpaceForItems => 1;
+
+    // With the socket full, refuse the extra bedistor by asserting the occupancy (mirrors the laser,
+    // issue #437). This is safe because every bedistor is Size 1 and the cube only holds bedistors:
+    // HaveRoomForItem can only fail here when one is already in the socket. The type check runs
+    // before the room check (PutProcessor, issue #417), so a non-bedistor still gets the type
+    // refusal below.
+    public override string NoRoomMessage =>
+        "There's already a bedistor in the socket. ";
+
     // The original's "put" handler ends with a refusal naming the item (CUBE-F, comptwo.zil:583).
     // Without this the type rejection has no message and falls through to the AI narrator, which
     // answers a deterministic refusal with a generated one (and a blank line if generation fails).


### PR DESCRIPTION
## Summary

Fixes #462. The `LargeMetalCube` at Course Control is meant to be a **single** bedistor socket, but it only declared a type restriction (`CanOnlyHoldTheseTypes => [BedistorBase]`) and never capped the count — so it inherited `ContainerBase`'s default `SpaceForItems` of **2**.

Each bedistor is `Size 1`, so a **good** bedistor dropped in *alongside* the shipped **fused** (broken) one fit (`1 + 1 <= 2`). Placing the good bedistor fired `CourseControl.ItIsFixed` — the warning lights went out and +6 points were awarded — **while the broken fused bedistor was still socketed**, and the "pry the fused bedistor out with the pliers" sub-puzzle was skipped entirely. Course Control is on the winning path, so this let the player skip a required sub-puzzle and left the game in a self-contradictory "fixed with the broken part still installed" state.

This is the same single-slot-container anti-pattern that #437 fixed for the laser depression.

## Fix

`Planetfall/Item/Lawanda/LargeMetalCube.cs`:
- **`protected override int SpaceForItems => 1;`** — the fused bedistor now fills the only slot, so the good one is refused until the fused one is pried out with the pliers first. Mirrors the laser depression (#437) and `FromitzAccessPanel` (`SpaceForItems => 4`, pre-loaded so a removal is forced).
- **`NoRoomMessage`** override asserting the occupancy ("There's already a bedistor in the socket."), so the refusal is a clean deterministic reply instead of falling through to the AI narrator. Safe because every bedistor is `Size 1` and the cube only holds bedistors, so the room check can only fail when one is already socketed; the type check runs first (per #417), so a non-bedistor still gets the type refusal.

## Tests (TDD)

Added two deterministic tests to `Planetfall.Tests/CourseControlTests.cs` (no randomness/AI):

- **`PutGoodBedistorInCube_WhileFusedStillInside_IsRefused`** — with the fused bedistor shipped inside, placing a `GoodBedistor` is refused: it stays in inventory, the cube keeps only the fused one, Course Control is **not** fixed, and no points are awarded. Fails before the fix (accepted + fixed), passes after.
- **`PutGoodBedistorInCube_AfterFusedRemoved_FixesCourseControl`** — guard: once the fused bedistor is removed, the good one is accepted and fixes Course Control (+6). Confirms the cap only blocks the second bedistor.

The existing `FullSolution` test (take fused with pliers → put good in cube → fixed) continues to pass.

## Verification

- New tests: red before the fix (for the right reason — good bedistor accepted alongside the fused one), green after.
- Full `Planetfall.Tests` suite: **3168 passed, 0 failed**.

## Faithful-to-original note

ZIL-independent: the defect is an internal contradiction (a single socket accepting two parts; "fixed" with the broken part in) provable from the C# alone, and the in-repo siblings (`FromitzAccessPanel`, the #437 laser) demonstrate the intended single-occupancy pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HUVi7YJ1SxUG8ydSPNGGt1

---
_Generated by [Claude Code](https://claude.ai/code/session_01HUVi7YJ1SxUG8ydSPNGGt1)_