### PR TITLE
Fix #479: shuttle "station ahead" window view gates on reachable position 23

### DIFF
--- a/Planetfall.Tests/ShuttleTests.cs
+++ b/Planetfall.Tests/ShuttleTests.cs
@@ -75,13 +75,59 @@ public class ShuttleTests : EngineTestsBase
     [Test]
     public async Task Look_WhileCloseToStation_Outbound()
     {
+        // Issue #479: while a car is moving, the approach position (23 -- one short of the
+        // platform at EndOfTunnel 24) shows a distinct "station ahead" window view. The port
+        // previously gated this on TunnelPosition 190/195, values TunnelPosition (0..24) never
+        // reaches, so the view was unreachable dead code. The ZIL ground truth (DESCRIBE-VIEW,
+        // globals.zil) keys off counter 23 while SHUTTLE-MOVING; the landmark table already
+        // uses 23 for the "approaching a brightly lit area" sign.
         var target = GetTarget();
-        StartHere<AlfieControlEast>().TunnelPosition = 190;
+        var controls = StartHere<AlfieControlEast>();
+        controls.TunnelPosition = 23;
+        controls.Speed = 5;
 
         var response = await target.GetResponse("look");
 
         response.Should()
             .Contain("Through the cabin window you can see parallel rails ending at a brightly lit station ahead");
+        response.Should().NotContain("vanishing in the distance");
+    }
+
+    [Test]
+    public async Task Look_ParkedAtApproachPosition_ShowsGenericView()
+    {
+        // Issue #479 faithfulness guard: the original conditions the "station ahead" view on
+        // SHUTTLE-MOVING. A car stopped (Speed 0) at the approach position (23) shows the
+        // generic tunnel view, not "station ahead".
+        var target = GetTarget();
+        var controls = StartHere<AlfieControlEast>();
+        controls.TunnelPosition = 23;
+        controls.Speed = 0;
+
+        var response = await target.GetResponse("look");
+
+        response.Should().Contain("vanishing in the distance");
+        response.Should().NotContain("station ahead");
+    }
+
+    [Test]
+    [TestCase(0)]
+    [TestCase(12)]
+    [TestCase(22)]
+    public async Task Look_MovingBeforeApproachPosition_ShowsGenericView(int position)
+    {
+        // Issue #479 boundary guard: only position 23 flips to the "station ahead" view.
+        // Earlier in-tunnel positions (even while moving) still show the generic view -- this
+        // pins the exact boundary so a future edit can't widen the window.
+        var target = GetTarget();
+        var controls = StartHere<AlfieControlEast>();
+        controls.TunnelPosition = position;
+        controls.Speed = 5;
+
+        var response = await target.GetResponse("look");
+
+        response.Should().Contain("vanishing in the distance");
+        response.Should().NotContain("station ahead");
     }
 
     [Test]

--- a/Planetfall/Location/Shuttle/ShuttleControl.cs
+++ b/Planetfall/Location/Shuttle/ShuttleControl.cs
@@ -24,6 +24,11 @@ public abstract class ShuttleControl<TCabin, TControl> : LocationWithNoStartingI
     protected const int EndOfTunnel = 24;
     protected const int StartOfTunnel = 0;
 
+    // Issue #479: the position, one short of the platform (EndOfTunnel), at which a moving car's
+    // window shows the "station ahead" view. Matches the ZIL DESCRIBE-VIEW check (globals.zil:
+    // SHUTTLE-COUNTER 23) and the "approaching a brightly lit area" landmark below.
+    private const int ApproachingStation = 23;
+
     private static readonly Dictionary<int, string> Landmarks = new()
     {
         { 2, "You pass a sign which says \"Limit 45.\"" },
@@ -76,7 +81,12 @@ public abstract class ShuttleControl<TCabin, TControl> : LocationWithNoStartingI
         TunnelPosition switch
         {
             EndOfTunnel => "a featureless concrete wall. ",
-            190 or 195 => "parallel rails ending at a brightly lit station ahead. ",
+            // Issue #479: only show the "station ahead" view when the moving car is one position
+            // short of the platform. Previously gated on 190/195 -- values TunnelPosition (0..24)
+            // never reaches -- so this view was unreachable dead code. The ZIL conditions the view
+            // on SHUTTLE-MOVING too, so a car parked (Speed == 0) at 23 falls through to the
+            // generic view.
+            ApproachingStation when Speed != 0 => "parallel rails ending at a brightly lit station ahead. ",
             _ => "parallel rails running along the floor of a long tunnel, vanishing in the distance. "
         };
 


### PR DESCRIPTION
## Summary

Fixes #479. While driving a shuttle car, the cabin window is supposed to show a distinct "…ending at a brightly lit station ahead" view one position short of the platform. In the port that view was **unreachable** — it was gated on `TunnelPosition == 190 or 195`, but `TunnelPosition` only ever runs `0..24` (`StartOfTunnel..EndOfTunnel`). So the player always saw the generic "long tunnel, vanishing in the distance" view right up until the car docked (where it flips to "concrete wall"). The `190/195` case was dead code.

## Root cause

`Planetfall/Location/Shuttle/ShuttleControl.cs` — `OutTheWindow` switched on `190 or 195` for the "station ahead" text. `TunnelPosition` starts at `StartOfTunnel = 0`, increments once per `Move()`, and `Arrived()` fires at `EndOfTunnel = 24`, so it never reaches 190/195.

## Fix

Gate the "station ahead" view on the approach position `23` while the car is moving (`Speed != 0`):

- **`23`** matches the ZIL ground truth (`DESCRIBE-VIEW` in `globals.zil` keys off `SHUTTLE-COUNTER 23`) and the port's own landmark table, which already uses `23` for the "approaching a brightly lit area" sign.
- **`Speed != 0`** preserves the original's `SHUTTLE-MOVING` condition: a car parked at 23 falls through to the generic view.

Extracted the magic number into a named `ApproachingStation` constant alongside `EndOfTunnel`/`StartOfTunnel`.

## Testing (TDD)

Per CLAUDE.md, red-before / green-after in `Planetfall.Tests/ShuttleTests.cs`:

- **Repurposed** `Look_WhileCloseToStation_Outbound` — it previously set `TunnelPosition = 190` (exercising the unreachable branch); it now sets position `23` + `Speed = 5` and asserts the "station ahead" view (and *not* the generic one). This test is **red** on the old `190/195` code and **green** after the fix.
- **Added** `Look_ParkedAtApproachPosition_ShowsGenericView` — position 23 with `Speed == 0` shows the generic view (faithfulness to `SHUTTLE-MOVING`).
- **Added** `Look_MovingBeforeApproachPosition_ShowsGenericView` (`TestCase 0/12/22`) — earlier moving positions still show the generic view, pinning the exact boundary.

Existing guards remain green: position 0 outbound (generic view) and position 24 inbound ("concrete wall").

All **3202** tests in `Planetfall.Tests` pass, 0 failures.

## Impact

Low — cosmetic/atmosphere. Restores the approaching-station window view the original provides; no progression effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U7WrzyowXb32NzrSWwCpHj

---
_Generated by [Claude Code](https://claude.ai/code/session_01U7WrzyowXb32NzrSWwCpHj)_