### PR TITLE
Fix #473: connector rooms drop first-visit description via early-return BeforeEnterLocation

### DIFF
--- a/Planetfall.Tests/AdminCorridorTests.cs
+++ b/Planetfall.Tests/AdminCorridorTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using Model;
 using Planetfall.Item.Feinstein;
 using Planetfall.Item.Kalamontee;
 using Planetfall.Item.Kalamontee.Mech;
@@ -98,6 +99,30 @@ public class AdminCorridorTests : EngineTestsBase
 
         response.Should().Contain("too wide to jump");
         Context.CurrentLocation.Should().BeOfType<AdminCorridor>();
+    }
+
+    // Issue #473: entering AdminCorridor from AdminCorridorNorth (crossing the ladder) returned the
+    // transition text directly instead of prepending it to base.BeforeEnterLocation(...). base is the
+    // only place VisitCount is incremented (and OnFirstTimeEnterLocation fires); in Brief mode
+    // LookProcessor shows the full room description only when VisitCount == 1, so entering via the
+    // transition path silently dropped the first-visit room description.
+    [Test]
+    public async Task EnterFromAdminCorridorNorth_FirstVisit_ShowsRoomDescriptionAndIncrementsVisitCount()
+    {
+        var target = GetTarget();
+        Context.Verbosity = Verbosity.Brief;
+        StartHere<AdminCorridorNorth>();
+        var ladder = GetItem<Ladder>();
+        ladder.IsExtended = true;
+        ladder.IsAcrossRift = true;
+
+        var response = await target.GetResponse("s");
+
+        Context.CurrentLocation.Should().BeOfType<AdminCorridor>();
+        // The ladder-crossing transition text must accompany, not replace, the first-visit description.
+        response.Should().Contain("You slowly make your way across the swaying ladder");
+        response.Should().Contain("has been rent apart here");
+        GetLocation<AdminCorridor>().VisitCount.Should().Be(1);
     }
 
     // Issue #369: "jump rift"/"jump into rift"/"jump over rift" were being misrouted to the

--- a/Planetfall.Tests/CorridorJunctionTests.cs
+++ b/Planetfall.Tests/CorridorJunctionTests.cs
@@ -1,0 +1,29 @@
+using FluentAssertions;
+using Model;
+using Planetfall.Location.Kalamontee;
+
+namespace Planetfall.Tests;
+
+public class CorridorJunctionTests : EngineTestsBase
+{
+    // Issue #473: entering CorridorJunction from DormCorridor returned the walk-transition text
+    // directly instead of prepending it to base.BeforeEnterLocation(...). base is the only place
+    // VisitCount is incremented (and OnFirstTimeEnterLocation fires); in Brief mode LookProcessor
+    // shows the full room description only when VisitCount == 1, so entering via the transition
+    // path silently dropped the first-visit room description.
+    [Test]
+    public async Task EnterFromDormCorridor_FirstVisit_ShowsRoomDescriptionAndIncrementsVisitCount()
+    {
+        var target = GetTarget();
+        Context.Verbosity = Verbosity.Brief;
+        StartHere<DormCorridor>();
+
+        var response = await target.GetResponse("east");
+
+        Context.CurrentLocation.Should().BeOfType<CorridorJunction>();
+        // The walk-transition text must accompany, not replace, the first-visit room description.
+        response.Should().Contain("You walk down the long, featureless hallway");
+        response.Should().Contain("A north-south corridor intersects the main corridor here");
+        GetLocation<CorridorJunction>().VisitCount.Should().Be(1);
+    }
+}

--- a/Planetfall.Tests/DormCorridorTests.cs
+++ b/Planetfall.Tests/DormCorridorTests.cs
@@ -1,0 +1,29 @@
+using FluentAssertions;
+using Model;
+using Planetfall.Location.Kalamontee;
+
+namespace Planetfall.Tests;
+
+public class DormCorridorTests : EngineTestsBase
+{
+    // Issue #473: entering DormCorridor from CorridorJunction returned the walk-transition text
+    // directly instead of prepending it to base.BeforeEnterLocation(...). base is the only place
+    // VisitCount is incremented (and OnFirstTimeEnterLocation fires); in Brief mode LookProcessor
+    // shows the full room description only when VisitCount == 1, so entering via the transition
+    // path silently dropped the first-visit room description.
+    [Test]
+    public async Task EnterFromCorridorJunction_FirstVisit_ShowsRoomDescriptionAndIncrementsVisitCount()
+    {
+        var target = GetTarget();
+        Context.Verbosity = Verbosity.Brief;
+        StartHere<CorridorJunction>();
+
+        var response = await target.GetResponse("west");
+
+        Context.CurrentLocation.Should().BeOfType<DormCorridor>();
+        // The walk-transition text must accompany, not replace, the first-visit room description.
+        response.Should().Contain("You walk down the long, featureless hallway");
+        response.Should().Contain("wide, east-west hallway with openings to the north and south");
+        GetLocation<DormCorridor>().VisitCount.Should().Be(1);
+    }
+}

--- a/Planetfall/Location/Kalamontee/Admin/AdminCorridor.cs
+++ b/Planetfall/Location/Kalamontee/Admin/AdminCorridor.cs
@@ -41,11 +41,16 @@ internal class AdminCorridor : RiftLocationBase
 
     public override string BeforeEnterLocation(IContext context, ILocation previousLocation)
     {
+        // Issue #473: prepend the transition text to base (mirroring AdminCorridorNorth) rather than
+        // returning it standalone. base.BeforeEnterLocation is the only place VisitCount is
+        // incremented (and OnFirstTimeEnterLocation fires); returning early skipped it, so in Brief
+        // mode the first-visit room description was silently dropped.
+        string prepend = "";
         if (previousLocation is AdminCorridorNorth)
-            return
+            prepend =
                 "You slowly make your way across the swaying ladder. You can see sharp, pointy rocks at the bottom of the rift, far below...\n\n";
 
-        return base.BeforeEnterLocation(context, previousLocation);
+        return prepend + base.BeforeEnterLocation(context, previousLocation);
     }
 
 

--- a/Planetfall/Location/Kalamontee/CorridorJunction.cs
+++ b/Planetfall/Location/Kalamontee/CorridorJunction.cs
@@ -35,10 +35,15 @@ internal class CorridorJunction : LocationWithNoStartingItems
 
     public override string BeforeEnterLocation(IContext context, ILocation previousLocation)
     {
+        // Issue #473: prepend the transition text to base (mirroring AdminCorridorNorth) rather than
+        // returning it standalone. base.BeforeEnterLocation is the only place VisitCount is
+        // incremented (and OnFirstTimeEnterLocation fires); returning early skipped it, so in Brief
+        // mode the first-visit room description was silently dropped.
+        string prepend = "";
         if (previousLocation is DormCorridor)
-            return
+            prepend =
                 "You walk down the long, featureless hallway for a long time. Finally, you see an intersection ahead...\n\n";
 
-        return base.BeforeEnterLocation(context, previousLocation);
+        return prepend + base.BeforeEnterLocation(context, previousLocation);
     }
 }

--- a/Planetfall/Location/Kalamontee/DormCorridor.cs
+++ b/Planetfall/Location/Kalamontee/DormCorridor.cs
@@ -20,11 +20,16 @@ internal class DormCorridor : LocationWithNoStartingItems
 
     public override string BeforeEnterLocation(IContext context, ILocation previousLocation)
     {
+        // Issue #473: prepend the transition text to base (mirroring AdminCorridorNorth) rather than
+        // returning it standalone. base.BeforeEnterLocation is the only place VisitCount is
+        // incremented (and OnFirstTimeEnterLocation fires); returning early skipped it, so in Brief
+        // mode the first-visit room description was silently dropped.
+        string prepend = "";
         if (previousLocation is CorridorJunction)
-            return
+            prepend =
                 "You walk down the long, featureless hallway for a long time. Finally, you see an intersection ahead...\n\n";
 
-        return base.BeforeEnterLocation(context, previousLocation);
+        return prepend + base.BeforeEnterLocation(context, previousLocation);
     }
 
     protected override string GetContextBasedDescription(IContext context)

--- a/ZorkOne.Tests/Places/MazeTests.cs
+++ b/ZorkOne.Tests/Places/MazeTests.cs
@@ -1,0 +1,38 @@
+using FluentAssertions;
+using GameEngine;
+using Model;
+using UnitTests;
+using ZorkOne.Item;
+using ZorkOne.Location.MazeLocation;
+
+namespace ZorkOne.Tests.Places;
+
+public class MazeTests : EngineTestsBase
+{
+    // Issue #473 (same lifecycle-override bug as the Planetfall connector rooms, found via the
+    // repo-wide grep the issue suggested): MazeEleven, entered from MazeNine, returned the
+    // "You won't be able to get back up..." transition text directly instead of prepending it to
+    // base.BeforeEnterLocation(...). base is the only place VisitCount is incremented (and
+    // OnFirstTimeEnterLocation fires); in Brief mode LookProcessor shows the full room description
+    // only when VisitCount == 1, so a lit first entry via this path dropped the maze description.
+    [Test]
+    public async Task EnterMazeElevenFromMazeNine_FirstVisit_ShowsMazeDescriptionAndIncrementsVisitCount()
+    {
+        var target = GetTarget();
+        target.Context.Verbosity = Verbosity.Brief;
+
+        // The maze is dark; carry a lit lantern so the room description (not the darkness text) shows.
+        var lamp = Repository.GetItem<Lantern>();
+        lamp.IsOn = true;
+        target.Context.Take(lamp);
+        target.Context.CurrentLocation = Repository.GetLocation<MazeNine>();
+
+        var response = await target.GetResponse("down");
+
+        target.Context.CurrentLocation.Should().BeOfType<MazeEleven>();
+        // The transition warning must accompany, not replace, the first-visit maze description.
+        response.Should().Contain("You won't be able to get back up to the tunnel");
+        response.Should().Contain("twisty little passages, all alike");
+        Repository.GetLocation<MazeEleven>().VisitCount.Should().Be(1);
+    }
+}

--- a/ZorkOne/Location/MazeLocation/MazeBase.cs
+++ b/ZorkOne/Location/MazeLocation/MazeBase.cs
@@ -197,11 +197,16 @@ public class MazeEleven : MazeBase
 
     public override string BeforeEnterLocation(IContext context, ILocation previousLocation)
     {
+        // Issue #473: prepend the transition text to base rather than returning it standalone.
+        // base.BeforeEnterLocation is the only place VisitCount is incremented (and
+        // OnFirstTimeEnterLocation fires); returning early skipped it, so in Brief mode the
+        // first-visit room description was silently dropped on this transition.
+        string prepend = "";
         if (previousLocation is MazeNine)
-            return
+            prepend =
                 "You won't be able to get back up to the tunnel you are going through when it gets to the next room.\n ";
 
-        return base.BeforeEnterLocation(context, previousLocation);
+        return prepend + base.BeforeEnterLocation(context, previousLocation);
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes #473. Three Planetfall connector rooms printed a walk-transition message when entered from a specific neighbor and **returned that string directly from `BeforeEnterLocation` instead of prepending it to `base.BeforeEnterLocation(...)`**.

`base.BeforeEnterLocation` (`LocationBase.cs`) is the only place `VisitCount` is incremented (and `OnFirstTimeEnterLocation` fires). In Brief mode (the default), `LookProcessor` shows the full room description only when `VisitCount == 1` — so entering via the transition path silently **dropped the first-visit room description**. The player saw the walk text and the room title, but not the description (which only appeared after a manual `look`).

## Root cause

The buggy handlers early-returned the transition literal, bypassing `base`:

- `Planetfall/Location/Kalamontee/DormCorridor.cs` — from `CorridorJunction`
- `Planetfall/Location/Kalamontee/CorridorJunction.cs` — from `DormCorridor`
- `Planetfall/Location/Kalamontee/Admin/AdminCorridor.cs` — from `AdminCorridorNorth`

The correct pattern already existed on the other side of the same rift — `AdminCorridorNorth` prepends the transition text to `base`. All three now mirror it:

```csharp
string prepend = "";
if (previousLocation is ...) prepend = "...transition text...";
return prepend + base.BeforeEnterLocation(context, previousLocation);
```

## Additional instance found via the suggested grep

The issue recommended a repo-wide grep for `BeforeEnterLocation` overrides returning a literal without `base.`. That grep surfaced the **identical** bug in Zork I's `MazeEleven` (`ZorkOne/Location/MazeLocation/MazeBase.cs`) when entered from `MazeNine` — with a lit lamp in Brief mode it dropped the "twisty little passages" maze description. Fixed the same way. (All other `BeforeEnterLocation` overrides either call `base` correctly or are deliberate special cases — `LabOffice`'s death path, `BatRoom`'s carry-off — that intentionally do not.)

## Testing (TDD)

Added deterministic, no-randomness/no-AI tests that set Brief verbosity, enter each room via the transition path, and assert the response contains the room description **and** `VisitCount == 1`. Each was confirmed to **fail before** the fix (walk text + title present, description missing) and **pass after**:

- `Planetfall.Tests/DormCorridorTests.cs` (new)
- `Planetfall.Tests/CorridorJunctionTests.cs` (new)
- `Planetfall.Tests/AdminCorridorTests.cs` (added test)
- `ZorkOne.Tests/Places/MazeTests.cs` (new)

Full suites pass with no regressions: `Planetfall.Tests` (3187), `ZorkOne.Tests` (1782, includes the maze/corridor walkthroughs), `UnitTests` (1069, 1 skipped).

## Faithful-to-original note

ZIL-independent — a lifecycle-override bug (dropping `base`'s side effects), provable from the C# alone and contradicted by the sibling `AdminCorridorNorth` that does it correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XEXVfpwwJGg5dW74eWhS8S)_