### PR TITLE
Move Planetfall-specific FloydAfterSaveGameRequest out of shared Model (#483)

### DIFF
--- a/Planetfall/Item/Kalamontee/Mech/FloydPart/FloydAfterSaveGameRequest.cs
+++ b/Planetfall/Item/Kalamontee/Mech/FloydPart/FloydAfterSaveGameRequest.cs
@@ -1,4 +1,6 @@
-namespace Model.AIGeneration.Requests;
+using Model.AIGeneration.Requests;
+
+namespace Planetfall.Item.Kalamontee.Mech.FloydPart;
 
 public class FloydAfterSaveGameRequest : Request
 {


### PR DESCRIPTION
## Summary

Fixes #483. Pure refactor — **no functionality change**.

`FloydAfterSaveGameRequest` is a Floyd-only (Planetfall) AI prompt class that lived in the game-agnostic `Model` library shared by every game and the engine. Its sole consumer is `PlanetfallContext`, so this relocates it into the `Planetfall` project alongside the rest of Floyd's code.

- **From:** `Model/AIGeneration/Requests/FloydAfterSaveGameRequest.cs`
- **To:** `Planetfall/Item/Kalamontee/Mech/FloydPart/FloydAfterSaveGameRequest.cs` (next to `FloydPrompts.cs` and Floyd's other files)

The generic sibling `AfterSaveGameRequest` correctly stays in `Model`.

## What changed

The prompt string is byte-for-byte unchanged (git reports a 97% rename). The only edits:
- namespace `Model.AIGeneration.Requests` → `Planetfall.Item.Kalamontee.Mech.FloydPart`
- added `using Model.AIGeneration.Requests;` so the `Request` base class stays in scope

No consumer edits were needed — `PlanetfallContext` already imported both `Planetfall.Item.Kalamontee.Mech.FloydPart` (it uses `Floyd`) and `Model.AIGeneration.Requests` (for the `Request?` return type).

## Verification

- Full solution `dotnet build` succeeds with **0 errors** (the 4 warnings are pre-existing in `MicrobeTests.cs`, untouched here).
- `grep` confirms no other references to the class — no tests or Lambdas pointed at it.

No test was added: per CLAUDE.md, TDD is mandatory for *bug fixes*; this is an explicit refactor with zero behavior change, and the whole solution (including all test projects) compiling against the moved type is the proof nothing broke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)