### PR TITLE
Remove ZorkOne default from Repository game-name helpers (#486)

### DIFF
--- a/GameEngine/Repository.cs
+++ b/GameEngine/Repository.cs
@@ -354,8 +354,14 @@ public static class Repository
     /// <summary>
     /// For unit testing purposes only.
     /// </summary>
+    /// <remarks>
+    /// Issue #486: <paramref name="gameName"/> is required - it is the game assembly to reflect over,
+    /// and <see cref="Repository"/> is engine-level and game-agnostic. A default here would bake one
+    /// specific game into the shared engine and silently load the wrong game's nouns whenever a caller
+    /// omitted it. Callers already have the game name available (e.g. <c>context.Game.GameName</c>).
+    /// </remarks>
     /// <returns></returns>
-    public static string[] GetNouns(string gameName = "ZorkOne")
+    public static string[] GetNouns(string gameName)
     {
         lock (_allNouns)
         {
@@ -379,10 +385,14 @@ public static class Repository
     }
 
     /// <summary>
-    /// For god mode purposes only. 
+    /// For god mode purposes only.
     /// </summary>
+    /// <remarks>
+    /// Issue #486: <paramref name="gameName"/> is required - see <see cref="GetNouns"/>. The engine
+    /// must never default to a specific game's assembly.
+    /// </remarks>
     /// <returns></returns>
-    public static void LoadAllLocations(string gameName = "ZorkOne")
+    public static void LoadAllLocations(string gameName)
     {
         lock (_allLocations)
         {
@@ -410,10 +420,14 @@ public static class Repository
     }
 
     /// <summary>
-    /// For god mode purposes only. 
+    /// For god mode purposes only.
     /// </summary>
+    /// <remarks>
+    /// Issue #486: <paramref name="gameName"/> is required - see <see cref="GetNouns"/>. The engine
+    /// must never default to a specific game's assembly.
+    /// </remarks>
     /// <returns></returns>
-    public static void LoadAllItems(string gameName = "ZorkOne")
+    public static void LoadAllItems(string gameName)
     {
         lock (_allItems)
         {
@@ -466,10 +480,14 @@ public static class Repository
     }
 
     /// <summary>
-    /// For unit testing purposes only. 
+    /// For unit testing purposes only.
     /// </summary>
+    /// <remarks>
+    /// Issue #486: <paramref name="gameName"/> is required - see <see cref="GetNouns"/>. The engine
+    /// must never default to a specific game's assembly.
+    /// </remarks>
     /// <returns></returns>
-    public static string[] GetContainers(string gameName = "ZorkOne")
+    public static string[] GetContainers(string gameName)
     {
         if (_allContainers.Length > 0) return _allContainers;
 

--- a/ZorkOne.Tests/Things/MiscItemTests.cs
+++ b/ZorkOne.Tests/Things/MiscItemTests.cs
@@ -31,7 +31,7 @@ public class MiscItemTests : EngineTestsBase
     {
         var target = GetTarget();
 
-        Repository.LoadAllItems();
+        Repository.LoadAllItems("ZorkOne");
         var item = Repository.GetItem(itemType);
         target.Context.Take(item);
 
@@ -59,7 +59,7 @@ public class MiscItemTests : EngineTestsBase
         var target = GetTarget();
 
         // Use the passed type to get the item
-        Repository.LoadAllItems();
+        Repository.LoadAllItems("ZorkOne");
         var item = Repository.GetItem(itemType)!;
         target.Context.CurrentLocation.ItemPlacedHere(item);
 
@@ -86,7 +86,7 @@ public class MiscItemTests : EngineTestsBase
     {
         var target = GetTarget();
 
-        Repository.LoadAllItems();
+        Repository.LoadAllItems("ZorkOne");
         var item = Repository.GetItem(itemType)!;
         target.Context.ItemPlacedHere(item);
         await target.GetResponse($"drop {itemType}");
@@ -110,7 +110,7 @@ public class MiscItemTests : EngineTestsBase
     {
         var target = GetTarget();
 
-        Repository.LoadAllItems();
+        Repository.LoadAllItems("ZorkOne");
         var item = Repository.GetItem(itemType)!;
         target.Context.CurrentLocation.ItemPlacedHere(item);
         if (!string.IsNullOrEmpty(precondition))


### PR DESCRIPTION
## What

`Repository` is the engine's central, game-agnostic store, but four of its static helpers baked a Zork One assembly name in as the **default** game name:

```csharp
// GameEngine/Repository.cs — before
public static string[] GetNouns(string gameName = "ZorkOne")
public static void     LoadAllLocations(string gameName = "ZorkOne")
public static void     LoadAllItems(string gameName = "ZorkOne")
public static string[] GetContainers(string gameName = "ZorkOne")
```

`Assembly.Load(gameName)` then reflects over that game's assembly to enumerate its item/location types. With `"ZorkOne"` as the default, any caller that omitted the argument would silently load Zork One's roster **regardless of which game was actually running** — a game concept leaking into the shared engine (issue #486).

## Fix

Remove the defaults and require an explicit `gameName` on all four helpers. This is a compile-time change: an omitted argument is now a build error, so no future caller can silently fall back to Zork One. Added `<remarks>` on each explaining why the parameter is required.

Every real caller already had the game name on hand, so no runtime behavior changes:

| Caller | Argument passed |
|---|---|
| `GodModeProcessor` (`Go`/`Take`/`Kill`) | `context.Game.GameName` |
| `RepositoryTests` | `"Planetfall"` |
| `TestParser` | its own `gameName` ctor arg |
| `MiscItemTests` (Zork I tests) | now `"ZorkOne"` explicitly *(was the only default-reliant caller)* |

## Why `gameName` exists in the Repository at all

These four are the only Repository methods that take a `gameName`, and it maps to a game's **compiled assembly name** (`"ZorkOne"`, `"Planetfall"`, `"ZorkTwo"`, `"EscapeRoom"` — see each game's `IInfocomGame.GameName`). They use `Assembly.Load(gameName)` + reflection to discover *all* `ItemBase`/`LocationBase`/`ContainerBase` types a game declares — something the normal lazy, per-type `GetItem<T>()`/`GetLocation<T>()` path can't do because it only knows a type once someone asks for it by name. Two features need the full roster:

- **God mode** (`GodModeProcessor`): `god mode take <item>` / `go <place>` must resolve *any* item/room by noun, even ones never touched this session, so it bulk-loads the whole assembly first.
- **The test parser** (`TestParser`): builds its noun/container dictionaries from every item a game defines, so walkthrough tests can parse commands without the live AI parser.

So the name is a legitimate engine input — it just must never have a game-specific *default*.

## Testing

Compile-time cleanup with no behavioral change; the compiler now enforces that every call site supplies a game name. The "game name is honored, not defaulted" behavior stays covered by the existing `RepositoryTests` (`GetNouns`/`GetContainers`/`LoadAllItems`/`LoadAllLocations` with `"Planetfall"`) and `MiscItemTests` (`LoadAllItems("ZorkOne")`). *Note: the .NET SDK is unavailable in this environment, so verification was by exhaustive static audit of all 14 call sites rather than a local build.*

Closes #486

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XDyuN9oH892rGo8FEcAkBp)_