### PR TITLE
Review follow-ups for #460: escape-pod explosion dice coverage + OpenAI seam comment

### DIFF
--- a/Planetfall.Tests/ExplosionTests.cs
+++ b/Planetfall.Tests/ExplosionTests.cs
@@ -872,5 +872,76 @@ public class ExplosionTests : EngineTestsBase
             Repository.GetItem<SurvivalKit>().CurrentLocation.Should().Be(pod);
             target.Context.Actors.Should().NotContain(pod);
         }
+
+        // TurnsSinceExplosion == 4 is the Feinstein blowing apart - the one landing branch the timeline
+        // tests above skip, and the only place the pod consults its IRandomChooser. Outside the web the
+        // player is thrown against the bulkhead: a 20% instant "head first" death (a RollDiceSuccess(5)
+        // hit, PROB 20 in the original), otherwise a survivable bruising. Mocking the chooser pins each
+        // side of that dice branch deterministically (see the Randomness Pattern in CLAUDE.md).
+        [Test]
+        public async Task ExplosionOutsideTheWeb_OnAFatalRoll_ThrowsThePlayerHeadFirst()
+        {
+            var target = GetTarget();
+            var pod = Repository.GetLocation<EscapePod>();
+            target.Context.CurrentLocation = pod;
+            pod.SubLocation = null;
+            pod.TurnsSinceExplosion = 3; // Act advances it to 4
+            target.Context.RegisterActor(pod);
+
+            var chooser = new Mock<IRandomChooser>();
+            chooser.Setup(c => c.RollDiceSuccess(5)).Returns(true);
+            pod.Chooser = chooser.Object;
+
+            var response = await pod.Act(target.Context, Mock.Of<IGenerationClient>());
+
+            response.Should().Contain("head first");
+            response.Should().Contain("You have died");
+            target.Context.DeathCounter.Should().Be(1);
+        }
+
+        [Test]
+        public async Task ExplosionOutsideTheWeb_OnASurvivableRoll_BruisesButDoesNotKill()
+        {
+            var target = GetTarget();
+            var pod = Repository.GetLocation<EscapePod>();
+            target.Context.CurrentLocation = pod;
+            pod.SubLocation = null;
+            pod.TurnsSinceExplosion = 3;
+            target.Context.RegisterActor(pod);
+
+            var chooser = new Mock<IRandomChooser>();
+            chooser.Setup(c => c.RollDiceSuccess(5)).Returns(false);
+            pod.Chooser = chooser.Object;
+
+            var response = await pod.Act(target.Context, Mock.Of<IGenerationClient>());
+
+            response.Should().Contain("bruising a few limbs");
+            response.Should().NotContain("head first");
+            target.Context.DeathCounter.Should().Be(0);
+        }
+
+        // In the web the throw never happens, so the fatal roll must not even be consulted - the pod
+        // rider takes no bruise and no death. Verifying the chooser is untouched pins the short-circuit
+        // (`!inWeb && ...`) that keeps a webbed player safe regardless of the dice.
+        [Test]
+        public async Task ExplosionInsideTheWeb_RidesItOutUnharmed_WithoutConsultingTheDice()
+        {
+            var target = GetTarget();
+            var pod = Repository.GetLocation<EscapePod>();
+            target.Context.CurrentLocation = pod;
+            pod.SubLocation = Repository.GetItem<SafetyWeb>();
+            pod.TurnsSinceExplosion = 3;
+            target.Context.RegisterActor(pod);
+
+            var chooser = new Mock<IRandomChooser>();
+            pod.Chooser = chooser.Object;
+
+            var response = await pod.Act(target.Context, Mock.Of<IGenerationClient>());
+
+            response.Should().NotContain("bruising");
+            response.Should().NotContain("head first");
+            target.Context.DeathCounter.Should().Be(0);
+            chooser.Verify(c => c.RollDiceSuccess(It.IsAny<int>()), Times.Never);
+        }
     }
 }

--- a/ZorkAI.OpenAI/OpenAIClientBase.cs
+++ b/ZorkAI.OpenAI/OpenAIClientBase.cs
@@ -20,6 +20,10 @@ public abstract class OpenAIClientBase
 
         if (clientOverride is not null)
         {
+            // An injected client means we have a working generation seam, so HasApiKey is true - but
+            // ApiKey stays null on purpose. ApiKey only exists to let a subclass build a *second*
+            // real ChatClient on another model (Floyd's companion speech); there is no raw key behind
+            // an injected seam, and any subclass that needs a companion client injects that too.
             HasApiKey = true;
             Client = clientOverride;
             return;


### PR DESCRIPTION
## Summary

Follow-up improvements from the code review of #460, stacked on top of that branch so the diff is only the new work. Targets `codex/increase-test-coverage` (not `main`) because the changes build on the seams that PR introduces.

Two changes:

- **Cover the one uncovered escape-pod branch.** #460's new `EscapePodTimelineTests` exercise the sinking timeline and the `case 14` landing, but skip `TurnsSinceExplosion == 4` — the Feinstein blowing apart, and the *only* place `EscapePod` consults its `IRandomChooser`. Add three deterministic tests that mock the chooser (per the Randomness Pattern in `CLAUDE.md`) to pin both sides of the 20% "head-first" death and to confirm a webbed rider never rolls the dice at all.
- **Document the injected-client seam.** In `OpenAIClientBase`, the `clientOverride` path sets `HasApiKey = true` but leaves `ApiKey` null. That is intentional (there is no raw key behind an injected seam, and `ApiKey` only exists to let a subclass build a *second* real `ChatClient` for Floyd's companion speech), but the two fields being decoupled reads like a bug at a glance. Added a comment so it doesn't.

## Test coverage

New tests in `Planetfall.Tests/ExplosionTests.cs` → `EscapePodTimelineTests`:

- `ExplosionOutsideTheWeb_OnAFatalRoll_ThrowsThePlayerHeadFirst` — `RollDiceSuccess(5)` → true, asserts the head-first death and `DeathCounter == 1`.
- `ExplosionOutsideTheWeb_OnASurvivableRoll_BruisesButDoesNotKill` — `RollDiceSuccess(5)` → false, asserts the bruise text and `DeathCounter == 0`.
- `ExplosionInsideTheWeb_RidesItOutUnharmed_WithoutConsultingTheDice` — in the web, asserts no bruise/death and `Verify(..., Times.Never)` on the chooser to lock in the `!inWeb && ...` short-circuit.

## Validation

No .NET SDK is available in this session, so I could not run the suite locally; the tests were verified statically against `Planetfall/Location/Feinstein/EscapePod.cs`. `dotnet.yml` runs on `pull_request` into `main`, so CI validates these changes through #460 once merged into that branch. The production change is comment-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jv6SaSfzVr1RtLui8tTM49

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jv6SaSfzVr1RtLui8tTM49)_