### PR TITLE
Move Planetfall companion-chat classes out of shared ChatLambda (#485)

### DIFF
--- a/IntegrationTests/ChatWithBlatherTests.cs
+++ b/IntegrationTests/ChatWithBlatherTests.cs
@@ -1,4 +1,5 @@
 using ChatLambda;
+using Planetfall.AI;
 
 namespace IntegrationTests;
 

--- a/IntegrationTests/ChatWithFloydTests.cs
+++ b/IntegrationTests/ChatWithFloydTests.cs
@@ -1,4 +1,5 @@
 ﻿using ChatLambda;
+using Planetfall.AI;
 
 namespace IntegrationTests;
 

--- a/Planetfall.Tests/FloydTests.cs
+++ b/Planetfall.Tests/FloydTests.cs
@@ -7,6 +7,7 @@ using Model.Intent;
 using Model.Interface;
 using Model.Item;
 using Moq;
+using Planetfall.AI;
 using Planetfall.Item;
 using Planetfall.Item.Feinstein;
 using Planetfall.Item.Kalamontee.Admin;

--- a/Planetfall.Tests/NamelessConversationRoutingTests.cs
+++ b/Planetfall.Tests/NamelessConversationRoutingTests.cs
@@ -1,6 +1,7 @@
 using ChatLambda;
 using FluentAssertions;
 using Moq;
+using Planetfall.AI;
 using Planetfall.Item.Kalamontee.Mech.FloydPart;
 using Planetfall.Location.Kalamontee.Mech;
 

--- a/Planetfall.Tests/Walkthrough/WalkthroughTestBase.cs
+++ b/Planetfall.Tests/Walkthrough/WalkthroughTestBase.cs
@@ -7,6 +7,7 @@ using GameEngine;
 using JetBrains.Annotations;
 using Model.Interface;
 using Moq;
+using Planetfall.AI;
 using Planetfall.Item.Feinstein;
 using Planetfall.Item.Kalamontee.Mech;
 using Planetfall.Item.Kalamontee.Mech.FloydPart;

--- a/Planetfall/AI/ChatWithAmbassador.cs
+++ b/Planetfall/AI/ChatWithAmbassador.cs
@@ -1,6 +1,7 @@
 using Amazon.Lambda;
+using ChatLambda;
 
-namespace ChatLambda;
+namespace Planetfall.AI;
 
 public class ChatWithAmbassador(IAmazonLambda? lambdaClient) : ChatWithCompanion(lambdaClient)
 {

--- a/Planetfall/AI/ChatWithBlather.cs
+++ b/Planetfall/AI/ChatWithBlather.cs
@@ -1,6 +1,7 @@
 using Amazon.Lambda;
+using ChatLambda;
 
-namespace ChatLambda;
+namespace Planetfall.AI;
 
 public class ChatWithBlather(IAmazonLambda? lambdaClient) : ChatWithCompanion(lambdaClient)
 {

--- a/Planetfall/AI/ChatWithFloyd.cs
+++ b/Planetfall/AI/ChatWithFloyd.cs
@@ -1,6 +1,7 @@
 using Amazon.Lambda;
+using ChatLambda;
 
-namespace ChatLambda;
+namespace Planetfall.AI;
 
 public class ChatWithFloyd(IAmazonLambda? lambdaClient) : ChatWithCompanion(lambdaClient), IChatWithFloyd
 {

--- a/Planetfall/AI/IChatWithFloyd.cs
+++ b/Planetfall/AI/IChatWithFloyd.cs
@@ -1,4 +1,6 @@
-namespace ChatLambda;
+using ChatLambda;
+
+namespace Planetfall.AI;
 
 /// <summary>
 /// Interface for communicating with Floyd's AI Lambda function.

--- a/Planetfall/Item/Feinstein/Ambassador.cs
+++ b/Planetfall/Item/Feinstein/Ambassador.cs
@@ -2,6 +2,7 @@
 using Model.AIGeneration;
 using Model.Item;
 using Newtonsoft.Json;
+using Planetfall.AI;
 
 namespace Planetfall.Item.Feinstein;
 

--- a/Planetfall/Item/Feinstein/Blather.cs
+++ b/Planetfall/Item/Feinstein/Blather.cs
@@ -1,5 +1,6 @@
 ﻿using ChatLambda;
 using Model.AIGeneration;
+using Planetfall.AI;
 using Planetfall.Command;
 
 namespace Planetfall.Item.Feinstein;

--- a/Planetfall/Item/Kalamontee/Mech/FloydPart/Floyd.cs
+++ b/Planetfall/Item/Kalamontee/Mech/FloydPart/Floyd.cs
@@ -2,6 +2,7 @@ using ChatLambda;
 using GameEngine.IntentEngine;
 using Model.AIGeneration;
 using Newtonsoft.Json;
+using Planetfall.AI;
 using Planetfall.Item.Kalamontee.Admin;
 using Planetfall.Item.Lawanda;
 using Planetfall.Location;

--- a/Planetfall/Planetfall.csproj
+++ b/Planetfall/Planetfall.csproj
@@ -23,9 +23,13 @@
       disk). PlanetfallHintProvider reads these resources and assembles the bundle at runtime — the
       concatenation logic lives in C#, not here. An explicit include means a missing/renamed walkthrough
       fails the build loudly rather than silently degrading the hints.
+
+      AI/ is excluded: it holds the companion-chat Lambda clients (ChatWithFloyd/Blather/Ambassador),
+      which are plumbing, not game knowledge. They previously lived in the ChatLambda project and were
+      never part of the hint bundle, so excluding them keeps the bundle byte-identical after the move.
     -->
     <ItemGroup>
-        <EmbeddedResource Include="**/*.cs" Exclude="obj/**;bin/**" />
+        <EmbeddedResource Include="**/*.cs" Exclude="obj/**;bin/**;AI/**" />
         <EmbeddedResource Include="../Planetfall.Tests/Walkthrough/WalkthroughTestOne.cs" />
     </ItemGroup>
 

--- a/UnitTests/LambdaChat/ChatWithFloydTests.cs
+++ b/UnitTests/LambdaChat/ChatWithFloydTests.cs
@@ -2,6 +2,7 @@ using System.Text;
 using Amazon.Lambda;
 using Amazon.Lambda.Model;
 using ChatLambda;
+using Planetfall.AI;
 
 namespace UnitTests.LambdaChat;
 


### PR DESCRIPTION
Fixes #485.

## What

`ChatLambda` is the shared companion-chat layer (referenced by `GameEngine`). Its base `ChatWithCompanion` is game-agnostic — good — but four Planetfall-specific types had leaked into it:

- `ChatWithFloyd.cs` (`AssistantName => "floyd"`)
- `ChatWithBlather.cs` (`AssistantName => "blather"`)
- `ChatWithAmbassador.cs` (`AssistantName => "ambassador"`)
- `IChatWithFloyd.cs`

Floyd, Blather, and the Ambassador are Planetfall characters, and all four types are referenced **only** by `Planetfall` and its test projects.

This PR takes option 1 from the issue: move the three subclasses + the interface into the `Planetfall` project, under a new `Planetfall.AI` namespace. The generic base `ChatWithCompanion` and its `CompanionResponse` / `CompanionMetadata` records stay in `ChatLambda`, so consumers keep `using ChatLambda;` and add `using Planetfall.AI;`.

I chose option 1 over option 2 (drop the subclasses, pass `assistantName` as a constructor arg) deliberately: option 2 would delete the `IChatWithFloyd` seam that Floyd's tests mock, change method signatures, and touch far more behavior — not a pure refactor. Option 1 keeps every class body identical.

## Changes

- **Moved** (git-detected renames, bodies unchanged): `ChatWith{Floyd,Blather,Ambassador}.cs` and `IChatWithFloyd.cs` from `ChatLambda/` → `Planetfall/AI/`, namespace `ChatLambda` → `Planetfall.AI`, plus a `using ChatLambda;` for the base type and the response records.
- **Consumers** (`Floyd.cs`, `Blather.cs`, `Ambassador.cs`) and **tests** (`UnitTests/LambdaChat/ChatWithFloydTests.cs`, `IntegrationTests/ChatWith{Floyd,Blather}Tests.cs`, `Planetfall.Tests/{FloydTests,NamelessConversationRoutingTests,Walkthrough/WalkthroughTestBase}.cs`): added `using Planetfall.AI;`.
- **`Planetfall.csproj`**: excluded the new `AI/` folder from the `**/*.cs` hint-knowledge embed.

## Why it's a pure refactor (no behavior change)

- Class bodies, method names, and the `AssistantName` constants are untouched. The only edits to the moved files are the namespace line and one `using`.
- The `AI/` folder is excluded from the `PlanetfallHintProvider` embed. Those files were never part of the hint bundle when they lived in `ChatLambda`, so excluding them keeps the assembled bundle **byte-identical** — the AI hint input does not change.
- The `Floyd-...` Lambda `FunctionName` constant in `ChatWithCompanion` was left exactly as-is (the issue's secondary note about injecting it is out of scope for a zero-behavior-change refactor).

## Testing

- Full solution builds with **0 errors** (pre-existing nullable warnings in `MicrobeTests.cs` only).
- `UnitTests`: **1083 passed**, 1 skipped (pre-existing `[Explicit]`).
- `Planetfall.Tests`: **3207 passed**.
- `IntegrationTests` (`[Explicit]`, AWS-gated) compiles as part of the full build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SSrjFiBTE1Etpdxkg3ZQoe

---
_Generated by [Claude Code](https://claude.ai/code/session_01SSrjFiBTE1Etpdxkg3ZQoe)_