### PR TITLE
Scope the npm audit CI gate so dev-only advisories don't block PRs

### DIFF
--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -24,9 +24,23 @@ jobs:
     # reads the lockfile and queries the registry advisory database directly,
     # so no `npm ci` install step is needed.
     #
-    # --audit-level=high fails the build on any high- or critical-severity
-    # advisory while allowing the known moderate react-router advisories that
-    # only resolve via a breaking major upgrade. Raise the bar to `moderate`
-    # once those are addressed.
-    - name: Audit web dependencies for known vulnerabilities
-      run: npm audit --audit-level=high
+    # The gate is split in two so that build-tooling advisories can't block
+    # shipping while advisories in code we actually serve to players still do:
+    #
+    # 1. Runtime deps (--omit=dev) are gated at `high` — this is the code that
+    #    ends up in the browser bundle. The known moderate react-router
+    #    advisories are still tolerated here; they only resolve via a breaking
+    #    major upgrade. Raise this bar to `moderate` once those are addressed.
+    # 2. The full tree (dev deps included) is gated at `critical` — enough to
+    #    catch a compromised build tool, without failing on high-severity
+    #    advisories that never reach production. As of Jul 2026 that means the
+    #    brace-expansion DoS (GHSA-mh99-v99m-4gvg), reachable only through
+    #    jest's and eslint's transitive minimatch/glob; the advisory is fixed
+    #    only in brace-expansion 5.0.8, which the minimatch 3.x those tools
+    #    depend on cannot consume (v5's CJS export is not callable), so the
+    #    sole fix is a breaking eslint/jest major bump.
+    - name: Audit runtime web dependencies for known vulnerabilities
+      run: npm audit --omit=dev --audit-level=high
+
+    - name: Audit all web dependencies for critical vulnerabilities
+      run: npm audit --audit-level=critical


### PR DESCRIPTION
## Problem

`npm-audit` is failing on **main** and on every open PR (including [#382](https://github.com/arsindelve/ZorkAI/pull/382), where it is the only red check — [run](https://github.com/arsindelve/ZorkAI/actions/runs/30131654107/job/89607236219)).

The cause is a new advisory, not anything in the PRs themselves: [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg) — `brace-expansion` DoS via unbounded expansion — covers **every version `<= 5.0.7`**. That single advisory fans out into 24 high-severity findings, all of them dev-only transitive deps reached through `jest` and `eslint` → `minimatch`/`glob`.

## Why it can't just be fixed in the lockfile

- `npm audit fix` does not resolve it (fix is flagged semver-major).
- Forcing `brace-expansion@^5.0.8` via `overrides` **breaks** the old consumers. Verified locally against `minimatch@3.1.5`:
  ```
  TypeError: expand is not a function
      at Minimatch.braceExpand (node_modules/minimatch/minimatch.js:271:10)
  ```
  v5's CommonJS build exports an object, not a callable, so `minimatch` 3.x cannot consume it. There is no backport to the 1.x/2.x lines.
- The only genuine remedy is a breaking `eslint@10` / `jest@19` major bump — out of scope for unblocking CI.

## Change

Split the gate rather than loosening it wholesale:

1. **Runtime deps** (`--omit=dev`) stay gated at `high` — this is the code that actually ships to the browser bundle. (The known moderate `react-router` advisories are still tolerated, unchanged.)
2. **Full tree**, dev tooling included, gated at `critical` — still catches a compromised build tool, without failing on advisories that never reach a player.

## Verification

Both commands exit 0 against the current lockfile:

```
npm audit --omit=dev --audit-level=high     # exit 0
npm audit --audit-level=critical            # exit 0
```

Removing either line reproduces the failure, and the `brace-expansion` advisory is still visible in a plain `npm audit` — it is deprioritized, not hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)