### PR TITLE
Fix Floyd Bio-Lab sacrifice unwinnable in prod (#493) + serialization-state guard

### DIFF
--- a/Planetfall.Tests/BioLockEastTests.cs
+++ b/Planetfall.Tests/BioLockEastTests.cs
@@ -433,6 +433,77 @@ public class BioLockEastTests : EngineTestsBase
     }
 
     [Test]
+    public async Task AbandoningSequence_ByWalkingAway_ThenReturning_DoesNotSpuriouslyKillThePlayer()
+    {
+        // Issue #493 review follow-up: OnLeaveLocation releases Floyd (IsAwayOnScriptedSequence=false) when
+        // the player abandons the sequence mid-rush, but it left LabSequenceState frozen at
+        // FloydRushedInNeedToCloseDoor. Floyd follows the player back out, but the moment the player walks
+        // back into Bio Lock East the actor is re-registered and resumes that frozen state, firing the
+        // "you failed to close the door" death - with Floyd standing right next to them. Abandoning must
+        // reset the sequence so a later re-entry is safe.
+        var target = GetTarget();
+        var floyd = GetItem<Floyd>();
+        floyd.IsOn = true;
+        floyd.TurnOnCountdown = 0;
+        floyd.HasEverBeenOn = true;
+        var mockChooser = new Mock<IRandomChooser>();
+        mockChooser.Setup(r => r.RollDiceSuccess(5)).Returns(false); // deterministic: always the "follow" branch
+        floyd.Chooser = mockChooser.Object;
+        var bioLockEast = StartHere<BioLockEast>();
+        bioLockEast.ItemPlacedHere(floyd);
+        bioLockEast.StateMachine.HasWaitedOneTurnInBioLockEast = true;
+        bioLockEast.StateMachine.FloydHasSaidNeedToGetCard = true;
+        target.Context.RegisterActor(floyd);
+        target.Context.RegisterActor(bioLockEast);
+
+        await target.GetResponse("open door"); // Floyd rushes into the lab
+
+        await target.GetResponse("west"); // abandon the sequence
+        bioLockEast.StateMachine.LabSequenceState.Should().Be(FloydLabSequenceState.NotStarted,
+            "abandoning the sequence must reset it, not leave it frozen mid-rush");
+
+        var returnResponse = await target.GetResponse("east"); // walk back in
+        returnResponse.Should().NotContain("You have died");
+        returnResponse.Should().NotContain(FloydConstants.BiologicalNightmaresDeath);
+
+        var waitResponse = await target.GetResponse("wait"); // a further turn is still safe
+        waitResponse.Should().NotContain("You have died");
+    }
+
+    [Test]
+    public async Task AfterSacrificeCompletes_ReenteringRoom_DeadFloydDoesNotNagToOpenTheDoor()
+    {
+        // Issue #493 review follow-up: EndSequence marks Floyd dead and lays his body back in this room but
+        // leaves IsOn true, so IsHereAndIsOn stays true for the corpse. With the leftover
+        // FloydHasSaidNeedToGetCard flag and a zero door-open counter, re-entering the room made
+        // HandleTurnAction fall into the "waiting for door open" branch - the dead robot cheerfully asking
+        // the player to open the door again. Once the sequence is Completed the actor must stay silent.
+        var target = GetTarget();
+        var floyd = GetItem<Floyd>();
+        floyd.IsOn = true;
+        var bioLockEast = StartHere<BioLockEast>();
+        bioLockEast.ItemPlacedHere(floyd);
+        bioLockEast.StateMachine.HasWaitedOneTurnInBioLockEast = true;
+        bioLockEast.StateMachine.FloydHasSaidNeedToGetCard = true;
+        bioLockEast.StateMachine.LabSequenceState = FloydLabSequenceState.DoorReopenedNeedToCloseAgain;
+        var door = GetItem<BioLockInnerDoor>();
+        door.IsOpen = true;
+        target.Context.RegisterActor(bioLockEast);
+
+        var complete = await target.GetResponse("close door"); // completes the sacrifice
+        complete.Should().Contain("Floyd staggers to the ground");
+        bioLockEast.StateMachine.LabSequenceState.Should().Be(FloydLabSequenceState.Completed);
+
+        await target.GetResponse("west"); // leave
+        var returnResponse = await target.GetResponse("east"); // and come back
+        var waitResponse = await target.GetResponse("wait");
+
+        returnResponse.Should().NotContain(FloydConstants.OpenTheDoor);
+        waitResponse.Should().NotContain(FloydConstants.OpenTheDoor);
+        waitResponse.Should().NotContain(FloydConstants.Sulk);
+    }
+
+    [Test]
     public async Task FloydFighting_Turn1_ShouldShowInTheLabTwo()
     {
         var target = GetTarget();

--- a/Planetfall.Tests/BioLockEastTests.cs
+++ b/Planetfall.Tests/BioLockEastTests.cs
@@ -471,6 +471,45 @@ public class BioLockEastTests : EngineTestsBase
     }
 
     [Test]
+    public async Task AbandoningSequence_ByWalkingAway_ThenReturning_SacrificeCanBeRestarted()
+    {
+        // Issue #493 review follow-up: abandoning must restore the true pre-sequence state, which includes
+        // CLOSING the inner door Floyd rushed through. If the door is left open, returning leaves Floyd
+        // nagging "open the door" while it is already open - and re-opening an open door is a no-op
+        // ("It is already open.") that never re-fires HandleDoorOpening - so the obvious recovery
+        // ("open door") does nothing and the sacrifice can only be restarted via a non-obvious close/open.
+        var target = GetTarget();
+        var floyd = GetItem<Floyd>();
+        floyd.IsOn = true;
+        floyd.TurnOnCountdown = 0;
+        floyd.HasEverBeenOn = true;
+        var mockChooser = new Mock<IRandomChooser>();
+        mockChooser.Setup(r => r.RollDiceSuccess(5)).Returns(false); // deterministic: always the "follow" branch
+        floyd.Chooser = mockChooser.Object;
+        var bioLockEast = StartHere<BioLockEast>();
+        bioLockEast.ItemPlacedHere(floyd);
+        bioLockEast.StateMachine.HasWaitedOneTurnInBioLockEast = true;
+        bioLockEast.StateMachine.FloydHasSaidNeedToGetCard = true;
+        target.Context.RegisterActor(floyd);
+        target.Context.RegisterActor(bioLockEast);
+
+        await target.GetResponse("open door"); // Floyd rushes into the lab
+        await target.GetResponse("west"); // abandon the sequence
+
+        // The inner door must be closed again - the reset restores the real pre-sequence state.
+        GetItem<BioLockInnerDoor>().IsOpen.Should()
+            .BeFalse("abandoning must close the door Floyd rushed through, not leave a 'NotStarted + open' state");
+
+        await target.GetResponse("east"); // walk back in
+
+        // The obvious recovery must work: 'open door' restarts the whole sacrifice from the top.
+        var restart = await target.GetResponse("open door");
+        restart.Should().Contain(FloydConstants.InTheLabOne);
+        restart.Should().NotContain("already open");
+        bioLockEast.StateMachine.LabSequenceState.Should().Be(FloydLabSequenceState.FloydRushedInNeedToCloseDoor);
+    }
+
+    [Test]
     public async Task AfterSacrificeCompletes_ReenteringRoom_DeadFloydDoesNotNagToOpenTheDoor()
     {
         // Issue #493 review follow-up: EndSequence marks Floyd dead and lays his body back in this room but

--- a/Planetfall.Tests/FloydSacrificePersistenceTests.cs
+++ b/Planetfall.Tests/FloydSacrificePersistenceTests.cs
@@ -1,0 +1,183 @@
+using FluentAssertions;
+using GameEngine;
+using Planetfall.Item.Kalamontee.Mech.FloydPart;
+using Planetfall.Item.Lawanda.Lab;
+using Planetfall.Location.Lawanda;
+using Planetfall.Location.Lawanda.Lab;
+using static Planetfall.Location.Lawanda.Lab.BioLockStateMachineManager;
+
+namespace Planetfall.Tests;
+
+/// <summary>
+///     Issue #493 (same player-visible failure as closed #365 / AB-052). Floyd's Bio-Lab sacrifice — the
+///     only way to obtain the miniaturization access card that gates Station 384 — cannot be performed in
+///     the deployed (stateless) game. The whole sequence's state lives in <c>BioLockEast.StateMachine</c>,
+///     which was a get-only property. The session serializer deliberately drops read-only properties
+///     (<c>DoNotSerializeReadOnlyPropertiesResolver</c>), so the state machine was never written to the
+///     base64 session and re-initialised to a fresh <c>new()</c> on every turn: Floyd never offered the
+///     plan and opening the inner door was always an instant "wrong time" death.
+///
+///     This is the same class of bug fixed in #472 (disambiguation state that lived only in memory). Like
+///     those tests, every test here serializes + deserializes the game between turns, mirroring the Lambda
+///     save/restore round-trip. A single-process test passes with or without the fix — the object simply
+///     survives in memory between turns in-process — so only a round-tripping test can prove it.
+/// </summary>
+public class FloydSacrificePersistenceTests : EngineTestsBase
+{
+    private GameEngine<PlanetfallGame, PlanetfallContext> RoundTrip(
+        GameEngine<PlanetfallGame, PlanetfallContext> engine)
+    {
+        var saved = engine.SaveGame();
+        var restored = GetTarget();
+        restored.RestoreGame(saved);
+        return restored;
+    }
+
+    [Test]
+    public void StateMachine_Fields_SurviveSaveRestore()
+    {
+        var engine = GetTarget();
+        var bioLockEast = StartHere<BioLockEast>();
+        bioLockEast.StateMachine.HasWaitedOneTurnInBioLockEast = true;
+        bioLockEast.StateMachine.FloydHasSaidNeedToGetCard = true;
+        bioLockEast.StateMachine.FloydWaitingForDoorOpenCount = 3;
+        bioLockEast.StateMachine.LabSequenceState = FloydLabSequenceState.DoorClosedFloydFighting;
+        bioLockEast.StateMachine.FloydFightingTurnCount = 1;
+
+        RoundTrip(engine);
+
+        // Before the fix the get-only StateMachine property was dropped by the serializer, so every one
+        // of these reset to its default on restore.
+        var machine = Repository.GetLocation<BioLockEast>().StateMachine;
+        machine.HasWaitedOneTurnInBioLockEast.Should().BeTrue();
+        machine.FloydHasSaidNeedToGetCard.Should().BeTrue();
+        machine.FloydWaitingForDoorOpenCount.Should().Be(3);
+        machine.LabSequenceState.Should().Be(FloydLabSequenceState.DoorClosedFloydFighting);
+        machine.FloydFightingTurnCount.Should().Be(1);
+    }
+
+    [Test]
+    public async Task NeedToGetCard_FiresAfterConcern_AcrossSaveRestore()
+    {
+        var engine = GetTarget();
+        var floyd = GetItem<Floyd>();
+        floyd.IsOn = true;
+        var bioLockEast = StartHere<BioLockEast>();
+        bioLockEast.ItemPlacedHere(floyd);
+        bioLockEast.StateMachine.HasWaitedOneTurnInBioLockEast = true; // Skip the one-turn delay
+        engine.Context.RegisterActor(bioLockEast);
+        GetLocation<ComputerRoom>().FloydHasExpressedConcern = true;
+
+        // The player saved after Floyd expressed concern and reached the window; restore, then wait.
+        var restored = RoundTrip(engine);
+        var response = await restored.GetResponse("wait");
+
+        // Before the fix, HasWaitedOneTurnInBioLockEast reset to false every turn, so the state machine
+        // returned on the "first-turn is silent" branch forever and the plan dialogue never appeared.
+        response.Should().Contain(FloydConstants.NeedToGetCard);
+    }
+
+    [Test]
+    public async Task OpenDoor_WhenFloydReady_StartsSequence_AcrossSaveRestore()
+    {
+        var engine = GetTarget();
+        var floyd = GetItem<Floyd>();
+        floyd.IsOn = true;
+        var bioLockEast = StartHere<BioLockEast>();
+        bioLockEast.ItemPlacedHere(floyd);
+        bioLockEast.StateMachine.FloydHasSaidNeedToGetCard = true;
+        engine.Context.RegisterActor(bioLockEast);
+
+        var restored = RoundTrip(engine);
+        var response = await restored.GetResponse("open door");
+
+        // Before the fix FloydHasSaidNeedToGetCard reset to false, so isFloydReady was always false and
+        // opening the inner door hit the fallback "wrong time" branch — instant death — instead of
+        // starting the sacrifice.
+        response.Should().Contain(FloydConstants.InTheLabOne);
+        response.Should().NotContain("devour you");
+        Repository.GetLocation<BioLockEast>().StateMachine.LabSequenceState
+            .Should().Be(FloydLabSequenceState.FloydRushedInNeedToCloseDoor);
+    }
+
+    [Test]
+    public async Task FullSacrificeChoreography_CompletesAcrossSaveRestore()
+    {
+        var engine = GetTarget();
+        var floyd = GetItem<Floyd>();
+        floyd.IsOn = true;
+        var bioLockEast = StartHere<BioLockEast>();
+        bioLockEast.ItemPlacedHere(floyd);
+        bioLockEast.StateMachine.HasWaitedOneTurnInBioLockEast = true; // Skip the one-turn delay
+        bioLockEast.StateMachine.FloydHasSaidNeedToGetCard = true;
+        engine.Context.RegisterActor(bioLockEast);
+
+        // open door -> Floyd rushes in
+        engine = RoundTrip(engine);
+        var open = await engine.GetResponse("open door");
+        open.Should().Contain(FloydConstants.InTheLabOne);
+
+        // close door -> Floyd fighting behind the door
+        engine = RoundTrip(engine);
+        var close = await engine.GetResponse("close door");
+        close.Should().Contain("And not a moment too soon!");
+
+        // wait -> Floyd knocks (InTheLabThree), state advances to NeedToReopenDoor
+        engine = RoundTrip(engine);
+        await engine.GetResponse("wait");
+
+        // open door -> Floyd stumbles back with the card
+        engine = RoundTrip(engine);
+        var reopen = await engine.GetResponse("open door");
+        reopen.Should().Contain(FloydConstants.FloydReturnsWithCard);
+
+        // close door -> sacrifice completes: body + card placed, +2 awarded
+        engine = RoundTrip(engine);
+        var final = await engine.GetResponse("close door");
+
+        final.Should().Contain("Floyd staggers to the ground");
+
+        var restoredBioLockEast = Repository.GetLocation<BioLockEast>();
+        restoredBioLockEast.StateMachine.LabSequenceState.Should().Be(FloydLabSequenceState.Completed);
+
+        var miniCard = Repository.GetItem<MiniaturizationAccessCard>();
+        miniCard.CurrentLocation.Should().Be(restoredBioLockEast);
+        Repository.GetItem<Floyd>().HasDied.Should().BeTrue();
+        Repository.GetItem<Floyd>().CurrentLocation.Should().Be(restoredBioLockEast);
+        engine.Context.Score.Should().Be(2);
+    }
+
+    [Test]
+    public async Task AfterSacrifice_DeadFloydStaysSilentOnReentry_AcrossSaveRestore()
+    {
+        // Issue #493 review follow-up: once the sacrifice is Completed, leaving and walking back into Bio
+        // Lock East must not make Floyd's corpse ask you to open the door again. The Completed state (and
+        // the guard that silences the actor) has to survive the stateless save/restore boundary, so this
+        // exercises the exact deployed path: round-trip the game, leave, round-trip, return.
+        var engine = GetTarget();
+        var floyd = GetItem<Floyd>();
+        floyd.IsOn = true;
+        var bioLockEast = StartHere<BioLockEast>();
+        bioLockEast.ItemPlacedHere(floyd);
+        bioLockEast.StateMachine.HasWaitedOneTurnInBioLockEast = true;
+        bioLockEast.StateMachine.FloydHasSaidNeedToGetCard = true;
+        bioLockEast.StateMachine.LabSequenceState = FloydLabSequenceState.DoorReopenedNeedToCloseAgain;
+        GetItem<BioLockInnerDoor>().IsOpen = true;
+        engine.Context.RegisterActor(bioLockEast);
+
+        var complete = await engine.GetResponse("close door"); // completes the sacrifice
+        complete.Should().Contain("Floyd staggers to the ground");
+
+        engine = RoundTrip(engine);
+        await engine.GetResponse("west"); // leave
+        engine = RoundTrip(engine);
+        var back = await engine.GetResponse("east"); // and come back
+        var wait = await engine.GetResponse("wait");
+
+        back.Should().NotContain(FloydConstants.OpenTheDoor);
+        wait.Should().NotContain(FloydConstants.OpenTheDoor);
+        wait.Should().NotContain(FloydConstants.Sulk);
+        Repository.GetLocation<BioLockEast>().StateMachine.LabSequenceState
+            .Should().Be(FloydLabSequenceState.Completed);
+    }
+}

--- a/Planetfall/Item/Lawanda/MiniaturizationSlot.cs
+++ b/Planetfall/Item/Lawanda/MiniaturizationSlot.cs
@@ -7,8 +7,8 @@ namespace Planetfall.Item.Lawanda;
 
 internal class MiniaturizationSlot : SlotBase<MiniaturizationAccessCard, MiniaturizationSlot>
 {
-    public override string[] NounsForMatching { get; }
-        = ["miniaturization slot", "slot", "miniaturization card slot"];
+    public override string[] NounsForMatching =>
+        ["miniaturization slot", "slot", "miniaturization card slot"];
 
     protected override InteractionResult OnSuccessfulSlide(IContext context, string? afterMessage)
     {

--- a/Planetfall/Item/TeleportationSlot.cs
+++ b/Planetfall/Item/TeleportationSlot.cs
@@ -17,9 +17,10 @@ namespace Planetfall.Item;
 internal class TeleportationSlot<TBooth> : SlotBase<TeleportationAccessCard, TeleportationSlot<TBooth>>
     where TBooth : BoothBase, ILocation, new()
 {
-    public override string[] NounsForMatching { get; }
-    = ["teleportation slot", "slot", "teleportation card slot"];
-    
+    public override string[] NounsForMatching =>
+        ["teleportation slot", "slot", "teleportation card slot"];
+
+
     protected override InteractionResult OnSuccessfulSlide(IContext context, string? afterMessage)
     {
         // Activate the booth AND start its 30-turn expiry countdown (issue #399). Previously this only

--- a/Planetfall/Item/TeleportationSlot.cs
+++ b/Planetfall/Item/TeleportationSlot.cs
@@ -20,7 +20,6 @@ internal class TeleportationSlot<TBooth> : SlotBase<TeleportationAccessCard, Tel
     public override string[] NounsForMatching =>
         ["teleportation slot", "slot", "teleportation card slot"];
 
-
     protected override InteractionResult OnSuccessfulSlide(IContext context, string? afterMessage)
     {
         // Activate the booth AND start its 30-turn expiry countdown (issue #399). Previously this only

--- a/Planetfall/Location/Lawanda/Lab/BioLockEast.cs
+++ b/Planetfall/Location/Lawanda/Lab/BioLockEast.cs
@@ -10,7 +10,14 @@ internal class BioLockEast : LocationBase, ITurnBasedActor, IFloydDoesNotTalkHer
 {
     public override string Name => "Bio Lock East";
 
-    public BioLockStateMachineManager StateMachine { get; } = new();
+    // Issue #493: this MUST have a setter. The deployed game is stateless — each turn is a separate
+    // request whose full state travels in the base64 session — and the session serializer deliberately
+    // drops read-only properties (GameEngine.DoNotSerializeReadOnlyPropertiesResolver). As a get-only
+    // property, the entire Bio-Lab sacrifice state machine was never written to the session and reset to
+    // a fresh new() every turn, so Floyd never offered the plan and opening the inner door was always an
+    // instant "wrong time" death — making the mini card (and thus the game) unreachable in production.
+    // A setter lets it round-trip like every other writable state object (cf. the #472 disambiguation fix).
+    public BioLockStateMachineManager StateMachine { get; set; } = new();
 
     public override void Init()
     {
@@ -80,7 +87,16 @@ internal class BioLockEast : LocationBase, ITurnBasedActor, IFloydDoesNotTalkHer
         // the state machine. Without releasing Floyd here, IsAwayOnScriptedSequence would stay true
         // forever with no other code path to clear it, permanently blocking his normal following behavior.
         if (StateMachine.IsFloydInLabFighting)
+        {
             Repository.GetItem<Floyd>().IsAwayOnScriptedSequence = false;
+
+            // Issue #493 review: releasing Floyd is not enough. The state machine is still frozen mid-
+            // sequence (e.g. FloydRushedInNeedToCloseDoor). Left as-is, walking back into Bio Lock East
+            // re-registers this actor and resumes that state, firing a spurious "you failed to close the
+            // door" death even though Floyd followed the player out. Reset the sequence so a later
+            // re-entry starts clean (Floyd, who still remembers he volunteered, simply re-offers).
+            StateMachine.ResetSequence();
+        }
 
         context.RemoveActor(this);
     }

--- a/Planetfall/Location/Lawanda/Lab/BioLockEast.cs
+++ b/Planetfall/Location/Lawanda/Lab/BioLockEast.cs
@@ -96,6 +96,13 @@ internal class BioLockEast : LocationBase, ITurnBasedActor, IFloydDoesNotTalkHer
             // door" death even though Floyd followed the player out. Reset the sequence so a later
             // re-entry starts clean (Floyd, who still remembers he volunteered, simply re-offers).
             StateMachine.ResetSequence();
+
+            // Also close the inner door Floyd rushed through. Resetting the state machine alone would
+            // leave an anomalous "NotStarted but door open" state: on re-entry Floyd nags "open the door"
+            // while it is already open, and re-opening an open door is a no-op (OpenMe short-circuits to
+            // "It is already open." without calling OnOpening), so the obvious restart does nothing.
+            // Closing it restores the genuine pre-sequence state, so "open door" cleanly restarts the rush.
+            GetItem<BioLockInnerDoor>().IsOpen = false;
         }
 
         context.RemoveActor(this);

--- a/Planetfall/Location/Lawanda/Lab/BioLockStateMachineManager.cs
+++ b/Planetfall/Location/Lawanda/Lab/BioLockStateMachineManager.cs
@@ -37,10 +37,38 @@ public class BioLockStateMachineManager
         LabSequenceState == FloydLabSequenceState.DoorReopenedNeedToCloseAgain;
 
     /// <summary>
+    /// Reset the transient lab-sequence sub-state so the choreography can be restarted cleanly. Called
+    /// when the player abandons the sequence mid-flight (walks out of Bio Lock East while Floyd is away).
+    /// The "Floyd has offered / has been introduced" flags (<see cref="FloydHasSaidLookAMiniCard"/>,
+    /// <see cref="FloydHasSaidNeedToGetCard"/>, <see cref="HasWaitedOneTurnInBioLockEast"/>) are
+    /// deliberately preserved - Floyd still remembers he volunteered - but the sequence position and every
+    /// counter return to their defaults so a later re-entry does not resume a frozen mid-sequence state
+    /// (issue #493 review: otherwise returning fires the "you failed to close the door" death with Floyd
+    /// standing right next to the player, having followed them out).
+    /// </summary>
+    public void ResetSequence()
+    {
+        LabSequenceState = FloydLabSequenceState.NotStarted;
+        FloydWaitingForDoorOpenCount = 0;
+        TurnsAfterFloydRushedIn = 0;
+        FloydFightingTurnCount = 0;
+        TurnsAfterDoorReopened = 0;
+    }
+
+    /// <summary>
     /// Handle turn-based actions for Floyd in BioLockEast
     /// </summary>
     public string HandleTurnAction(bool isFloydHereAndOn, bool computerRoomFloydHasExpressedConcern, IContext context, Floyd floyd)
     {
+        // Once the sequence has finished - Floyd sacrificed himself and his body lies here (EndSequence),
+        // or he died trapped in the lab (the NeedToReopenDoor terminal branch) - this actor must stay
+        // silent. EndSequence leaves the corpse's IsOn true and places it back in this room, so
+        // isFloydHereAndOn is true for the body; without this guard, re-entering the room re-registers the
+        // actor and the leftover FloydHasSaidNeedToGetCard flag falls into the "waiting for door open"
+        // branch below, making Floyd's corpse cheerfully ask the player to open the door again (issue #493).
+        if (LabSequenceState == FloydLabSequenceState.Completed)
+            return string.Empty;
+
         // During the lab sequence, Floyd is not in the room (he's in the lab fighting)
         var isFloydInLab = LabSequenceState == FloydLabSequenceState.FloydRushedInNeedToCloseDoor ||
                            LabSequenceState == FloydLabSequenceState.DoorClosedFloydFighting ||

--- a/UnitTests/SessionStateSerializationGuardTests.cs
+++ b/UnitTests/SessionStateSerializationGuardTests.cs
@@ -1,0 +1,153 @@
+using System.Reflection;
+using System.Text;
+using FluentAssertions;
+using Model.Interface;
+using Model.Item;
+using Model.Location;
+using Newtonsoft.Json;
+using NUnit.Framework;
+
+namespace UnitTests;
+
+/// <summary>
+///     Systemic guard for the recurring stateless-serialization trap behind issues #365 and #493.
+///
+///     The deployed game is stateless: every turn re-hydrates the whole game from the base64 session, and
+///     <c>GameEngine.DoNotSerializeReadOnlyPropertiesResolver</c> deliberately drops every property that is
+///     not writable. A get-only auto-property whose value is a <em>mutable reference type</em> (a state
+///     machine, a manager, a mutable collection) is therefore never written to the session and silently
+///     re-initialises to its <c>= new()</c> default on every request — so any per-turn/session state it
+///     holds resets every turn in production, while every single-process test keeps passing.
+///
+///     <c>BioLockEast.StateMachine</c> was exactly this shape and made Planetfall unwinnable in prod for
+///     two separate issues before it was given a setter. This test reflects over every serialized type
+///     (locations, items, contexts) and fails if any such get-only-holding-mutable-state property exists,
+///     so the next one is caught at PR time instead of in production. The fix is almost always to add a
+///     setter (<c>{ get; set; }</c> or <c>{ get; private set; }</c>) so the object round-trips; genuinely
+///     immutable, always-reconstructed config goes on <see cref="Allowlisted"/> with a reason.
+///
+///     Scope: the serialization roots — every concrete location, item, and context. A nested state-holder
+///     these reference (e.g. <c>BioLockStateMachineManager</c>) must likewise keep all of its own state on
+///     writable properties; today they all do.
+/// </summary>
+[TestFixture]
+public class SessionStateSerializationGuardTests
+{
+    // Assemblies whose concrete locations/items/contexts travel in the serialized session.
+    private static readonly string[] GameAssemblies = ["GameEngine", "ZorkOne", "Planetfall"];
+
+    /// <summary>
+    ///     "DeclaringType.PropertyName" entries that are get-only reference-typed properties on serialized
+    ///     types but are provably safe because their value is immutable configuration that is reconstructed
+    ///     identically on every fresh instance (never mutated after construction), so losing it to the
+    ///     serializer and rebuilding it from the initializer is a no-op. Each entry must carry a reason.
+    /// </summary>
+    private static readonly HashSet<string> Allowlisted = new();
+
+    [Test]
+    public void NoSerializedType_HasAGetOnlyPropertyHoldingMutableState()
+    {
+        var offenders = new List<string>();
+        var seen = new HashSet<string>();
+
+        foreach (var assembly in GameAssemblies.Select(Assembly.Load))
+        foreach (var type in GetLoadableTypes(assembly))
+        {
+            if (!IsSerializedType(type))
+                continue;
+
+            // Public instance properties, INCLUDING inherited ones, so get-only state declared on an
+            // abstract base (ContainerBase, LocationBase, Context<T>) is covered too. Newtonsoft's default
+            // contract resolver serializes public members, so those are the ones the trap applies to;
+            // `seen` dedups each declaring-type property so a base property is only reported once.
+            foreach (var prop in type.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+            {
+                if (!IsSilentStateLossRisk(prop))
+                    continue;
+
+                var key = $"{prop.DeclaringType!.FullName}.{prop.Name}";
+                if (!seen.Add(key) || Allowlisted.Contains($"{prop.DeclaringType!.Name}.{prop.Name}"))
+                    continue;
+
+                offenders.Add($"{prop.DeclaringType!.Name}.{prop.Name} : {FriendlyTypeName(prop.PropertyType)}");
+            }
+        }
+
+        offenders.Should().BeEmpty(BuildFailureMessage(offenders));
+    }
+
+    private static bool IsSerializedType(Type type)
+    {
+        if (!type.IsClass || type.IsAbstract)
+            return false;
+
+        return typeof(ILocation).IsAssignableFrom(type) ||
+               typeof(IItem).IsAssignableFrom(type) ||
+               typeof(IContext).IsAssignableFrom(type);
+    }
+
+    private static bool IsSilentStateLossRisk(PropertyInfo prop)
+    {
+        // Serializable, writable properties round-trip fine. The resolver only drops properties with no
+        // setter at all (a private/protected setter still counts as Writable to Newtonsoft, so those are
+        // safe). [JsonIgnore] properties are intentionally excluded from serialization, so resetting them
+        // is by design.
+        if (prop.GetMethod is null || prop.SetMethod is not null)
+            return false;
+
+        if (prop.GetCustomAttribute<JsonIgnoreAttribute>() is not null)
+            return false;
+
+        // Only auto-properties hold state. Expression-bodied read-only properties (=> ...) recompute on
+        // every access, so the serializer dropping them is harmless. An auto-property has a
+        // compiler-generated "<Name>k__BackingField".
+        if (!IsAutoProperty(prop))
+            return false;
+
+        // A get-only auto-property of a value type / string / enum can never diverge from its initializer
+        // (nothing can reassign it without a setter), so it cannot lose state. Only a mutable reference
+        // type whose contents are mutated in place is dangerous.
+        var t = prop.PropertyType;
+        return t is { IsValueType: false } && t != typeof(string);
+    }
+
+    private static bool IsAutoProperty(PropertyInfo prop)
+    {
+        return prop.DeclaringType!.GetField($"<{prop.Name}>k__BackingField",
+            BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public) is not null;
+    }
+
+    private static IEnumerable<Type> GetLoadableTypes(Assembly assembly)
+    {
+        try
+        {
+            return assembly.GetTypes();
+        }
+        catch (ReflectionTypeLoadException ex)
+        {
+            return ex.Types.Where(t => t is not null)!;
+        }
+    }
+
+    private static string FriendlyTypeName(Type t)
+    {
+        if (!t.IsGenericType)
+            return t.Name;
+
+        var args = string.Join(", ", t.GetGenericArguments().Select(FriendlyTypeName));
+        return $"{t.Name[..t.Name.IndexOf('`')]}<{args}>";
+    }
+
+    private static string BuildFailureMessage(IReadOnlyCollection<string> offenders)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine(
+            "these get-only auto-properties hold a mutable reference type on a serialized type, so the " +
+            "stateless session serializer (DoNotSerializeReadOnlyPropertiesResolver) drops them and they " +
+            "reset to a fresh instance every turn in production (the issue #365/#493 trap). Give each a " +
+            "setter so it round-trips, or add it to Allowlisted with a reason if it is immutable config:");
+        foreach (var offender in offenders.OrderBy(x => x))
+            sb.AppendLine($"  - {offender}");
+        return sb.ToString();
+    }
+}

--- a/UnitTests/SessionStateSerializationGuardTests.cs
+++ b/UnitTests/SessionStateSerializationGuardTests.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using System.Reflection;
 using System.Text;
 using FluentAssertions;
@@ -26,15 +27,29 @@ namespace UnitTests;
 ///     setter (<c>{ get; set; }</c> or <c>{ get; private set; }</c>) so the object round-trips; genuinely
 ///     immutable, always-reconstructed config goes on <see cref="Allowlisted"/> with a reason.
 ///
-///     Scope: the serialization roots — every concrete location, item, and context. A nested state-holder
-///     these reference (e.g. <c>BioLockStateMachineManager</c>) must likewise keep all of its own state on
-///     writable properties; today they all do.
+///     Scope and known limitations (kept deliberately narrow to stay false-positive-free):
+///     - It scans the serialization roots — every concrete location, item, and context in every game
+///       assembly (discovered dynamically, so new games are covered automatically) — plus their inherited
+///       base properties.
+///     - It does NOT recurse into nested state-holders reached via writable properties (e.g.
+///       <c>BioLockStateMachineManager</c>, timers, coordinators). Those must likewise keep all of their
+///       own state on writable properties; today they all do, but nothing here enforces it.
+///     - It only recognises the auto-property shape (a compiler-generated backing field). The
+///       semantically identical field-backed form —
+///       <c>private readonly Mgr _m = new(); public Mgr M => _m;</c> — also loses state (a private field
+///       is not serialized either) but is not detected, because a read-only expression-bodied property
+///       cannot be told apart from a genuinely computed one by reflection alone. Prefer a writable
+///       property for any serialized state; do not hide it behind a read-only field accessor.
 /// </summary>
 [TestFixture]
 public class SessionStateSerializationGuardTests
 {
-    // Assemblies whose concrete locations/items/contexts travel in the serialized session.
-    private static readonly string[] GameAssemblies = ["GameEngine", "ZorkOne", "Planetfall"];
+    // A floor of games that discovery must always find. This is a failsafe against discovery silently
+    // finding nothing (which would make the whole guard pass vacuously) - NOT the list of what gets
+    // scanned. Any game whose DLL is in the test output is discovered and scanned automatically, so a
+    // newly-added game is covered without touching this list; it only needs updating if a game is renamed
+    // or removed.
+    private static readonly string[] ExpectedGames = ["ZorkOne", "Planetfall", "EscapeRoom", "ZorkTwo"];
 
     /// <summary>
     ///     "DeclaringType.PropertyName" entries that are get-only reference-typed properties on serialized
@@ -47,10 +62,17 @@ public class SessionStateSerializationGuardTests
     [Test]
     public void NoSerializedType_HasAGetOnlyPropertyHoldingMutableState()
     {
+        var gameAssemblies = DiscoverGameAssemblies();
+
+        // Failsafe: if discovery finds fewer games than expected, the guard would be silently protecting
+        // less than it claims - fail loudly rather than pass vacuously.
+        gameAssemblies.Select(a => a.GetName().Name!).Should().Contain(ExpectedGames,
+            "the serialization guard must scan every game; if discovery misses one it is not protecting it");
+
         var offenders = new List<string>();
         var seen = new HashSet<string>();
 
-        foreach (var assembly in GameAssemblies.Select(Assembly.Load))
+        foreach (var assembly in gameAssemblies)
         foreach (var type in GetLoadableTypes(assembly))
         {
             if (!IsSerializedType(type))
@@ -74,6 +96,38 @@ public class SessionStateSerializationGuardTests
         }
 
         offenders.Should().BeEmpty(BuildFailureMessage(offenders));
+    }
+
+    private static IReadOnlyList<Assembly> DiscoverGameAssemblies()
+    {
+        // Directory-scan the test output instead of hardcoding game names, so a newly-added game is
+        // covered automatically once it is referenced (its DLL then lands here). A game assembly is one
+        // that references GameEngine and defines at least one concrete serialized type. GameEngine itself
+        // is intentionally excluded: its abstract bases (LocationBase, ItemBase, Context<T>) carry no
+        // concrete types, and their inherited properties are already covered when a concrete game type
+        // that derives from them is scanned.
+        var assemblies = new List<Assembly>();
+
+        foreach (var dll in Directory.GetFiles(AppContext.BaseDirectory, "*.dll"))
+        {
+            Assembly asm;
+            try
+            {
+                asm = Assembly.LoadFrom(dll);
+            }
+            catch
+            {
+                continue; // unmanaged / unloadable dll in the output - not a game assembly
+            }
+
+            if (!asm.GetReferencedAssemblies().Any(r => r.Name == "GameEngine"))
+                continue;
+
+            if (GetLoadableTypes(asm).Any(IsSerializedType))
+                assemblies.Add(asm);
+        }
+
+        return assemblies;
     }
 
     private static bool IsSerializedType(Type type)

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -37,6 +37,10 @@
         <ProjectReference Include="..\Planetfall\Planetfall.csproj"/>
         <ProjectReference Include="..\Planetfall-Lambda\src\Planetfall-Lambda\Planetfall-Lambda.csproj"/>
         <ProjectReference Include="..\ZorkOne\ZorkOne.csproj"/>
+        <!-- Referenced so their DLLs land in the test output and the serialization guard
+             (SessionStateSerializationGuardTests) covers every game, not just Zork One / Planetfall. -->
+        <ProjectReference Include="..\EscapeRoom\EscapeRoom.csproj"/>
+        <ProjectReference Include="..\ZorkTwo\ZorkTwo.csproj"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/package-lock.json
+++ b/package-lock.json
@@ -3203,7 +3203,6 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -4332,6 +4331,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/cosmiconfig/node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/create-jest": {
@@ -7361,9 +7369,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -7789,9 +7797,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.12",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
-      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "funding": [
         {
           "type": "opencollective",
@@ -7808,7 +7816,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -9492,12 +9500,21 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
-      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yargs": {


### PR DESCRIPTION
Fixes #493.

## Summary

Floyd's Bio-Lab sacrifice — the only way to obtain the miniaturization access card that gates Station 384 — could not be performed in the deployed (stateless) game, making **Planetfall unwinnable in production**.

**Root cause:** the whole sequence's state lives in `BioLockEast.StateMachine`, which was a **get-only property**. The session serializer deliberately drops read-only properties (`DoNotSerializeReadOnlyPropertiesResolver`), so the state machine was never written to the base64 session and re-initialised to a fresh `new()` on every stateless turn. Floyd never offered the plan, and opening the inner door was always an instant "wrong time" death. This is the same class of bug as the still-reproducing closed #365.

**Fix:** give `StateMachine` a setter so it round-trips like every other writable state object (cf. the #472 disambiguation fix).

## Latent re-entry bugs this exposed

Making the sequence actually persist made two previously-unreachable code paths reachable in prod (caught in review, both fixed here):

- **Abandon + return spurious death** — `OnLeaveLocation` released Floyd but left `LabSequenceState` frozen mid-rush, so walking back into Bio Lock East resumed the "you failed to close the door" death with Floyd standing right next to you. Fix: reset the sequence when it is abandoned (`StateMachine.ResetSequence()`).
- **Dead Floyd re-nags** — `EndSequence` leaves the corpse's `IsOn` true, so on re-entry `HandleTurnAction` fell into the "waiting for door open" branch and the dead robot cheerfully asked you to open the door again. Fix: `HandleTurnAction` returns early once `LabSequenceState == Completed`.

## Systemic hardening

Added `UnitTests/SessionStateSerializationGuardTests` — a reflection guard that fails on **any** get-only auto-property holding a mutable reference type on a serialized type (location/item/context), i.e. the exact shape the resolver silently drops. This trap has now bitten three times (#365, #493, and the re-entry bugs above), so the guard stops the next one at PR time.

Sweeping the codebase with it turned up only two *immutable* `NounsForMatching` arrays on `MiniaturizationSlot`/`TeleportationSlot` (converted to the standard expression-bodied form); no other stateful offenders. Proven to have teeth by reverting the `BioLockEast` setter and watching the guard flag it.

## Tests (TDD)

- `FloydSacrificePersistenceTests` — round-trips the game across save/restore (mirroring the Lambda path) to prove the sequence completes; each test failed before the fix and passes after.
- New `BioLockEastTests` cover the leave/re-enter boundary for both re-entry bugs (Floyd registered as a co-actor, as in real gameplay).
- `SessionStateSerializationGuardTests` — the systemic guard.

All suites green: **UnitTests 1084 passed**, **Planetfall.Tests 3214 passed**, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)