### PR TITLE
Add NuGet package vulnerability CI gate

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,37 @@
+<Project>
+
+    <!--
+      NuGet package vulnerability CI gate.
+
+      .NET's built-in NuGet audit runs during `dotnet restore` and emits a warning whenever a
+      referenced package (direct or, with NuGetAuditMode=all, transitive) has a known vulnerability
+      published in the GitHub Advisory Database via nuget.org:
+
+          NU1901  low severity
+          NU1902  moderate severity
+          NU1903  high severity
+          NU1904  critical severity
+
+      By default these are only warnings, so a vulnerable package does NOT fail the build. This file
+      promotes them to errors so the existing `.NET` CI workflow (which runs `dotnet restore` /
+      `dotnet build`) fails the moment any known-vulnerable package enters the dependency tree.
+
+      NU1900 (unable to reach the audit source) is deliberately left as a warning so a transient
+      nuget.org outage cannot spuriously break the build.
+
+      This is a root Directory.Build.props, so it is imported by every project in the solution
+      automatically. To triage a finding locally, run `dotnet list package` with the vulnerable
+      and include-transitive flags.
+    -->
+    <PropertyGroup>
+        <!-- Audit both direct and transitive dependencies. -->
+        <NuGetAudit>true</NuGetAudit>
+        <NuGetAuditMode>all</NuGetAuditMode>
+        <!-- Report every severity, from low upward. -->
+        <NuGetAuditLevel>low</NuGetAuditLevel>
+        <!-- Fail on any vulnerability finding without turning unrelated compiler warnings into
+             errors (only the NuGet audit codes are promoted). -->
+        <WarningsAsErrors>$(WarningsAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsAsErrors>
+    </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
## What & why

There was no CI gate for NuGet package vulnerabilities. The `.NET` workflow ran `dotnet restore` / `build` / `test`, but .NET's built-in NuGet audit only emits **warnings** (`NU1901`–`NU1904`) for vulnerable packages, so a package with a known advisory would sail through green. There was also no `Directory.Build.props` enabling the audit and no `dependabot.yml`.

This adds a root `Directory.Build.props` that promotes the audit warnings to **build errors**, so the existing CI workflow now fails when any direct or transitive dependency has a known advisory — no new tooling or extra workflow steps required (the gate rides on the `dotnet restore` step CI already runs).

## Changes

- **`Directory.Build.props`** (new, repo root — imported automatically by all 24 projects):
  - `NuGetAudit=true`, `NuGetAuditMode=all` — audit **direct and transitive** dependencies.
  - `NuGetAuditLevel=low` — report every severity, low through critical.
  - `WarningsAsErrors += NU1901;NU1902;NU1903;NU1904` — fail the build on any finding, **without** turning unrelated compiler warnings into errors (only the NuGet audit codes are promoted).
  - `NU1900` (audit source unreachable) is deliberately **left as a warning** so a transient nuget.org outage can't spuriously break the build.

## Severity → warning code mapping

| Code | Severity | Gated? |
|------|----------|--------|
| NU1900 | audit source unreachable | no (stays a warning) |
| NU1901 | low | yes |
| NU1902 | moderate | yes |
| NU1903 | high | yes |
| NU1904 | critical | yes |

## Triage

When the gate trips, CI's restore step names the offending package(s) and codes. To reproduce locally:

```
dotnet list package --vulnerable --include-transitive
```

## Verification note

The `.NET` CI workflow on this PR is the live check — no .NET SDK was available in the authoring environment to run the audit locally. If CI goes red on this PR, that's the gate surfacing a pre-existing advisory (most likely a transitive dependency of the older `Microsoft.NET.Test.Sdk` 15.5.0 / `xunit` 2.4.2 in the two Lambda test projects); the fix in that case is a targeted package bump, which can follow here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KbdsUrNf7PmjaRnSestf9v

---
_Generated by [Claude Code](https://claude.ai/code/session_01KbdsUrNf7PmjaRnSestf9v)_