### PR TITLE
Fix #478: lab uniform pocket capacity fits its two seeded items

### DIFF
--- a/Planetfall.Tests/UniformTests.cs
+++ b/Planetfall.Tests/UniformTests.cs
@@ -1,6 +1,8 @@
 using FluentAssertions;
 using GameEngine;
 using Planetfall.Item.Feinstein;
+using Planetfall.Item.Kalamontee.Admin;
+using Planetfall.Item.Lawanda.Lab;
 using Planetfall.Location.Feinstein;
 using Planetfall.Location.Lawanda.Lab;
 
@@ -155,6 +157,46 @@ public class UniformTests : EngineTestsBase
 
         var response = await target.GetResponse("take paper");
         response.Should().NotContain("Taken");
+    }
+
+    [Test]
+    public async Task LabUniform_TakeCardFromPocket_ThenPutItBack()
+    {
+        // Issue #478: the pocket ships with two size-1 items (teleportation access card and
+        // piece of paper) but capacity must fit both. A container that can't hold its own
+        // starting contents is an invariant violation - after taking the card out, it must
+        // be possible to put it back.
+        var target = GetTarget();
+        StartHere<LabStorage>();
+
+        await target.GetResponse("open pocket");
+        (await target.GetResponse("take card")).Should().Contain("Taken");
+
+        var response = await target.GetResponse("put card in pocket");
+        response.Should().NotContain("There's no room");
+        response.Should().Contain("Done");
+
+        // Both seeded items coexist in the pocket once the card is returned.
+        var pocket = Repository.GetItem<LabUniformPocket>();
+        pocket.Items.Should().Contain(Repository.GetItem<TeleportationAccessCard>());
+        pocket.Items.Should().Contain(Repository.GetItem<PieceOfPaper>());
+    }
+
+    [Test]
+    public void LabUniform_PocketHasRoomForItsSeededContents()
+    {
+        // Guard: the pocket's declared capacity must accommodate both items it starts with.
+        GetTarget();
+        StartHere<LabStorage>();
+
+        var pocket = Repository.GetItem<LabUniformPocket>();
+        var card = Repository.GetItem<TeleportationAccessCard>();
+
+        pocket.Items.Should().HaveCount(2);
+
+        // Remove the card, then confirm the pocket still reports room to take it back.
+        pocket.RemoveItem(card);
+        pocket.HaveRoomForItem(card).Should().BeTrue();
     }
     
     [Test]

--- a/Planetfall/Item/Lawanda/Lab/LabUniformPocket.cs
+++ b/Planetfall/Item/Lawanda/Lab/LabUniformPocket.cs
@@ -7,8 +7,11 @@ internal class LabUniformPocket : OpenAndCloseContainerBase, ICanBeExamined
 {
     public override string[] NounsForMatching => ["pocket", "lab pocket", "lab uniform pocket"];
 
-    protected override int SpaceForItems => 1;
-
+    // The pocket ships with two size-1 items (teleportation access card + piece of paper), so it
+    // must have room for both. Inherit ContainerBase's default capacity of 2 - do NOT override this
+    // to 1 (as the sibling PatrolUniformPocket does; that pocket only seeds a single item). A
+    // capacity of 1 leaves the pocket unable to hold its own starting contents: take either item
+    // out and it can't be put back. See issue #478.
     public override bool IsTransparent => false;
 
     public string ExaminationDescription => ItemListDescription("Lab uniform pocket", null);


### PR DESCRIPTION
## Summary

Fixes #478. The Planetfall lab uniform pocket seeds **two** size-1 items (a teleportation access card and a piece of paper) but capped `SpaceForItems` at **one**. The pocket therefore began in a state it could never return to: take either item out and you couldn't put it back, because the remaining item already filled the single slot ("There's no room.").

`ContainerBase.HaveRoomForItem` is a size-sum check (`Items.Sum(s => s.Size) + item.Size <= SpaceForItems`), so a capacity-1 pocket holding one size-1 item rejects a second — even the very item that was just taken out of it.

## Root cause

`Planetfall/Item/Lawanda/Lab/LabUniformPocket.cs` had an explicit `protected override int SpaceForItems => 1;`. `ContainerBase`'s default is already **2**, so the override is what broke it. The override was copied from the sibling `PatrolUniformPocket`, which correctly uses `1` because it seeds only a *single* item (`IdCard`) — the pattern was copied without accounting for the lab pocket's two items.

## Fix

Remove the `SpaceForItems => 1` override so the pocket inherits `ContainerBase`'s default capacity of 2, with a comment explaining why it must not be re-capped at 1. ZIL ground truth confirms the original pocket holds both items (`comptwo.zil:1657`: *"You discover a small piece of paper and a teleportation access card in the [pocket]"*).

## Testing (TDD)

Added two tests to `Planetfall.Tests/UniformTests.cs`, both **red before** the fix and **green after**:

- `LabUniform_TakeCardFromPocket_ThenPutItBack` — reproduces the bug: open the pocket, take the card, put it back; asserts the response is not "There's no room" and that both seeded items coexist in the pocket afterward.
- `LabUniform_PocketHasRoomForItsSeededContents` — a guard asserting the pocket ships with 2 items and that `HaveRoomForItem` still reports room to re-insert a removed item.

Full `Planetfall.Tests` suite passes (3200 passed, 0 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L5D97kPT45DXFpcGZ6H931

---
_Generated by [Claude Code](https://claude.ai/code/session_01L5D97kPT45DXFpcGZ6H931)_