### PR TITLE
Fix #472: persist pending disambiguation across the stateless request boundary

### DIFF
--- a/GameEngine/Context.cs
+++ b/GameEngine/Context.cs
@@ -134,6 +134,21 @@ public abstract class Context<T> : IContext where T : IInfocomGame, new()
     [JsonIgnore]
     public bool TurnConsumedByForcedEvent { get; set; }
 
+    /// <summary>
+    ///     Persists an in-flight "which one do you mean?" disambiguation across the stateless per-request
+    ///     save/restore boundary (issue #472). Unlike <see cref="PendingDeath" /> this is NOT
+    ///     <c>[JsonIgnore]</c> — it must round-trip so the rebuilt engine can restore the pending prompt and
+    ///     route the next input to it. See <see cref="IContext.PendingDisambiguation" />.
+    /// </summary>
+    public PendingDisambiguation? PendingDisambiguation { get; set; }
+
+    /// <summary>
+    ///     Persists an in-flight "it"/"them" clarification (the command awaiting a noun) across the same
+    ///     boundary as <see cref="PendingDisambiguation" /> (issue #472). See
+    ///     <see cref="IContext.PendingClarificationCommand" />.
+    /// </summary>
+    public string? PendingClarificationCommand { get; set; }
+
     public List<TItem> GetItems<TItem>()
     {
         return Items.OfType<TItem>().ToList();

--- a/GameEngine/GameEngine.cs
+++ b/GameEngine/GameEngine.cs
@@ -255,8 +255,10 @@ public class GameEngine<TInfocomGame, TContext> : IGameEngine
         // "it" clarification). A crash can occur *after* _processorInProgress was assigned but before
         // the turn completed; if we leave it set, the NEXT turn's input is fed into that orphaned
         // processor instead of being parsed normally — soft-locking the player in a long-lived engine
-        // (e.g. console runtime). Clearing it keeps the "player can keep playing" guarantee (issue #271).
-        _processorInProgress = null;
+        // (e.g. console runtime). Clearing it — and its persisted descriptors (issue #472), so the
+        // orphaned prompt cannot be rehydrated on a later request either — keeps the "player can keep
+        // playing" guarantee (issue #271).
+        ClearProcessorInProgress();
 
         _logger?.LogError(ex,
             "Unhandled exception during turn processing for input '{Input}'. TurnCorrelationId: {TurnCorrelationId}",
@@ -621,6 +623,10 @@ public class GameEngine<TInfocomGame, TContext> : IGameEngine
         if (requiresClarification)
         {
             _processorInProgress = _itProcessor;
+            // Persist the command awaiting a noun so the "What item are you referring to?" clarification
+            // survives the stateless save/restore boundary (issue #472). _currentInput is exactly what
+            // ItProcessor.Check just stashed as the command to complete once the noun arrives.
+            Context.PendingClarificationCommand = _currentInput;
             return PostProcessing(replacedInput);
         }
 
@@ -730,6 +736,12 @@ public class GameEngine<TInfocomGame, TContext> : IGameEngine
         // with yet.
         if (Context.RequestSequence == 0 && Context.Moves > 0)
             Context.RequestSequence = Context.Moves;
+
+        // Rebuild any pending "which one do you mean?" / "it"-clarification prompt that was armed on the
+        // turn this state was saved (issue #472). The live processor lives only in an engine field, which
+        // the stateless deployment does not serialize, so without this the next input — the player's
+        // answer — would be parsed as a fresh command instead of resolving the prompt.
+        RehydrateProcessorInProgress();
 
         return Context;
     }
@@ -905,7 +917,7 @@ public class GameEngine<TInfocomGame, TContext> : IGameEngine
         };
 
         if (complexIntentResult.resultObject is DisambiguationInteractionResult complexResult)
-            _processorInProgress = new DisambiguationProcessor(complexResult);
+            ArmDisambiguation(complexResult);
 
         return complexIntentResult;
     }
@@ -1038,7 +1050,7 @@ public class GameEngine<TInfocomGame, TContext> : IGameEngine
         if (_processorInProgress.Completed)
         {
             var continueProcessingThisInput = _processorInProgress.ContinueProcessing;
-            _processorInProgress = null;
+            ClearProcessorInProgress();
 
             // Does the processor want us to return what it outputted?....
             if (!continueProcessingThisInput)
@@ -1054,6 +1066,59 @@ public class GameEngine<TInfocomGame, TContext> : IGameEngine
         }
 
         return (immediatelyReturn, processorInProgressOutput);
+    }
+
+    /// <summary>
+    ///     Arms a pending "which one do you mean?" disambiguation and, crucially, mirrors the two fields
+    ///     the answer needs into a serializable descriptor on the <see cref="Context" /> so the prompt
+    ///     survives the stateless per-request save/restore boundary (issue #472). The live
+    ///     <see cref="DisambiguationProcessor" /> is an in-memory field that is never serialized; the
+    ///     descriptor is what actually round-trips and lets <see cref="RehydrateProcessorInProgress" />
+    ///     rebuild the processor on the next request.
+    /// </summary>
+    private void ArmDisambiguation(DisambiguationInteractionResult disambiguation)
+    {
+        _processorInProgress = new DisambiguationProcessor(disambiguation);
+        Context.PendingDisambiguation = new PendingDisambiguation
+        {
+            PossibleResponses = disambiguation.PossibleResponses,
+            ReplacementString = disambiguation.ReplacementString
+        };
+    }
+
+    /// <summary>
+    ///     Clears the in-progress stateful processor together with the persisted descriptors that back the
+    ///     two prompts which must survive the request boundary (issue #472). Called whenever a processor
+    ///     finishes or is abandoned; clearing both descriptors unconditionally is safe because at most one
+    ///     can be set at a time, and the save/quit/restore processors never set either.
+    /// </summary>
+    private void ClearProcessorInProgress()
+    {
+        _processorInProgress = null;
+        Context.PendingDisambiguation = null;
+        Context.PendingClarificationCommand = null;
+    }
+
+    /// <summary>
+    ///     Reconstructs <see cref="_processorInProgress" /> from whichever pending-prompt descriptor
+    ///     round-tripped on the restored <see cref="Context" /> (issue #472). The two descriptors are
+    ///     mutually exclusive by construction — a turn arms exactly one prompt — so disambiguation is
+    ///     simply checked first. Does nothing when no prompt was pending, leaving normal parsing in charge.
+    /// </summary>
+    private void RehydrateProcessorInProgress()
+    {
+        if (Context.PendingDisambiguation is { } pending)
+        {
+            // The stored prompt text is irrelevant when answering — only the response map and template
+            // drive resolution — so rebuild the result with an empty message.
+            _processorInProgress = new DisambiguationProcessor(
+                new DisambiguationInteractionResult(
+                    string.Empty, pending.PossibleResponses, pending.ReplacementString));
+            return;
+        }
+
+        if (!string.IsNullOrEmpty(Context.PendingClarificationCommand))
+            _processorInProgress = new ItProcessor(Context.PendingClarificationCommand);
     }
 
     private static async Task<string> GetGeneratedNoOpResponse(

--- a/GameEngine/StaticCommand/Implementation/ItProcessor.cs
+++ b/GameEngine/StaticCommand/Implementation/ItProcessor.cs
@@ -10,6 +10,24 @@ internal class ItProcessor : IStatefulProcessor
 {
     private string? _lastInput;
 
+    public ItProcessor()
+    {
+    }
+
+    /// <summary>
+    ///     Rebuilds an "it"/"them" clarification that was already asked on a previous turn but whose
+    ///     answer arrives on a freshly reconstructed engine (issue #472). <paramref name="commandAwaitingNoun" />
+    ///     is the original command the player is completing (e.g. "take it"); re-detecting the pronoun from
+    ///     it restores <see cref="PronounUsed" /> so <see cref="Process" /> substitutes the answer correctly.
+    ///     Leaving <see cref="Completed" />/<see cref="ContinueProcessing" /> at their false defaults puts
+    ///     the processor back into the "armed, waiting for the noun" state.
+    /// </summary>
+    public ItProcessor(string commandAwaitingNoun)
+    {
+        _lastInput = commandAwaitingNoun;
+        DidWeUseItOrThem(commandAwaitingNoun);
+    }
+
     public Pronoun PronounUsed { get; set; }
 
     public bool Completed { get; private set; }

--- a/Model/Interaction/PendingDisambiguation.cs
+++ b/Model/Interaction/PendingDisambiguation.cs
@@ -1,0 +1,35 @@
+namespace Model.Interaction;
+
+/// <summary>
+///     A serializable snapshot of an in-flight "which one do you mean?" disambiguation prompt, stored on
+///     the <see cref="Model.Interface.IContext" /> so it survives the stateless per-request save/restore
+///     boundary in the deployed game (issue #472).
+/// </summary>
+/// <remarks>
+///     The live prompt is held by an in-memory engine field (the disambiguation
+///     <c>IStatefulProcessor</c>). That field is NOT part of the serialized session, so in production —
+///     where the engine is rebuilt per request and the full game state travels in the base64 session —
+///     the pending prompt was lost between the turn that asked the question and the turn that carried the
+///     answer, and the answer was mis-parsed as a brand-new command. Persisting this lightweight
+///     descriptor on the Context (which already round-trips inventory/score/flags) lets the engine
+///     rebuild the pending processor on restore and route the next input to it.
+///
+///     Only the two fields the processor needs to resolve an answer are captured — the map of accepted
+///     replies to their fully-qualified nouns, and the command template to fill in. The human-readable
+///     prompt text is not stored: it is only shown when the question is first asked, never when it is
+///     answered.
+/// </remarks>
+public class PendingDisambiguation
+{
+    /// <summary>
+    ///     Mirrors <see cref="DisambiguationInteractionResult.PossibleResponses" />: the accepted replies
+    ///     (keys, matched by substring) mapped to the fully-qualified noun each one resolves to.
+    /// </summary>
+    public Dictionary<string, string> PossibleResponses { get; set; } = new();
+
+    /// <summary>
+    ///     Mirrors <see cref="DisambiguationInteractionResult.ReplacementString" />: the command template
+    ///     (e.g. <c>"drop {0}"</c>) the chosen noun is substituted into to form the resolved command.
+    /// </summary>
+    public string ReplacementString { get; set; } = "";
+}

--- a/Model/Interface/IContext.cs
+++ b/Model/Interface/IContext.cs
@@ -301,6 +301,25 @@ public interface IContext : ICanContainItems
     bool TurnConsumedByForcedEvent { get; set; }
 
     /// <summary>
+    ///     A serializable snapshot of an in-flight "which one do you mean?" disambiguation prompt, or null
+    ///     when no prompt is pending. Lives on the Context (rather than only in an in-memory engine field)
+    ///     so it round-trips through the save/restore boundary: in the stateless deployment the engine is
+    ///     rebuilt every request, so without this the pending prompt is lost between the turn that asks the
+    ///     question and the turn that carries the answer, and the answer is mis-parsed as a fresh command
+    ///     (issue #472). The engine rebuilds the pending processor from this on restore.
+    /// </summary>
+    PendingDisambiguation? PendingDisambiguation { get; set; }
+
+    /// <summary>
+    ///     The original command awaiting a noun after an "it"/"them" pronoun could not be resolved and the
+    ///     engine asked "What item are you referring to?" (e.g. <c>"take it"</c>), or null when no such
+    ///     clarification is pending. Persisted on the Context for the same reason as
+    ///     <see cref="PendingDisambiguation" /> — the "it"-clarification path uses the identical in-memory
+    ///     processor mechanism and was broken by the same stateless-deployment gap (issue #472).
+    /// </summary>
+    string? PendingClarificationCommand { get; set; }
+
+    /// <summary>
     ///     Gets the current death count. Override in game-specific contexts that track deaths.
     /// </summary>
     int GetDeathCount();

--- a/Planetfall.Tests/DisambiguationPersistenceTests.cs
+++ b/Planetfall.Tests/DisambiguationPersistenceTests.cs
@@ -1,0 +1,113 @@
+using FluentAssertions;
+using GameEngine;
+using NUnit.Framework;
+using Planetfall.Item.Kalamontee.Admin;
+using Planetfall.Location.Kalamontee;
+
+namespace Planetfall.Tests;
+
+/// <summary>
+///     Issue #472, reproduced on the exact families the bug was reported against (the access cards). The
+///     deployed game is stateless: the pending "which card do you mean?" prompt lives in an in-memory
+///     engine field that is not serialized, so before the fix the player's answer arrived on a rebuilt
+///     engine with no pending prompt and was parsed as a fresh command — "no effect", a re-prompt, or the
+///     notorious movement side effect where answering "kitchen" walked the player toward the Kitchen.
+///
+///     Each test serializes + deserializes the game between the prompt and the answer, mirroring the
+///     Lambda save/restore round-trip; the single-process CardTests do not exercise this boundary.
+/// </summary>
+public class DisambiguationPersistenceTests : EngineTestsBase
+{
+    private GameEngine<PlanetfallGame, PlanetfallContext> RoundTrip(GameEngine<PlanetfallGame, PlanetfallContext> engine)
+    {
+        var saved = engine.SaveGame();
+        var restored = GetTarget();
+        restored.RestoreGame(saved);
+        return restored;
+    }
+
+    [Test]
+    [TestCase("kitchen")]
+    [TestCase("kitchen access")]
+    [TestCase("kitchen card")]
+    [TestCase("kitchen access card")]
+    public async Task CardDisambiguation_AnswerResolves_AcrossSaveRestore(string reply)
+    {
+        var engine = GetTarget();
+        engine.Context.CurrentLocation = Repository.GetLocation<MessCorridor>();
+        engine.Context.ItemPlacedHere(Repository.GetItem<KitchenAccessCard>());
+        engine.Context.ItemPlacedHere(Repository.GetItem<ShuttleAccessCard>());
+
+        var prompt = await engine.GetResponse("drop card");
+        prompt.Should().Contain("Do you mean the kitchen access card or the shuttle access card?");
+
+        var restored = RoundTrip(engine);
+
+        var response = await restored.GetResponse(reply);
+
+        response.Should().Contain("Dropped");
+        Repository.GetItem<KitchenAccessCard>().CurrentLocation.Should().BeOfType<MessCorridor>();
+        restored.Context.Items.Should().ContainSingle().Which.Should().Be(Repository.GetItem<ShuttleAccessCard>());
+    }
+
+    // The issue's headline movement side effect: after the prompt is lost, answering "kitchen" parses as
+    // a movement command ("You can't get there from here."). Once the prompt persists, "kitchen" resolves
+    // to the kitchen card and drops it — it must NOT be treated as a move.
+    [Test]
+    public async Task AnsweringKitchen_ResolvesTheCard_DoesNotWalkTowardTheKitchen()
+    {
+        var engine = GetTarget();
+        engine.Context.CurrentLocation = Repository.GetLocation<MessCorridor>();
+        engine.Context.ItemPlacedHere(Repository.GetItem<KitchenAccessCard>());
+        engine.Context.ItemPlacedHere(Repository.GetItem<ShuttleAccessCard>());
+
+        await engine.GetResponse("drop card");
+        var restored = RoundTrip(engine);
+
+        var response = await restored.GetResponse("kitchen");
+
+        response.Should().Contain("Dropped");
+        response.Should().NotContain("get there", "the answer must resolve the prompt, not parse as movement");
+        restored.Context.CurrentLocation.Should().BeOfType<MessCorridor>("the player did not move");
+    }
+
+    // The issue's other reported phrasing, exercising the multi-noun engine ("slide X through slot")
+    // rather than the drop path — same _processorInProgress mechanism, so it must round-trip too.
+    [Test]
+    [TestCase("kitchen")]
+    [TestCase("kitchen access card")]
+    public async Task SlideCardThroughSlot_Disambiguation_AnswerResolves_AcrossSaveRestore(string reply)
+    {
+        var engine = GetTarget();
+        engine.Context.CurrentLocation = Repository.GetLocation<MessHall>();
+        engine.Context.ItemPlacedHere(Repository.GetItem<KitchenAccessCard>());
+        engine.Context.ItemPlacedHere(Repository.GetItem<ShuttleAccessCard>());
+
+        var prompt = await engine.GetResponse("slide card through slot");
+        prompt.Should().Contain("Do you mean the kitchen access card or the shuttle access card?");
+
+        var restored = RoundTrip(engine);
+
+        var response = await restored.GetResponse(reply);
+
+        response.Should().Contain("The kitchen door quietly slides open");
+    }
+
+    [Test]
+    public async Task WrongCard_Disambiguation_AnswerResolves_AcrossSaveRestore()
+    {
+        var engine = GetTarget();
+        engine.Context.CurrentLocation = Repository.GetLocation<MessCorridor>();
+        engine.Context.ItemPlacedHere(Repository.GetItem<ShuttleAccessCard>());
+        engine.Context.ItemPlacedHere(Repository.GetItem<KitchenAccessCard>());
+
+        await engine.GetResponse("drop card");
+        var restored = RoundTrip(engine);
+
+        var response = await restored.GetResponse("shuttle");
+
+        response.Should().Contain("Dropped");
+        Repository.GetItem<ShuttleAccessCard>().CurrentLocation.Should().BeOfType<MessCorridor>();
+        restored.Context.HasItem<KitchenAccessCard>().Should().BeTrue("only the shuttle card was chosen");
+    }
+}

--- a/UnitTests/Engine/DisambiguationPersistenceTests.cs
+++ b/UnitTests/Engine/DisambiguationPersistenceTests.cs
@@ -1,0 +1,314 @@
+using System.Text;
+using GameEngine;
+using ZorkOne;
+
+namespace UnitTests.Engine;
+
+/// <summary>
+///     Issue #472: the deployed game is stateless — every command is a separate request whose full
+///     state travels in the serialized session, and the <see cref="GameEngine{TInfocomGame,TContext}" />
+///     is rebuilt per request. A "which one do you mean?" disambiguation (and the sibling "it"/"them"
+///     clarification) is armed in an in-memory engine field, so before this fix it was lost across the
+///     request boundary and the player's answer was parsed as a brand-new command ("no effect", a
+///     re-prompt, or an accidental movement).
+///
+///     Every test here serializes + deserializes the game between the PROMPT turn and the ANSWER turn,
+///     mirroring the Lambda save/restore round-trip. A single-process test that skips the round-trip does
+///     NOT catch this bug — the engine field survives in memory — so the round-trip is the essential part.
+/// </summary>
+public class DisambiguationPersistenceTests : EngineTestsBase
+{
+    /// <summary>
+    ///     Rebuild the engine from a saved-game blob exactly as the stateless deployment does on the next
+    ///     request: a fresh engine (which also resets the Repository) with the prior state restored into it.
+    /// </summary>
+    private GameEngine<ZorkI, ZorkIContext> RoundTrip(GameEngine<ZorkI, ZorkIContext> engine)
+    {
+        var saved = engine.SaveGame();
+        var restored = GetTarget();
+        restored.RestoreGame(saved);
+        return restored;
+    }
+
+    [Test]
+    public async Task Knife_Disambiguation_AnswerResolves_AcrossSaveRestore()
+    {
+        var engine = GetTarget();
+        var room = Repository.GetLocation<MaintenanceRoom>();
+        room.IsNoLongerDark = true;
+        engine.Context.ItemPlacedHere(Repository.GetItem<NastyKnife>());
+        engine.Context.ItemPlacedHere(Repository.GetItem<RustyKnife>());
+        engine.Context.CurrentLocation = room;
+
+        var prompt = await engine.GetResponse("drop knife");
+        prompt.Should().Contain("Do you mean the nasty knife or the rusty knife");
+
+        // The stateless deployment reconstructs the engine here; the answer arrives on a fresh engine.
+        var restored = RoundTrip(engine);
+
+        var response = await restored.GetResponse("rusty");
+
+        response.Should().Contain("Dropped", "the restored engine must still resolve the pending prompt");
+        restored.Context.HasItem<RustyKnife>().Should().BeFalse("the rusty knife was the one dropped");
+        restored.Context.HasItem<NastyKnife>().Should().BeTrue("only the rusty knife was chosen");
+    }
+
+    [Test]
+    public async Task Button_Disambiguation_AnswerResolves_AcrossSaveRestore()
+    {
+        var engine = GetTarget();
+        var room = Repository.GetLocation<MaintenanceRoom>();
+        room.IsNoLongerDark = true;
+        engine.Context.CurrentLocation = room;
+
+        var prompt = await engine.GetResponse("press button");
+        prompt.Should().Contain("Which button do you mean");
+
+        var restored = RoundTrip(engine);
+
+        // "yellow one" does NOT independently parse as "press the yellow button" — it only resolves if
+        // the restored engine still routes it through the pending disambiguation processor.
+        var response = await restored.GetResponse("yellow one");
+
+        response.Should().Contain("Click");
+    }
+
+    [Test]
+    public async Task Disambiguation_PlainNounAnswer_ThatDoesNotIndependentlyResolve_StillWorks()
+    {
+        // The control case from the issue: an answer that would be inert as a standalone command
+        // ("rusty" alone is not a full command) must resolve when it answers the pending prompt.
+        var engine = GetTarget();
+        var room = Repository.GetLocation<MaintenanceRoom>();
+        room.IsNoLongerDark = true;
+        engine.Context.ItemPlacedHere(Repository.GetItem<NastyKnife>());
+        engine.Context.ItemPlacedHere(Repository.GetItem<RustyKnife>());
+        engine.Context.CurrentLocation = room;
+
+        await engine.GetResponse("drop knife");
+        var restored = RoundTrip(engine);
+
+        var response = await restored.GetResponse("nasty");
+
+        response.Should().Contain("Dropped");
+        restored.Context.HasItem<NastyKnife>().Should().BeFalse();
+    }
+
+    [Test]
+    public async Task Disambiguation_UnrelatedAnswerAfterRestore_ProcessesAsNewCommand()
+    {
+        // Answering with something that is not one of the choices abandons the prompt and processes the
+        // new command normally (matching the in-memory behavior), and must NOT drop a knife.
+        var engine = GetTarget();
+        var room = Repository.GetLocation<MaintenanceRoom>();
+        room.IsNoLongerDark = true;
+        engine.Context.ItemPlacedHere(Repository.GetItem<NastyKnife>());
+        engine.Context.ItemPlacedHere(Repository.GetItem<RustyKnife>());
+        engine.Context.CurrentLocation = room;
+
+        await engine.GetResponse("drop knife");
+        var restored = RoundTrip(engine);
+
+        var response = await restored.GetResponse("wait");
+
+        response.Should().Contain("Time passes");
+        restored.Context.HasItem<NastyKnife>().Should().BeTrue("no knife should have been dropped");
+        restored.Context.HasItem<RustyKnife>().Should().BeTrue("no knife should have been dropped");
+    }
+
+    [Test]
+    public async Task Disambiguation_DoesNotHijackTheTurnAfterItIsResolved()
+    {
+        // After the pending prompt is answered across a restore, the NEXT command must be parsed
+        // normally — the pending state must not linger and swallow it.
+        var engine = GetTarget();
+        var room = Repository.GetLocation<MaintenanceRoom>();
+        room.IsNoLongerDark = true;
+        engine.Context.ItemPlacedHere(Repository.GetItem<NastyKnife>());
+        engine.Context.ItemPlacedHere(Repository.GetItem<RustyKnife>());
+        engine.Context.CurrentLocation = room;
+
+        await engine.GetResponse("drop knife");
+        var afterPrompt = RoundTrip(engine);
+        await afterPrompt.GetResponse("rusty"); // resolves the prompt
+
+        // Round-trip again (next stateless request) and issue an unrelated command.
+        var afterAnswer = RoundTrip(afterPrompt);
+        var response = await afterAnswer.GetResponse("wait");
+
+        response.Should().Contain("Time passes", "the resolved prompt must not linger and hijack this turn");
+    }
+
+    [Test]
+    public async Task It_Clarification_AnswerResolves_AcrossSaveRestore()
+    {
+        // The "it"/"them" clarification path is the same _processorInProgress mechanism the issue calls
+        // out. "take it" with no antecedent asks "What item are you referring to?"; the noun answer must
+        // survive the request boundary too.
+        var engine = GetTarget();
+        engine.Context.CurrentLocation = Repository.GetLocation<LivingRoom>();
+
+        var prompt = await engine.GetResponse("take it");
+        prompt.Should().Contain("What item are you referring to");
+
+        var restored = RoundTrip(engine);
+
+        var response = await restored.GetResponse("lantern");
+
+        response.Should().Contain("Taken");
+        restored.Context.HasItem<Lantern>().Should().BeTrue();
+    }
+
+    [Test]
+    public async Task Them_Clarification_AnswerResolves_AcrossSaveRestore()
+    {
+        // "drop them" with only a single non-plural item held asks for clarification too; that path must
+        // round-trip as well.
+        var engine = GetTarget();
+        engine.Context.CurrentLocation = Repository.GetLocation<LivingRoom>();
+        await engine.GetResponse("take lantern");
+
+        var prompt = await engine.GetResponse("drop them");
+        prompt.Should().Contain("What item are you referring to");
+
+        var restored = RoundTrip(engine);
+
+        var response = await restored.GetResponse("lantern");
+
+        response.Should().Contain("Dropped");
+        restored.Context.HasItem<Lantern>().Should().BeFalse();
+    }
+
+    // ----- White-box: the descriptor is what actually persists, and it is armed/cleared correctly. -----
+
+    [Test]
+    public async Task Prompt_ArmsPendingDisambiguationDescriptor_OnContext()
+    {
+        var engine = GetTarget();
+        var room = Repository.GetLocation<MaintenanceRoom>();
+        room.IsNoLongerDark = true;
+        engine.Context.ItemPlacedHere(Repository.GetItem<NastyKnife>());
+        engine.Context.ItemPlacedHere(Repository.GetItem<RustyKnife>());
+        engine.Context.CurrentLocation = room;
+
+        engine.Context.PendingDisambiguation.Should().BeNull("no prompt has been asked yet");
+
+        await engine.GetResponse("drop knife");
+
+        engine.Context.PendingDisambiguation.Should().NotBeNull("the prompt must be recorded on the Context so it can round-trip");
+        engine.Context.PendingDisambiguation!.PossibleResponses.Values
+            .Should().Contain("rusty knife").And.Contain("nasty knife");
+        engine.Context.PendingDisambiguation.ReplacementString.Should().Contain("{0}");
+    }
+
+    [Test]
+    public async Task SaveGameJson_CarriesPendingDisambiguation_WhilePromptIsOpen()
+    {
+        var engine = GetTarget();
+        var room = Repository.GetLocation<MaintenanceRoom>();
+        room.IsNoLongerDark = true;
+        engine.Context.ItemPlacedHere(Repository.GetItem<NastyKnife>());
+        engine.Context.ItemPlacedHere(Repository.GetItem<RustyKnife>());
+        engine.Context.CurrentLocation = room;
+
+        await engine.GetResponse("drop knife");
+
+        // The serialized session — the ONLY thing that travels across the stateless request boundary —
+        // must contain the pending prompt's payload. This is the crux of issue #472. (The property NAME
+        // alone is always present because Newtonsoft writes nulls, so assert on the response map, which
+        // only appears when the descriptor is actually populated.)
+        var json = engine.SaveGame();
+        json.Should().Contain("PossibleResponses");
+        json.Should().Contain("rusty knife");
+    }
+
+    [Test]
+    public async Task PendingDisambiguation_IsClearedAfterAnswer_AndDoesNotLeakIntoTheNextSave()
+    {
+        var engine = GetTarget();
+        var room = Repository.GetLocation<MaintenanceRoom>();
+        room.IsNoLongerDark = true;
+        engine.Context.ItemPlacedHere(Repository.GetItem<NastyKnife>());
+        engine.Context.ItemPlacedHere(Repository.GetItem<RustyKnife>());
+        engine.Context.CurrentLocation = room;
+
+        await engine.GetResponse("drop knife");
+        var restored = RoundTrip(engine);
+        await restored.GetResponse("rusty");
+
+        restored.Context.PendingDisambiguation.Should().BeNull("answering the prompt must clear the pending state");
+        restored.SaveGame().Should().NotContain("PossibleResponses",
+            "a resolved prompt must not leak into the next turn's serialized session");
+    }
+
+    [Test]
+    public async Task UnrelatedAnswer_ClearsPendingDisambiguation()
+    {
+        var engine = GetTarget();
+        var room = Repository.GetLocation<MaintenanceRoom>();
+        room.IsNoLongerDark = true;
+        engine.Context.ItemPlacedHere(Repository.GetItem<NastyKnife>());
+        engine.Context.ItemPlacedHere(Repository.GetItem<RustyKnife>());
+        engine.Context.CurrentLocation = room;
+
+        await engine.GetResponse("drop knife");
+        var restored = RoundTrip(engine);
+        await restored.GetResponse("wait"); // abandons the prompt
+
+        restored.Context.PendingDisambiguation.Should().BeNull("abandoning the prompt must clear it too");
+    }
+
+    [Test]
+    public async Task NormalCommand_DoesNotArmAnyPendingState()
+    {
+        var engine = GetTarget();
+        engine.Context.CurrentLocation = Repository.GetLocation<LivingRoom>();
+
+        await engine.GetResponse("take lantern");
+
+        engine.Context.PendingDisambiguation.Should().BeNull();
+        engine.Context.PendingClarificationCommand.Should().BeNull();
+        engine.SaveGame().Should().NotContain("PossibleResponses");
+    }
+
+    [Test]
+    public async Task ItClarification_ArmsAndClearsPendingClarificationCommand()
+    {
+        var engine = GetTarget();
+        engine.Context.CurrentLocation = Repository.GetLocation<LivingRoom>();
+
+        await engine.GetResponse("take it");
+        engine.Context.PendingClarificationCommand.Should().Be("take it");
+
+        var restored = RoundTrip(engine);
+        restored.Context.PendingClarificationCommand.Should().Be("take it", "the clarification must survive the round-trip");
+
+        await restored.GetResponse("lantern");
+        restored.Context.PendingClarificationCommand.Should().BeNull("resolving the clarification clears it");
+    }
+
+    [Test]
+    public async Task Disambiguation_SurvivesTheExactLambdaBase64RoundTrip()
+    {
+        // Faithful reproduction of ZorkOneController's session handling: SaveGame() -> UTF8 -> base64 ->
+        // (DynamoDB) -> base64 decode -> RestoreGame(). Base64 is lossless, so this must behave exactly
+        // like RoundTrip above; included to pin the real transport the bug was reported on.
+        var engine = GetTarget();
+        var room = Repository.GetLocation<MaintenanceRoom>();
+        room.IsNoLongerDark = true;
+        engine.Context.ItemPlacedHere(Repository.GetItem<NastyKnife>());
+        engine.Context.ItemPlacedHere(Repository.GetItem<RustyKnife>());
+        engine.Context.CurrentLocation = room;
+
+        await engine.GetResponse("drop knife");
+
+        var encoded = Convert.ToBase64String(Encoding.UTF8.GetBytes(engine.SaveGame()));
+        var decoded = Encoding.UTF8.GetString(Convert.FromBase64String(encoded));
+
+        var restored = GetTarget();
+        restored.RestoreGame(decoded);
+        var response = await restored.GetResponse("rusty");
+
+        response.Should().Contain("Dropped");
+    }
+}


### PR DESCRIPTION
## Problem

Fixes #472. In the deployed game, a disambiguation question ("Do you mean the kitchen access card or the shuttle access card?") is **unanswerable**: whatever you type next is parsed as a brand-new command instead of resolving the prompt — producing "no effect", a re-prompt, or the notorious movement side effect where answering `kitchen` walks the player toward the Kitchen.

**Root cause:** the deployed game is stateless. Each command is a separate request whose full state travels in the base64 session, and `GameEngine` is rebuilt per request. The pending prompt was armed only in the in-memory `GameEngine._processorInProgress` field, which is **never serialized**. So the answer arrives on a reconstructed engine with `_processorInProgress == null`, falls through to normal parsing, and the disambiguation map is never consulted. The console/single-process build works only because the field survives in memory between turns — which is exactly why a test that skips the save/restore round-trip cannot catch this.

This affects every generic same-noun disambiguation (cards, bedistors, knives, buttons, any two objects sharing a noun) in both Zork and Planetfall, plus the `it`/`them` clarification path, which uses the same mechanism.

## Fix

Mirror the pending prompt into small **serializable descriptors on the `Context`**, which already round-trips inventory/score/flags:

- `IContext.PendingDisambiguation` — a `PendingDisambiguation` snapshot (the accepted-reply map + the command template) for "which one do you mean?".
- `IContext.PendingClarificationCommand` — the command awaiting a noun for the `it`/`them` clarification (e.g. `"take it"`).

The engine now:
1. **Arms** the descriptor alongside `_processorInProgress` when a disambiguation / clarification is raised.
2. **Clears** both descriptors whenever the processor completes or a turn crashes (extending the issue #271 safety-net cleanup), so a resolved prompt never leaks into the next turn.
3. **Rehydrates** `_processorInProgress` from the descriptor in `RestoreGame`, so the next input is routed to the pending prompt before normal parsing.

The save/quit/restore stateful processors deliberately **do not** set a descriptor — the web client handles those via dedicated endpoints — so they continue not to persist, exactly as before.

## TDD

Per the issue's note, a single-process test does not catch this — the field survives in memory — so every new test **serializes + deserializes the game between the prompt and the answer**, mirroring the Lambda save/restore round-trip. All were red before the fix and green after.

- `UnitTests/Engine/DisambiguationPersistenceTests.cs` (14 tests): knife + button round-trips; a plain-noun answer that does not independently resolve; unrelated-answer abandonment; the `it`/`them` clarification round-trip; and white-box checks that the descriptor is armed, serialized into `SaveGame()` (including the exact base64 transport), and cleared without leaking.
- `Planetfall.Tests/DisambiguationPersistenceTests.cs` (8 tests): the reported card family across both the drop path (simple-interaction engine) and `slide card through slot` (multi-noun engine); and the headline movement side effect — answering `kitchen` now resolves the card instead of walking toward the Kitchen.

## Verification

Ran each suite separately (per CLAUDE.md):

- `UnitTests` — 1083 passed, 1 skipped
- `ZorkOne.Tests` — 1781 passed
- `Planetfall.Tests` — 3190 passed

Full solution builds with 0 warnings / 0 errors. (The pre-existing `ValuesControllerTests.TestGet` 404 in the Lambda test projects fails identically on the base branch and is unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lxgd3cPcWab21PhqiZuFeP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lxgd3cPcWab21PhqiZuFeP)_