### PR TITLE
Fix #461: Shuttle Car Betty's platform doorway is south, not north

### DIFF
--- a/Planetfall.Tests/ShuttleTests.cs
+++ b/Planetfall.Tests/ShuttleTests.cs
@@ -714,8 +714,11 @@ public class ShuttleTests : EngineTestsBase
         output = await target.GetResponse("E");
         Console.Write(output);
         output.Should().Contain("Shuttle Car Betty");
-        
-        output = await target.GetResponse("N");
+
+        // Issue #461: the doorway out of Betty is SOUTH (you boarded Betty by going north
+        // from the platform, so the platform lies south of the cabin). This used to be "N",
+        // encoding the old non-Euclidean north<->north loop.
+        output = await target.GetResponse("S");
         Console.Write(output);
         output.Should().Contain("An open shuttle car lies to the north.");
         output.Should().Contain("Kalamontee");
@@ -828,5 +831,59 @@ public class ShuttleTests : EngineTestsBase
         // Second lever manipulation - should NOT set pending comment (prompt already used)
         await target.GetResponse("pull lever");
         pfContext.PendingFloydActionCommentPrompt.Should().BeNull();
+    }
+
+    [Test]
+    public async Task Betty_SouthReturnsToPlatform_MatchingCabinDescription()
+    {
+        // Regression test for issue #461: Shuttle Car Betty's cabin description says the
+        // doorway to the platform is "to the south", but the platform exit was wired to
+        // Direction.N -- so following the description ("go south") failed with "can't go
+        // that way" and the player had to guess "north". You board Betty by going NORTH
+        // from the platform, so the platform genuinely lies SOUTH of the cabin: the
+        // description is correct and the map direction (N) was the defect.
+        var target = GetTarget();
+        StartHere<ShuttleCarBetty>();
+
+        var description = await target.GetResponse("look");
+        description.Should().Contain("doorway leads out to a wide platform to the south");
+
+        await target.GetResponse("south");
+
+        // South returns you to the platform the description points at.
+        target.Context.CurrentLocation.Should().BeOfType<LawandaPlatform>();
+    }
+
+    [Test]
+    public async Task Betty_NorthNoLongerReturnsToPlatform()
+    {
+        // Companion to #461: the old wiring let you board Betty by going NORTH and then
+        // leave by going NORTH again -- a non-Euclidean north<->north loop that also
+        // contradicted the cabin description. After the fix, north from inside Betty is
+        // not the way back to the platform.
+        var target = GetTarget();
+        StartHere<ShuttleCarBetty>();
+
+        await target.GetResponse("north");
+
+        target.Context.CurrentLocation.Should().BeOfType<ShuttleCarBetty>();
+    }
+
+    [Test]
+    public async Task Alfie_NorthReturnsToPlatform_MatchingCabinDescription()
+    {
+        // Guard mirroring #461 against Betty's already-consistent sibling: Alfie's cabin
+        // says the platform is "to the north" AND its platform exit is Direction.N. You
+        // board Alfie by going SOUTH from the platform, so the platform lies north of the
+        // cabin -- description and map agree. Fixing Betty must not disturb this.
+        var target = GetTarget();
+        StartHere<ShuttleCarAlfie>();
+
+        var description = await target.GetResponse("look");
+        description.Should().Contain("doorway leads out to a wide platform to the north");
+
+        await target.GetResponse("north");
+
+        target.Context.CurrentLocation.Should().BeOfType<KalamonteePlatform>();
     }
 }

--- a/Planetfall/Location/Shuttle/ShuttleCarBetty.cs
+++ b/Planetfall/Location/Shuttle/ShuttleCarBetty.cs
@@ -13,7 +13,11 @@ public class ShuttleCarBetty : ShuttleCabin
             { Direction.W, Go<BettyControlWest>() },
             { Direction.E, Go<BettyControlEast>() },
             {
-                Direction.N,
+                // Issue #461: the platform lies SOUTH of the cabin (you board Betty by going
+                // north from the platform), and the cabin description says "platform to the
+                // south". The exit was wired to Direction.N, contradicting both -- so "go
+                // south" failed and the only way out was an unintuitive north<->north loop.
+                Direction.S,
                 Repository.GetLocation<AlfieControlEast>().TunnelPosition == 0
                     ? Go<LawandaPlatform>()
                     : Go<KalamonteePlatform>()


### PR DESCRIPTION
## Summary

Fixes #461. Inside **Shuttle Car Betty**, the cabin description says a doorway leads out to the platform **"to the south"**, but the platform exit was wired to `Direction.N`. The two contradicted each other, so typing `south` (following the description) returned "You cannot go that way." and the player had to guess `north` to leave.

## Root cause

`ShuttleCabin.cs` builds the cabin description from the abstract `Exit` string:

```csharp
$"...a doorway leads out to a wide platform to the {Exit}."
```

`ShuttleCarBetty` sets `Exit => "south"` but keyed its platform exit off `Direction.N`. You board Betty by going **north** from the platform (both `LawandaPlatform` and `KalamonteePlatform` map `N -> Betty`), so Betty sits north of the platform and the platform is genuinely **south** of the cabin. The description (`"south"`) is correct; the map direction was the defect — it also produced a non-Euclidean north↔north loop (north to board, north to leave).

Betty's sibling car **Alfie** is internally consistent (`Exit => "north"` **and** a `Direction.N` platform exit, because you board Alfie by going south), which makes Betty the provable divergence.

## Fix

Change Betty's platform exit from `Direction.N` to `Direction.S` so it matches `Exit => "south"` and the platform's boarding geometry, mirroring Alfie's consistent pairing. The destination expression (`AlfieControlEast.TunnelPosition == 0 ? Lawanda : Kalamontee`) is unchanged — the issue notes the `AlfieControlEast`-vs-`BettyControlEast` keying is a separate matter to be filed on its own.

## Testing (TDD)

Deterministic, no randomness/AI. In `Planetfall.Tests/ShuttleTests.cs`:

- **`Betty_SouthReturnsToPlatform_MatchingCabinDescription`** — asserts the cabin says "platform to the south" and that `south` reaches the platform. Fails before (south → can't go that way), passes after.
- **`Betty_NorthNoLongerReturnsToPlatform`** — pins the removal of the north↔north loop: `north` from inside Betty no longer leaves the cabin. Fails before, passes after.
- **`Alfie_NorthReturnsToPlatform_MatchingCabinDescription`** — consistency guard on Betty's sibling; passes before and after.
- Updated **`RoundTrip`**, which had encoded the old north exit out of Betty, to use `south`.

All 3169 `Planetfall.Tests` pass (the changed code is Planetfall-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XD6TEmbyjTmJ8w7f5YZxH5)_