### PR TITLE
Fix #469: clear FlaskUnderSpout when the flask is taken off the spout

### DIFF
--- a/Planetfall.Tests/CommRoomAndMachineRoomTests.cs
+++ b/Planetfall.Tests/CommRoomAndMachineRoomTests.cs
@@ -338,6 +338,35 @@ public class CommRoomAndMachineRoomTests : EngineTestsBase
         response.Should().Contain("The flask fills with some clear chemical fluid");
     }
 
+    // Issue #469: MachineShop.FlaskUnderSpout was write-once — "put flask under spout" set it true and
+    // nothing ever cleared it. Taking the flask back left the flag stuck on, so the room kept reporting the
+    // flask "under the spout" while it sat in the player's hand, and pressing a dispenser button filled the
+    // in-hand flask. Taking the flask off the spout must clear the flag: the description drops the "under the
+    // spout" line and a button press spills instead of filling.
+    [Test]
+    public async Task TakeFlaskFromSpout_ClearsUnderSpoutState()
+    {
+        var target = GetTarget();
+        Take<Flask>();
+        StartHere<MachineShop>();
+
+        await target.GetResponse("put flask under spout");
+        GetLocation<MachineShop>().FlaskUnderSpout.Should().BeTrue();
+
+        await target.GetResponse("take flask");
+        target.Context.HasItem<Flask>().Should().BeTrue();
+        GetLocation<MachineShop>().FlaskUnderSpout.Should().BeFalse();
+
+        // (a) look no longer claims the flask is under the spout while it's in your hand
+        var lookResponse = await target.GetResponse("look");
+        lookResponse.Should().NotContain("Sitting under the spout is a glass flask.");
+
+        // (b) pressing a button spills onto the floor instead of filling the in-hand flask
+        var pressResponse = await target.GetResponse("press red button");
+        pressResponse.Should().Contain("spills all over the floor, and dries up");
+        GetItem<Flask>().LiquidColor.Should().BeNull();
+    }
+
     [Test]
     public async Task PressButton_FlaskUnderneath_AlreadyFull()
     {

--- a/Planetfall/Item/Kalamontee/Mech/Flask.cs
+++ b/Planetfall/Item/Kalamontee/Mech/Flask.cs
@@ -1,5 +1,6 @@
 using Model.AIGeneration;
 using Planetfall.Command;
+using Planetfall.Location.Kalamontee.Mech;
 
 namespace Planetfall.Item.Kalamontee.Mech;
 
@@ -8,6 +9,19 @@ public class Flask : ItemBase, ICanBeExamined, ICanBeTakenAndDropped
     public override string[] NounsForMatching => ["glass flask", "flask", "large glass flask"];
 
     public string? LiquidColor { get; set; }
+
+    // Issue #469: MachineShop.FlaskUnderSpout is the room's record that the flask is genuinely under the
+    // spout — the description and the dispenser buttons both trust it. "put flask under spout" sets it, but
+    // nothing used to clear it, so taking the flask back left it stuck true: the room kept describing the
+    // flask "under the spout" while it was in the player's hand, and a button press filled the in-hand flask.
+    // Clearing it here, when the flask leaves the spout, mirrors how putting it there set it.
+    public override string? OnBeingTaken(IContext context, ICanContainItems? previousLocation)
+    {
+        if (previousLocation is MachineShop machineShop)
+            machineShop.FlaskUnderSpout = false;
+
+        return base.OnBeingTaken(context, previousLocation);
+    }
 
     public string ExaminationDescription =>
         "The flask has a wide mouth and looks large enough to hold one or two liters. It is made of glass, " +


### PR DESCRIPTION
## Problem

Fixes #469.

`MachineShop.FlaskUnderSpout` was a **write-once** flag: `put flask under spout` set it `true` and nothing ever set it back to `false`. Taking the flask back left the flag stuck on, which produced two visible bugs (both reproduced on prod):

1. `look` kept printing *"Sitting under the spout is a glass flask."* while the flask was actually in the player's inventory (even after carrying it away to the Comm Room).
2. Pressing a dispenser button filled the flask **while it was in the player's hand** — `Click()` gated only on the flag, not on the flask actually being under the spout.

## Root cause

In `Planetfall/Location/Kalamontee/Mech/MachineShop.cs`, `FlaskUnderSpout` is written `true` in exactly one place (the `put ... under spout` handler) and never written `false`. `Flask` had no take/drop hook to clear it when the flask left the spout, so both the room description and `Click()` trusted a flag that no longer reflected the flask's location.

## Fix

Clear the flag in `Flask.OnBeingTaken` when the flask is taken from the Machine Shop, mirroring how `put ... under spout` sets it.

I kept the flag (rather than switching the description and `Click()` to a bare `CurrentLocation is MachineShop` check) on purpose: a room-presence check would report a flask **dropped on the floor** of the Machine Shop as "under the spout" too, losing the distinction the flag exists to capture. Clearing the flag when the flask leaves the spout keeps that distinction precise while fixing the stuck-flag bug.

## Testing (TDD)

Added a deterministic regression test `TakeFlaskFromSpout_ClearsUnderSpoutState` in `CommRoomAndMachineRoomTests` — no randomness/AI. It:

1. puts the flask under the spout (flag `true`),
2. takes the flask back and asserts the flag is now `false` and the flask is in inventory,
3. asserts `look` no longer contains *"Sitting under the spout is a glass flask."*, and
4. asserts pressing a button spills onto the floor instead of filling the in-hand flask (`LiquidColor` stays `null`).

The test fails before the fix (flag stuck `true`) and passes after. The full `Planetfall.Tests` suite (3183 tests) passes with no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012yiHx6T7LCJCZCA5Jegh6U

---
_Generated by [Claude Code](https://claude.ai/code/session_012yiHx6T7LCJCZCA5Jegh6U)_