### PR TITLE
Fix #468: Shuttle Car Betty's platform exit keys off Betty's own control, not Alfie's

### DIFF
--- a/Planetfall.Tests/ShuttleTests.cs
+++ b/Planetfall.Tests/ShuttleTests.cs
@@ -886,4 +886,44 @@ public class ShuttleTests : EngineTestsBase
 
         target.Context.CurrentLocation.Should().BeOfType<KalamonteePlatform>();
     }
+
+    [Test]
+    public async Task Betty_PlatformExit_KeysOffBettyControl_NotAlfie()
+    {
+        // Regression test for issue #468: Shuttle Car Betty's platform-exit destination was
+        // computed from AlfieControlEast.TunnelPosition -- the OTHER car's control -- instead
+        // of Betty's own BettyControlEast. The two cars move independently, so once Alfie's
+        // tunnel position is non-zero (e.g. after anyone drives Alfie), stepping out of a
+        // stationary Betty at Lawanda teleported the player to Kalamontee with no shuttle
+        // ride -- a free teleport / world-state desync.
+        var target = GetTarget();
+        StartHere<ShuttleCarBetty>();
+
+        // Betty is untouched and still docked at Lawanda (BettyControlWest == 0). Drive
+        // Alfie's East control off zero WITHOUT moving Betty -- the exact state that arises
+        // in ordinary play after an East-initiated Alfie trip. Betty's exit must ignore it.
+        GetLocation<AlfieControlEast>().TunnelPosition = 12;
+
+        await target.GetResponse("south");
+
+        // Betty never moved, so exiting her lands you back at Lawanda -- not Kalamontee.
+        target.Context.CurrentLocation.Should().BeOfType<LawandaPlatform>();
+    }
+
+    [Test]
+    public async Task Alfie_PlatformExit_IgnoresBettyControl()
+    {
+        // Guard for issue #468's fix: Alfie's platform exit keys off AlfieControlEast and
+        // must stay independent of BettyControlEast. Move Betty's East control off zero (as
+        // if Betty had been driven) while Alfie sits untouched at Kalamontee, and confirm
+        // Alfie still exits to Kalamontee.
+        var target = GetTarget();
+        StartHere<ShuttleCarAlfie>();
+
+        GetLocation<BettyControlEast>().TunnelPosition = 12;
+
+        await target.GetResponse("north");
+
+        target.Context.CurrentLocation.Should().BeOfType<KalamonteePlatform>();
+    }
 }

--- a/Planetfall/Location/Shuttle/ShuttleCarBetty.cs
+++ b/Planetfall/Location/Shuttle/ShuttleCarBetty.cs
@@ -18,9 +18,15 @@ public class ShuttleCarBetty : ShuttleCabin
                 // south". The exit was wired to Direction.N, contradicting both -- so "go
                 // south" failed and the only way out was an unintuitive north<->north loop.
                 Direction.S,
-                Repository.GetLocation<AlfieControlEast>().TunnelPosition == 0
-                    ? Go<LawandaPlatform>()
-                    : Go<KalamonteePlatform>()
+                // Issue #468: key the destination off Betty's OWN control (BettyControlEast),
+                // not Alfie's. The two cars move independently and nothing links them, so
+                // reading AlfieControlEast teleported a stationary Betty to the wrong station
+                // the moment Alfie's tunnel position went non-zero. BettyControlEast == 0
+                // means Betty is docked at Kalamontee (its East end); otherwise Lawanda --
+                // mirroring Alfie's own-control logic and KalamonteePlatform.BettyIsHere.
+                Repository.GetLocation<BettyControlEast>().TunnelPosition == 0
+                    ? Go<KalamonteePlatform>()
+                    : Go<LawandaPlatform>()
             }
         };
     }


### PR DESCRIPTION
## Summary

Fixes #468. **Shuttle Car Betty**'s platform-exit destination was computed from **`AlfieControlEast.TunnelPosition`** — the *other* car's control — instead of Betty's own `BettyControlEast`. The two shuttle cars move independently and nothing links them, so the moment Alfie's tunnel position went non-zero, stepping out of a stationary Betty at Lawanda dropped the player at **Kalamontee** with no shuttle ride — a free teleport / world-state desync.

## Root cause

`Planetfall/Location/Shuttle/ShuttleCarBetty.cs` resolved its `Direction.S` platform exit from `AlfieControlEast`:

```csharp
Repository.GetLocation<AlfieControlEast>().TunnelPosition == 0
    ? Go<LawandaPlatform>()
    : Go<KalamonteePlatform>()
```

The expression was copy-pasted from `ShuttleCarAlfie` and never re-pointed at Betty's control. Its branch order was also mirror-swapped (`== 0 → Lawanda`) so it read correct **only** while `AlfieControlEast` happened to be `0` — which is true at game start but not after Alfie is driven. `AlfieControlEast.Arrived()` resets only `AlfieControlWest`, so `AlfieControlEast.TunnelPosition` stays non-zero after an East-initiated Alfie trip, making the desync reachable in ordinary play.

The authoritative source of truth is already in the codebase: `KalamonteePlatform.BettyIsHere => BettyControlEast.TunnelPosition == 0`. So Betty is docked at Kalamontee iff `BettyControlEast == 0`, otherwise Lawanda.

## Fix

Point Betty's exit at its **own** control and align the branch order with Alfie's own-control logic (and with `KalamonteePlatform.BettyIsHere`):

```csharp
Repository.GetLocation<BettyControlEast>().TunnelPosition == 0
    ? Go<KalamonteePlatform>()
    : Go<LawandaPlatform>()
```

This makes Betty's exit expression structurally identical to Alfie's — each car reads its own East control, and the overridden `BettyControlEast` default (`EndOfTunnel`) correctly encodes Betty's starting position at Lawanda.

## Testing (TDD)

Deterministic, no randomness/AI. In `Planetfall.Tests/ShuttleTests.cs`:

- **`Betty_PlatformExit_KeysOffBettyControl_NotAlfie`** (proving test) — starts the player in Betty (docked at Lawanda), drives `AlfieControlEast` off zero *without moving Betty*, and asserts `south` returns to **Lawanda**. Fails before the fix (`Expected LawandaPlatform, but found KalamonteePlatform`), passes after.
- **`Alfie_PlatformExit_IgnoresBettyControl`** (guard) — moves `BettyControlEast` off zero while Alfie sits at Kalamontee and confirms Alfie still exits to Kalamontee, pinning the two cars' independence.

The existing `RoundTrip`, `Betty_SouthReturnsToPlatform_MatchingCabinDescription`, and `Alfie_NorthReturnsToPlatform_MatchingCabinDescription` tests continue to pass. Full `Planetfall.Tests` suite: **3184 passed, 0 failed** (the changed code is Planetfall-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CV8cwbqKMTYy65ZDCA2g9C)_