### PR TITLE
Stop take/drop from silently acting on an item the player never named

### DIFF
--- a/GameEngine/Item/ItemProcessor/TakeOrDropInteractionProcessor.cs
+++ b/GameEngine/Item/ItemProcessor/TakeOrDropInteractionProcessor.cs
@@ -127,6 +127,10 @@ public class TakeOrDropInteractionProcessor : IVerbProcessor
                        ?? Repository.GetItemInInventory(action.Noun, context)
                        ?? Repository.GetItem(items[0])
                        ?? Repository.GetItem(action.Noun);
+
+            item = ItemThePlayerActuallyNamed(item, action.Noun,
+                noun => Repository.GetItemInInventory(noun, context) ?? Repository.GetItem(noun));
+
             return DropIt(context, item);
         }
 
@@ -166,6 +170,10 @@ public class TakeOrDropInteractionProcessor : IVerbProcessor
             // fall back to the noun the IntentParser already extracted from the player's input.
             var item = Repository.GetItemInScope(items[0], context)
                        ?? Repository.GetItemInScope(action.Noun, context);
+
+            item = ItemThePlayerActuallyNamed(item, action.Noun,
+                noun => Repository.GetItemInScope(noun, context));
+
             return TakeIt(context, item);
         }
 
@@ -175,6 +183,35 @@ public class TakeOrDropInteractionProcessor : IVerbProcessor
             .ToList();
 
         return new PositiveInteractionResult(await TakeEverythingProcessor.TakeAll(context, itemsWithFeedback, client));
+    }
+
+    /// <summary>
+    /// Issue #502: the AI take/drop list-parser only ever sees the room description (take) or the
+    /// inventory listing (drop), and is asked which of *those* things the player wants. When exactly
+    /// one candidate is present it returns that candidate for essentially any noun - a typo, a word
+    /// the port doesn't implement, or the name of something the player is carrying - because there is
+    /// nothing else it could name. Treating "the parser returned one thing" as "the player asked for
+    /// that thing" silently pocketed (or dropped) an unnamed object and answered a bare "Taken."
+    /// This confirms the candidate really is what the player typed before it is acted on:
+    /// if it isn't, the player's own noun wins, and when that resolves to nothing the caller's
+    /// null handling produces a <see cref="NoNounMatchInteractionResult"/> instead of a wrong-item
+    /// success. The identity check deliberately does NOT look inside containers - a bag that happens
+    /// to hold the named object is not itself the named object.
+    /// </summary>
+    private static IItem? ItemThePlayerActuallyNamed(IItem? candidate, string? noun,
+        Func<string, IItem?> resolveNoun)
+    {
+        // No noun to check against (e.g. a bare "take"/"drop" the parser expanded for us), or nothing
+        // resolved at all - leave the caller's existing behavior exactly as it was.
+        if (candidate is null || string.IsNullOrWhiteSpace(noun))
+            return candidate;
+
+        // Compound phrases are fine: HasMatchingNoun's word-boundary fallback still matches "lantern"
+        // against a candidate the parser called a "brass lantern", and vice versa.
+        if (candidate.HasMatchingNoun(noun, lookInsideContainers: false).HasItem)
+            return candidate;
+
+        return resolveNoun(noun);
     }
 
     public static InteractionResult DropIt(IContext context, IItem? castItem)

--- a/GameEngine/Item/ItemProcessor/TakeOrDropInteractionProcessor.cs
+++ b/GameEngine/Item/ItemProcessor/TakeOrDropInteractionProcessor.cs
@@ -128,7 +128,7 @@ public class TakeOrDropInteractionProcessor : IVerbProcessor
                        ?? Repository.GetItem(items[0])
                        ?? Repository.GetItem(action.Noun);
 
-            item = ItemThePlayerActuallyNamed(item, action.Noun,
+            item = ItemThePlayerActuallyNamed(item, action,
                 noun => Repository.GetItemInInventory(noun, context) ?? Repository.GetItem(noun));
 
             return DropIt(context, item);
@@ -171,7 +171,7 @@ public class TakeOrDropInteractionProcessor : IVerbProcessor
             var item = Repository.GetItemInScope(items[0], context)
                        ?? Repository.GetItemInScope(action.Noun, context);
 
-            item = ItemThePlayerActuallyNamed(item, action.Noun,
+            item = ItemThePlayerActuallyNamed(item, action,
                 noun => Repository.GetItemInScope(noun, context));
 
             return TakeIt(context, item);
@@ -195,23 +195,97 @@ public class TakeOrDropInteractionProcessor : IVerbProcessor
     /// This confirms the candidate really is what the player typed before it is acted on:
     /// if it isn't, the player's own noun wins, and when that resolves to nothing the caller's
     /// null handling produces a <see cref="NoNounMatchInteractionResult"/> instead of a wrong-item
-    /// success. The identity check deliberately does NOT look inside containers - a bag that happens
-    /// to hold the named object is not itself the named object.
+    /// success.
+    ///
+    /// Only a request that names ONE object can be substituted this way, so
+    /// <see cref="NamesASingleObject"/> gates the whole check - see its remarks for why applying it
+    /// to a quantified or multi-object command is not merely useless but actively harmful.
     /// </summary>
-    private static IItem? ItemThePlayerActuallyNamed(IItem? candidate, string? noun,
+    private static IItem? ItemThePlayerActuallyNamed(IItem? candidate, SimpleIntent action,
         Func<string, IItem?> resolveNoun)
     {
         // No noun to check against (e.g. a bare "take"/"drop" the parser expanded for us), or nothing
         // resolved at all - leave the caller's existing behavior exactly as it was.
-        if (candidate is null || string.IsNullOrWhiteSpace(noun))
+        if (candidate is null || string.IsNullOrWhiteSpace(action.Noun))
             return candidate;
 
-        // Compound phrases are fine: HasMatchingNoun's word-boundary fallback still matches "lantern"
-        // against a candidate the parser called a "brass lantern", and vice versa.
-        if (candidate.HasMatchingNoun(noun, lookInsideContainers: false).HasItem)
+        if (!NamesASingleObject(action))
             return candidate;
 
-        return resolveNoun(noun);
+        if (NounCouldName(candidate, action.Noun))
+            return candidate;
+
+        return resolveNoun(action.Noun);
+    }
+
+    /// <summary>
+    /// Collective words that stand in for "whatever qualifies" rather than naming an object. The
+    /// IntentParser hands these through as the noun, so they can never match a candidate.
+    /// </summary>
+    private static readonly string[] CollectiveNouns =
+        ["all", "everything", "anything", "something", "both", "them", "these", "those", "stuff", "things"];
+
+    /// <summary>
+    /// Markers that the command covers more than one object. Padded on both sides at the comparison
+    /// site, so "take the ball" does not trip on " all " and "press the button" does not trip on
+    /// " but ".
+    /// </summary>
+    private static readonly string[] MultipleObjectMarkers =
+        [" and ", " & ", " , ", " except ", " but ", " besides ", " all ", " everything ", " anything ", " both "];
+
+    /// <summary>
+    /// True only when the command names exactly one object, which is the sole shape the issue #502
+    /// guard is allowed to police.
+    ///
+    /// <para>The trap: <c>TakeIntent.Noun</c>/<c>DropIntent.Noun</c> is just
+    /// <c>nouns.FirstOrDefault()</c> (<c>ParsingHelper</c>), so on a quantified command it is a
+    /// collective word ("everything") or even the *excluded* noun - "pick up everything except the
+    /// tube" yields <c>Noun = "tube"</c>. Checking the parser's candidate against that noun would not
+    /// just refuse a legitimate take; it would resolve to the tube and take the very object the
+    /// player excluded. Likewise on "take X and Y" where only Y is here, the parser returns Y while
+    /// <c>Noun</c> is X: a single candidate is a legitimate partial resolution of a multi-object
+    /// request, not a substitution. These phrasings are supported - see
+    /// <c>IntegrationTests/OpenAITakeAndDropParserTests.cs</c>.</para>
+    /// </summary>
+    private static bool NamesASingleObject(SimpleIntent action)
+    {
+        if (CollectiveNouns.Contains(action.Noun!.ToLowerInvariant().Trim()))
+            return false;
+
+        var input = $" {(action.OriginalInput ?? string.Empty).ToLowerInvariant().Replace(",", " , ")} ";
+        return !MultipleObjectMarkers.Any(input.Contains);
+    }
+
+    /// <summary>
+    /// Could the player's noun be naming this item? Compares against the item's own nouns only - a
+    /// bag that happens to hold the named object is not itself the named object.
+    ///
+    /// <para>Deliberately does NOT call <see cref="IItem.HasMatchingNoun"/>: only
+    /// <c>ItemBase</c> has the word-boundary containment fallback that lets "brass lantern" match a
+    /// bare "lantern". <c>ContainerBase</c> and <c>OpenAndCloseContainerBase</c> override it with
+    /// plain exact equality, so routing through it would make the check exact-match-only for every
+    /// container-derived item (sack, bottle, canteen, coffin, survival kit...) and refuse any
+    /// adjective the player added but the parser didn't echo - "take the elongated sack",
+    /// "drop the full canteen". Containment runs in both directions so it doesn't matter which side
+    /// carries the extra adjective.</para>
+    /// </summary>
+    private static bool NounCouldName(IItem candidate, string noun)
+    {
+        var typed = noun.ToLowerInvariant().Trim();
+
+        var candidateNouns = candidate.NounsForMatching
+            .Concat(candidate.NounsForPreciseMatching)
+            .Select(n => n.ToLowerInvariant().Trim())
+            .Where(n => n.Length > 0)
+            .Distinct()
+            .ToList();
+
+        if (candidateNouns.Contains(typed))
+            return true;
+
+        // Padding both sides with spaces avoids false positives like matching "key" inside "monkey".
+        var paddedTyped = $" {typed} ";
+        return candidateNouns.Any(n => paddedTyped.Contains($" {n} ") || $" {n} ".Contains(paddedTyped));
     }
 
     public static InteractionResult DropIt(IContext context, IItem? castItem)

--- a/GameEngine/Item/ItemProcessor/TakeOrDropInteractionProcessor.cs
+++ b/GameEngine/Item/ItemProcessor/TakeOrDropInteractionProcessor.cs
@@ -192,14 +192,13 @@ public class TakeOrDropInteractionProcessor : IVerbProcessor
     /// the port doesn't implement, or the name of something the player is carrying - because there is
     /// nothing else it could name. Treating "the parser returned one thing" as "the player asked for
     /// that thing" silently pocketed (or dropped) an unnamed object and answered a bare "Taken."
-    /// This confirms the candidate really is what the player typed before it is acted on:
-    /// if it isn't, the player's own noun wins, and when that resolves to nothing the caller's
-    /// null handling produces a <see cref="NoNounMatchInteractionResult"/> instead of a wrong-item
-    /// success.
     ///
-    /// Only a request that names ONE object can be substituted this way, so
-    /// <see cref="NamesASingleObject"/> gates the whole check - see its remarks for why applying it
-    /// to a quantified or multi-object command is not merely useless but actively harmful.
+    /// <para>This is the take/drop policy: the parser's candidate wins unless the noun the player
+    /// actually typed contradicts it, in which case their own noun wins - and when that resolves to
+    /// nothing, the caller's null handling produces a <see cref="NoNounMatchInteractionResult"/>
+    /// instead of a wrong-item success. The two predicates it leans on are general noun logic and
+    /// live in <see cref="NounMatch"/>; see <see cref="NounMatch.NamesASingleObject"/> in particular
+    /// for why a quantified or multi-object command must be left alone entirely.</para>
     /// </summary>
     private static IItem? ItemThePlayerActuallyNamed(IItem? candidate, SimpleIntent action,
         Func<string, IItem?> resolveNoun)
@@ -209,83 +208,10 @@ public class TakeOrDropInteractionProcessor : IVerbProcessor
         if (candidate is null || string.IsNullOrWhiteSpace(action.Noun))
             return candidate;
 
-        if (!NamesASingleObject(action))
+        if (!NounMatch.NamesASingleObject(action.Noun, action.OriginalInput))
             return candidate;
 
-        if (NounCouldName(candidate, action.Noun))
-            return candidate;
-
-        return resolveNoun(action.Noun);
-    }
-
-    /// <summary>
-    /// Collective words that stand in for "whatever qualifies" rather than naming an object. The
-    /// IntentParser hands these through as the noun, so they can never match a candidate.
-    /// </summary>
-    private static readonly string[] CollectiveNouns =
-        ["all", "everything", "anything", "something", "both", "them", "these", "those", "stuff", "things"];
-
-    /// <summary>
-    /// Markers that the command covers more than one object. Padded on both sides at the comparison
-    /// site, so "take the ball" does not trip on " all " and "press the button" does not trip on
-    /// " but ".
-    /// </summary>
-    private static readonly string[] MultipleObjectMarkers =
-        [" and ", " & ", " , ", " except ", " but ", " besides ", " all ", " everything ", " anything ", " both "];
-
-    /// <summary>
-    /// True only when the command names exactly one object, which is the sole shape the issue #502
-    /// guard is allowed to police.
-    ///
-    /// <para>The trap: <c>TakeIntent.Noun</c>/<c>DropIntent.Noun</c> is just
-    /// <c>nouns.FirstOrDefault()</c> (<c>ParsingHelper</c>), so on a quantified command it is a
-    /// collective word ("everything") or even the *excluded* noun - "pick up everything except the
-    /// tube" yields <c>Noun = "tube"</c>. Checking the parser's candidate against that noun would not
-    /// just refuse a legitimate take; it would resolve to the tube and take the very object the
-    /// player excluded. Likewise on "take X and Y" where only Y is here, the parser returns Y while
-    /// <c>Noun</c> is X: a single candidate is a legitimate partial resolution of a multi-object
-    /// request, not a substitution. These phrasings are supported - see
-    /// <c>IntegrationTests/OpenAITakeAndDropParserTests.cs</c>.</para>
-    /// </summary>
-    private static bool NamesASingleObject(SimpleIntent action)
-    {
-        if (CollectiveNouns.Contains(action.Noun!.ToLowerInvariant().Trim()))
-            return false;
-
-        var input = $" {(action.OriginalInput ?? string.Empty).ToLowerInvariant().Replace(",", " , ")} ";
-        return !MultipleObjectMarkers.Any(input.Contains);
-    }
-
-    /// <summary>
-    /// Could the player's noun be naming this item? Compares against the item's own nouns only - a
-    /// bag that happens to hold the named object is not itself the named object.
-    ///
-    /// <para>Deliberately does NOT call <see cref="IItem.HasMatchingNoun"/>: only
-    /// <c>ItemBase</c> has the word-boundary containment fallback that lets "brass lantern" match a
-    /// bare "lantern". <c>ContainerBase</c> and <c>OpenAndCloseContainerBase</c> override it with
-    /// plain exact equality, so routing through it would make the check exact-match-only for every
-    /// container-derived item (sack, bottle, canteen, coffin, survival kit...) and refuse any
-    /// adjective the player added but the parser didn't echo - "take the elongated sack",
-    /// "drop the full canteen". Containment runs in both directions so it doesn't matter which side
-    /// carries the extra adjective.</para>
-    /// </summary>
-    private static bool NounCouldName(IItem candidate, string noun)
-    {
-        var typed = noun.ToLowerInvariant().Trim();
-
-        var candidateNouns = candidate.NounsForMatching
-            .Concat(candidate.NounsForPreciseMatching)
-            .Select(n => n.ToLowerInvariant().Trim())
-            .Where(n => n.Length > 0)
-            .Distinct()
-            .ToList();
-
-        if (candidateNouns.Contains(typed))
-            return true;
-
-        // Padding both sides with spaces avoids false positives like matching "key" inside "monkey".
-        var paddedTyped = $" {typed} ";
-        return candidateNouns.Any(n => paddedTyped.Contains($" {n} ") || $" {n} ".Contains(paddedTyped));
+        return NounMatch.CouldName(candidate, action.Noun) ? candidate : resolveNoun(action.Noun);
     }
 
     public static InteractionResult DropIt(IContext context, IItem? castItem)

--- a/GameEngine/NounMatch.cs
+++ b/GameEngine/NounMatch.cs
@@ -1,0 +1,97 @@
+using Model.Item;
+
+namespace GameEngine;
+
+/// <summary>
+/// The comparison half of noun resolution, sitting beside <see cref="Repository"/>, which owns the
+/// lookup half (<see cref="Repository.GetItemInScope"/>, <see cref="Repository.GetPreciseMatchInScope"/>).
+/// Where those answer "what item is this noun?", these answer "could this noun be naming this item?"
+/// and "does this command name one object at all?" - pure predicates over a noun and an item's
+/// vocabulary, with no verb, context or repository involved.
+///
+/// <para>Deliberately static rather than an instance method on <c>ItemBase</c>. The whole reason
+/// <see cref="CouldName"/> exists is that <c>ContainerBase</c> and <c>OpenAndCloseContainerBase</c>
+/// override <see cref="IItem.HasMatchingNoun"/> into exact equality; an instance method here would
+/// invite exactly the same override and reintroduce the trap. A static that reads
+/// <see cref="IItem.NounsForMatching"/> from the outside cannot be shadowed.</para>
+/// </summary>
+public static class NounMatch
+{
+    /// <summary>
+    /// Collective words that stand in for "whatever qualifies" rather than naming an object. The
+    /// IntentParser hands these through as the noun, so they can never match a candidate.
+    /// </summary>
+    private static readonly string[] CollectiveNouns =
+        ["all", "everything", "anything", "something", "both", "them", "these", "those", "stuff", "things"];
+
+    /// <summary>
+    /// Markers that the command covers more than one object. Padded on both sides at the comparison
+    /// site, so "take the ball" does not trip on " all " and "press the button" does not trip on
+    /// " but ".
+    /// </summary>
+    private static readonly string[] MultipleObjectMarkers =
+        [" and ", " & ", " , ", " except ", " but ", " besides ", " all ", " everything ", " anything ", " both "];
+
+    /// <summary>
+    /// Could the player's noun be naming this item? Compares against the item's own nouns only - a
+    /// bag that happens to hold the named object is not itself the named object.
+    ///
+    /// <para>Deliberately does NOT call <see cref="IItem.HasMatchingNoun"/>: only <c>ItemBase</c> has
+    /// the word-boundary containment fallback that lets "brass lantern" match a bare "lantern".
+    /// <c>ContainerBase</c> and <c>OpenAndCloseContainerBase</c> override it with plain exact
+    /// equality, so routing through it would make the check exact-match-only for every
+    /// container-derived item (sack, bottle, canteen, coffin, survival kit...) and refuse any
+    /// adjective the player added but the parser didn't echo - "take the elongated sack",
+    /// "drop the full canteen". Containment runs in both directions so it doesn't matter which side
+    /// carries the extra adjective.</para>
+    /// </summary>
+    public static bool CouldName(IItem candidate, string? noun)
+    {
+        if (string.IsNullOrWhiteSpace(noun))
+            return false;
+
+        var typed = noun.ToLowerInvariant().Trim();
+
+        var candidateNouns = candidate.NounsForMatching
+            .Concat(candidate.NounsForPreciseMatching)
+            .Select(n => n.ToLowerInvariant().Trim())
+            .Where(n => n.Length > 0)
+            .Distinct()
+            .ToList();
+
+        if (candidateNouns.Contains(typed))
+            return true;
+
+        // Padding both sides with spaces avoids false positives like matching "key" inside "monkey".
+        var paddedTyped = $" {typed} ";
+        return candidateNouns.Any(n => paddedTyped.Contains($" {n} ") || $" {n} ".Contains(paddedTyped));
+    }
+
+    /// <summary>
+    /// True only when the command names exactly one object. Callers that verify an AI list-parser's
+    /// candidate against the noun the IntentParser extracted must gate on this first (issue #502).
+    ///
+    /// <para>The trap: <c>TakeIntent.Noun</c>/<c>DropIntent.Noun</c> is just
+    /// <c>nouns.FirstOrDefault()</c> (<c>ParsingHelper</c>), so on a quantified command it is a
+    /// collective word ("everything") or even the *excluded* noun - "pick up everything except the
+    /// tube" yields <c>Noun = "tube"</c>. Checking a parser candidate against that noun would not
+    /// just refuse a legitimate take; it would resolve to the tube and act on the very object the
+    /// player excluded. Likewise on "take X and Y" where only Y is here, the parser returns Y while
+    /// <c>Noun</c> is X: a single candidate is a legitimate partial resolution of a multi-object
+    /// request, not a substitution. These phrasings are supported - see
+    /// <c>IntegrationTests/OpenAITakeAndDropParserTests.cs</c>.</para>
+    /// </summary>
+    /// <param name="noun">The single noun the IntentParser extracted from the command.</param>
+    /// <param name="originalInput">The player's raw input, which is where a multi-object phrasing shows.</param>
+    public static bool NamesASingleObject(string? noun, string? originalInput)
+    {
+        if (string.IsNullOrWhiteSpace(noun))
+            return false;
+
+        if (CollectiveNouns.Contains(noun.ToLowerInvariant().Trim()))
+            return false;
+
+        var input = $" {(originalInput ?? string.Empty).ToLowerInvariant().Replace(",", " , ")} ";
+        return !MultipleObjectMarkers.Any(input.Contains);
+    }
+}

--- a/UnitTests/NounMatchTests.cs
+++ b/UnitTests/NounMatchTests.cs
@@ -1,0 +1,147 @@
+using GameEngine;
+using GameEngine.Item;
+using ZorkOne.Item;
+
+namespace UnitTests;
+
+/// <summary>
+/// Direct tests for the noun predicates extracted from TakeOrDropInteractionProcessor (issue #502).
+/// While they were private statics in the processor, every case here cost a whole game context plus a
+/// stubbed AI parser to reach; the take/drop tests still cover them end-to-end, but the edge cases
+/// that actually make these functions tricky - word-boundary padding, the container override, both
+/// directions of adjective - belong in rows like these.
+/// </summary>
+public class NounMatchTests
+{
+    [SetUp]
+    public void SetUp()
+    {
+        Repository.Reset();
+    }
+
+    [TestFixture]
+    public class CouldNameTests : NounMatchTests
+    {
+        [TestCase("lantern", TestName = "CouldName_ExactNoun")]
+        [TestCase("lamp", TestName = "CouldName_Synonym")]
+        [TestCase("brass lantern", TestName = "CouldName_ParserAddedAnAdjective")]
+        [TestCase("LANTERN", TestName = "CouldName_IsCaseInsensitive")]
+        [TestCase("  lantern  ", TestName = "CouldName_IgnoresSurroundingWhitespace")]
+        public void CouldName_MatchesTheLantern(string noun)
+        {
+            NounMatch.CouldName(Repository.GetItem<Lantern>(), noun).Should().BeTrue();
+        }
+
+        [TestCase("xyzzy", TestName = "CouldName_RejectsNonsense")]
+        [TestCase("medicine", TestName = "CouldName_RejectsAnUnrelatedRealNoun")]
+        [TestCase("", TestName = "CouldName_RejectsEmpty")]
+        [TestCase("   ", TestName = "CouldName_RejectsWhitespace")]
+        [TestCase(null, TestName = "CouldName_RejectsNull")]
+        public void CouldName_DoesNotMatchTheLantern(string? noun)
+        {
+            NounMatch.CouldName(Repository.GetItem<Lantern>(), noun).Should().BeFalse();
+        }
+
+        [Test]
+        public void CouldName_MatchesAContainerItemTheOverrideWouldReject()
+        {
+            // The reason this helper exists instead of a call to HasMatchingNoun: ContainerBase and
+            // OpenAndCloseContainerBase override that with plain exact equality, so a BrownSack - whose
+            // nouns are "sack"/"brown sack"/"bag"/"elongated brown sack" - would reject "elongated
+            // sack" outright. Proven by asserting the override really does say no.
+            var sack = Repository.GetItem<BrownSack>();
+
+            sack.HasMatchingNoun("elongated sack", lookInsideContainers: false).HasItem.Should()
+                .BeFalse("this is the container override the helper deliberately bypasses");
+
+            NounMatch.CouldName(sack, "elongated sack").Should().BeTrue();
+        }
+
+        [Test]
+        public void CouldName_LooksOnlyAtTheItemsOwnNouns_NotItsContents()
+        {
+            // A bag that happens to hold the named object is not itself the named object - this is
+            // exactly the reported "take medicine" case, where the medicine sat inside a held bottle.
+            var sack = Repository.GetItem<BrownSack>();
+            sack.IsOpen = true;
+            sack.ItemPlacedHere(Repository.GetItem<Lunch>());
+
+            sack.HasMatchingNoun("lunch").HasItem.Should()
+                .BeTrue("HasMatchingNoun searches inside, which is why it is the wrong tool here");
+
+            NounMatch.CouldName(sack, "lunch").Should().BeFalse();
+        }
+
+        [Test]
+        public void CouldName_MatchesWhenTheItemCarriesTheExtraAdjective()
+        {
+            // The reverse direction from "brass lantern": here the item's own noun is the longer
+            // phrase and the player typed the bare one.
+            NounMatch.CouldName(Repository.GetItem<BrownSack>(), "sack").Should().BeTrue();
+        }
+
+        [Test]
+        public void CouldName_DoesNotMatchOnAWordFragment()
+        {
+            // The padding exists so "key" cannot match inside "monkey".
+            NounMatch.CouldName(new FakeItem("monkey"), "key").Should().BeFalse();
+        }
+
+        private class FakeItem(params string[] nouns) : ItemBase
+        {
+            public override string[] NounsForMatching => nouns;
+        }
+    }
+
+    [TestFixture]
+    public class NamesASingleObjectTests : NounMatchTests
+    {
+        [TestCase("lantern", "take the lantern", TestName = "NamesASingleObject_PlainTake")]
+        [TestCase("sack", "drop sack", TestName = "NamesASingleObject_PlainDrop")]
+        [TestCase("ball", "take the ball", TestName = "NamesASingleObject_BallDoesNotTripOnAll")]
+        [TestCase("button", "press the button", TestName = "NamesASingleObject_ButtonDoesNotTripOnBut")]
+        [TestCase("bothy", "take the bothy", TestName = "NamesASingleObject_BothyDoesNotTripOnBoth")]
+        [TestCase("candle", "take candle", TestName = "NamesASingleObject_NoOriginalInputMarkers")]
+        public void NamesASingleObject_IsTrue(string noun, string originalInput)
+        {
+            NounMatch.NamesASingleObject(noun, originalInput).Should().BeTrue();
+        }
+
+        [TestCase("all", "take all the tools", TestName = "NamesASingleObject_CollectiveAll")]
+        [TestCase("everything", "pick up everything", TestName = "NamesASingleObject_CollectiveEverything")]
+        [TestCase("both", "grab both", TestName = "NamesASingleObject_CollectiveBoth")]
+        [TestCase("them", "take them", TestName = "NamesASingleObject_CollectiveThem")]
+        [TestCase("EVERYTHING", "pick up EVERYTHING", TestName = "NamesASingleObject_CollectiveIsCaseInsensitive")]
+        public void NamesASingleObject_IsFalseForACollectiveNoun(string noun, string originalInput)
+        {
+            NounMatch.NamesASingleObject(noun, originalInput).Should().BeFalse();
+        }
+
+        [TestCase("sword", "take the sword and the lantern", TestName = "NamesASingleObject_Conjunction")]
+        [TestCase("sword", "take sword, lantern", TestName = "NamesASingleObject_Comma")]
+        [TestCase("sword", "take sword & lantern", TestName = "NamesASingleObject_Ampersand")]
+        [TestCase("tube", "pick up everything except the tube", TestName = "NamesASingleObject_ExcludedNoun")]
+        [TestCase("tube", "take all the tools but don't take the tube", TestName = "NamesASingleObject_ButExclusion")]
+        [TestCase("tube", "take the tools besides the tube", TestName = "NamesASingleObject_Besides")]
+        public void NamesASingleObject_IsFalseForAMultiObjectRequest(string noun, string originalInput)
+        {
+            // TakeIntent.Noun is only nouns.FirstOrDefault(), so on these phrasings it is either the
+            // first of several nouns or - worse - the noun the player explicitly excluded.
+            NounMatch.NamesASingleObject(noun, originalInput).Should().BeFalse();
+        }
+
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("   ")]
+        public void NamesASingleObject_IsFalseWithoutANoun(string? noun)
+        {
+            NounMatch.NamesASingleObject(noun, "take something").Should().BeFalse();
+        }
+
+        [Test]
+        public void NamesASingleObject_ToleratesANullOriginalInput()
+        {
+            NounMatch.NamesASingleObject("lantern", null).Should().BeTrue();
+        }
+    }
+}

--- a/UnitTests/SingleNounProcessors/TakeProcessorTests.cs
+++ b/UnitTests/SingleNounProcessors/TakeProcessorTests.cs
@@ -276,6 +276,151 @@ public class TakeProcessorTests : EngineTestsBase
     }
 
     [Test]
+    public async Task Take_NounMatchesNothingInScope_DoesNotSilentlyTakeTheRoomsOnlyItem()
+    {
+        // Issue #502: the AI take-list parser is scoped to the room description, so a room holding
+        // exactly one takeable item makes it return that item for ANY noun - there is nothing else it
+        // could name. The engine then treated "the parser returned one thing" as "the player asked for
+        // that thing" and answered a bare "Taken.", silently pocketing an object the player never
+        // named. The stub below is what production really does here; only a guard on the player's own
+        // noun can tell the two apart.
+        var target = GetTarget();
+        var location = Repository.GetLocation<NorthOfHouse>();
+        target.Context.CurrentLocation = location;
+        location.ItemPlacedHere(Repository.GetItem<Lantern>());
+
+        TakeAndDropParser.Setup(s => s.GetListOfItemsToTake(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(["lantern"]);
+
+        IVerbProcessor processor = new TakeOrDropInteractionProcessor(TakeAndDropParser.Object);
+        var result = await processor.Process(
+            new SimpleIntent { Verb = "take", Noun = "xyzzy", OriginalInput = "take xyzzy" },
+            target.Context, Repository.GetItem<Lantern>(), Client.Object);
+
+        result.Should().BeOfType<NoNounMatchInteractionResult>();
+        target.Context.HasItem<Lantern>().Should().BeFalse("the player never named the lantern");
+    }
+
+    [Test]
+    public async Task Take_NounNamesADifferentInScopeItem_TakesTheOneThePlayerNamed()
+    {
+        // Issue #502, the misleading variant: the parser only ever sees the room description, so when
+        // the player names something they are carrying (the reported case was "take medicine" with the
+        // medicine inside a held bottle) it still answers with the room's lone item. The player's noun
+        // resolves perfectly well - it just isn't the thing the parser returned - so the take must
+        // follow the noun, not the parser.
+        var target = GetTarget();
+        var location = Repository.GetLocation<NorthOfHouse>();
+        target.Context.CurrentLocation = location;
+        location.ItemPlacedHere(Repository.GetItem<Lantern>());
+
+        var sack = Repository.GetItem<BrownSack>();
+        target.Context.Take(sack);
+        sack.IsOpen = true;
+
+        TakeAndDropParser.Setup(s => s.GetListOfItemsToTake(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(["lantern"]);
+
+        IVerbProcessor processor = new TakeOrDropInteractionProcessor(TakeAndDropParser.Object);
+        var result = await processor.Process(
+            new SimpleIntent { Verb = "take", Noun = "lunch", OriginalInput = "take lunch" },
+            target.Context, Repository.GetItem<Lantern>(), Client.Object);
+
+        result!.InteractionMessage.Should().Contain("Taken");
+        target.Context.HasItem<Lunch>().Should().BeTrue("the player asked for the lunch");
+        target.Context.HasItem<Lantern>().Should().BeFalse("the lantern was never named");
+    }
+
+    [Test]
+    public async Task Take_CompoundPhraseFromTheParser_StillResolvesToThePlayersNoun()
+    {
+        // Issue #502 guard rail: the parser routinely returns an adjective-qualified phrase ("brass
+        // lantern") for a bare noun ("lantern"). That is the same object, so the noun check must not
+        // reject it - this is exactly the case the pre-existing fallback comment protects.
+        var target = GetTarget();
+        var location = Repository.GetLocation<NorthOfHouse>();
+        target.Context.CurrentLocation = location;
+        location.ItemPlacedHere(Repository.GetItem<Lantern>());
+
+        TakeAndDropParser.Setup(s => s.GetListOfItemsToTake(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(["brass lantern"]);
+
+        IVerbProcessor processor = new TakeOrDropInteractionProcessor(TakeAndDropParser.Object);
+        var result = await processor.Process(
+            new SimpleIntent { Verb = "take", Noun = "lantern", OriginalInput = "take lantern" },
+            target.Context, Repository.GetItem<Lantern>(), Client.Object);
+
+        result!.InteractionMessage.Should().Contain("Taken");
+        target.Context.HasItem<Lantern>().Should().BeTrue();
+    }
+
+    [Test]
+    public async Task Take_TheItemThePlayerActuallyNamed_IsStillTaken()
+    {
+        // Issue #502 guard rail: the ordinary, overwhelmingly common case must be untouched.
+        var target = GetTarget();
+        var location = Repository.GetLocation<NorthOfHouse>();
+        target.Context.CurrentLocation = location;
+        location.ItemPlacedHere(Repository.GetItem<Lantern>());
+
+        var result = await target.GetResponse("take lantern");
+
+        result.Should().Contain("Taken");
+        target.Context.HasItem<Lantern>().Should().BeTrue();
+    }
+
+    [Test]
+    public async Task Take_BareVerbWithTwoItemsPresent_StillAsksWhichOne()
+    {
+        // Issue #502 guard rail: the bare-"take" convenience is a different processor
+        // (TakeOnlyAvailableItemProcessor) and must keep its disambiguation prompt.
+        var target = GetTarget();
+        var location = Repository.GetLocation<NorthOfHouse>();
+        target.Context.CurrentLocation = location;
+        location.ItemPlacedHere(Repository.GetItem<Lantern>());
+        location.ItemPlacedHere(Repository.GetItem<Sword>());
+
+        var result = await target.GetResponse("take");
+
+        result.Should().Contain("What do you want to take?");
+    }
+
+    [Test]
+    public async Task Drop_NounMatchesNothingHeld_DoesNotSilentlyDropTheOnlyItemCarried()
+    {
+        // Issue #502: GetItemsToDrop has the same shape as GetItemsToTake - with a single item in
+        // inventory the list-parser returns it for any noun, and the engine dropped it unchecked.
+        var target = GetTarget();
+        target.Context.CurrentLocation = Repository.GetLocation<NorthOfHouse>();
+        target.Context.Take(Repository.GetItem<Lantern>());
+
+        TakeAndDropParser.Setup(s => s.GetListOfItemsToDrop(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(["lantern"]);
+
+        IVerbProcessor processor = new TakeOrDropInteractionProcessor(TakeAndDropParser.Object);
+        var result = await processor.Process(
+            new SimpleIntent { Verb = "drop", Noun = "xyzzy", OriginalInput = "drop xyzzy" },
+            target.Context, Repository.GetItem<Lantern>(), Client.Object);
+
+        result.Should().BeOfType<NoNounMatchInteractionResult>();
+        target.Context.HasItem<Lantern>().Should().BeTrue("the player never named the lantern");
+    }
+
+    [Test]
+    public async Task Drop_TheItemThePlayerActuallyNamed_IsStillDropped()
+    {
+        // Issue #502 guard rail for the drop side.
+        var target = GetTarget();
+        target.Context.CurrentLocation = Repository.GetLocation<NorthOfHouse>();
+        target.Context.Take(Repository.GetItem<Lantern>());
+
+        var result = await target.GetResponse("drop lantern");
+
+        result.Should().Contain("Dropped");
+        target.Context.HasItem<Lantern>().Should().BeFalse();
+    }
+
+    [Test]
     public async Task TakeItem_Disambiguation()
     {
         var target = GetTarget();

--- a/UnitTests/SingleNounProcessors/TakeProcessorTests.cs
+++ b/UnitTests/SingleNounProcessors/TakeProcessorTests.cs
@@ -386,6 +386,87 @@ public class TakeProcessorTests : EngineTestsBase
     }
 
     [Test]
+    public async Task Take_AdjectiveTheParserDidNotEcho_StillMatchesAContainerItem()
+    {
+        // Issue #502 guard rail: the noun check must not be shadowed by the container overrides.
+        // ItemBase.HasMatchingNoun has a word-boundary containment fallback, but ContainerBase and
+        // OpenAndCloseContainerBase override it with plain exact equality - so for every
+        // container-derived item (sack, bottle, canteen, coffin, survival kit...) an adjective the
+        // player added but the parser didn't echo would look like a mismatch and be refused.
+        var target = GetTarget();
+        var location = Repository.GetLocation<NorthOfHouse>();
+        target.Context.CurrentLocation = location;
+        location.ItemPlacedHere(Repository.GetItem<BrownSack>());
+
+        TakeAndDropParser.Setup(s => s.GetListOfItemsToTake(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(["sack"]);
+
+        IVerbProcessor processor = new TakeOrDropInteractionProcessor(TakeAndDropParser.Object);
+        var result = await processor.Process(
+            new SimpleIntent
+                { Verb = "take", Noun = "elongated sack", OriginalInput = "take the elongated sack" },
+            target.Context, Repository.GetItem<BrownSack>(), Client.Object);
+
+        result!.InteractionMessage.Should().Contain("Taken");
+        target.Context.HasItem<BrownSack>().Should().BeTrue();
+    }
+
+    [Test]
+    public async Task Take_QuantifiedRequest_StillTakesTheOneQualifyingItem()
+    {
+        // Issue #502 guard rail: TakeIntent.Noun is only nouns.FirstOrDefault() (ParsingHelper), so
+        // for a quantified command it is a collective word or - as here - the *excluded* noun, never
+        // the object the parser resolved. Applying the noun check to those would not just refuse the
+        // take, it would actively take the wrong thing (the sword the player explicitly excluded).
+        // "pick up everything except the tube" is a supported phrasing - see
+        // IntegrationTests/OpenAITakeAndDropParserTests.cs.
+        var target = GetTarget();
+        var location = Repository.GetLocation<NorthOfHouse>();
+        target.Context.CurrentLocation = location;
+        location.ItemPlacedHere(Repository.GetItem<Lantern>());
+        location.ItemPlacedHere(Repository.GetItem<Sword>());
+
+        TakeAndDropParser.Setup(s => s.GetListOfItemsToTake(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(["lantern"]);
+
+        IVerbProcessor processor = new TakeOrDropInteractionProcessor(TakeAndDropParser.Object);
+        var result = await processor.Process(
+            new SimpleIntent
+            {
+                Verb = "take", Noun = "sword",
+                OriginalInput = "pick up everything except the sword"
+            },
+            target.Context, Repository.GetItem<Lantern>(), Client.Object);
+
+        result!.InteractionMessage.Should().Contain("Taken");
+        target.Context.HasItem<Lantern>().Should().BeTrue("it is the only item the quantifier covers");
+        target.Context.HasItem<Sword>().Should().BeFalse("the player explicitly excluded the sword");
+    }
+
+    [Test]
+    public async Task Take_MultipleObjectsNamedButOnlyOnePresent_StillTakesThePresentOne()
+    {
+        // Issue #502 guard rail: on "take X and Y" the parser only ever returns what the room
+        // actually holds, while action.Noun is whichever noun came first. A single returned candidate
+        // is then a legitimate partial resolution of a multi-object request, not a substitution.
+        var target = GetTarget();
+        var location = Repository.GetLocation<NorthOfHouse>();
+        target.Context.CurrentLocation = location;
+        location.ItemPlacedHere(Repository.GetItem<Lantern>());
+
+        TakeAndDropParser.Setup(s => s.GetListOfItemsToTake(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(["lantern"]);
+
+        IVerbProcessor processor = new TakeOrDropInteractionProcessor(TakeAndDropParser.Object);
+        var result = await processor.Process(
+            new SimpleIntent { Verb = "take", Noun = "sword", OriginalInput = "take the sword and the lantern" },
+            target.Context, Repository.GetItem<Lantern>(), Client.Object);
+
+        result!.InteractionMessage.Should().Contain("Taken");
+        target.Context.HasItem<Lantern>().Should().BeTrue();
+    }
+
+    [Test]
     public async Task Drop_NounMatchesNothingHeld_DoesNotSilentlyDropTheOnlyItemCarried()
     {
         // Issue #502: GetItemsToDrop has the same shape as GetItemsToTake - with a single item in


### PR DESCRIPTION
Fixes #502.

## The bug

`TakeOrDropInteractionProcessor` asks the AI list-parser which items the player wants, scoped to the room description (take) or the inventory listing (drop). When exactly **one** candidate is present, the parser returns that candidate for essentially any noun — there is nothing else it could name. `GetItemsToTake` / `GetItemsToDrop` then treated *"the parser returned one thing"* as *"the player asked for that thing"* and acted on it unconditionally:

```
> take xyzzy
Taken.            <- the room's only item, silently pocketed
```

and, worse because the noun is legitimate:

```
> take medicine
Taken.            <- the red spool was taken; the medicine is still in the bottle
```

The two `GetItemInScope` / `GetItemInInventory` lookups already in that branch are fallbacks for *resolving* the returned string, not a guard on whether it was the right string. The zero- and multi-candidate cases behaved correctly only incidentally.

## The fix

`GameEngine/Item/ItemProcessor/TakeOrDropInteractionProcessor.cs` — new `ItemThePlayerActuallyNamed` helper, applied in both single-candidate branches. It confirms the candidate matches the noun the `IntentParser` already extracted from the player's input; if it doesn't, the player's own noun wins, and when that resolves to nothing the callers' existing null handling yields `NoNounMatchInteractionResult` instead of a wrong-item success.

This also improves the `take medicine` shape beyond a refusal: the noun resolves to a real in-scope object, so the take now follows the noun and picks up the medicine.

Two supporting pieces carry most of the correctness, both added in the second commit after code review found the first cut of the guard was too aggressive:

**`NamesASingleObject` — only a single-object request can be policed.** `TakeIntent.Noun` / `DropIntent.Noun` is just `nouns.FirstOrDefault()` (`ParsingHelper`), so on a quantified command it is a collective word or even the *excluded* noun: `"pick up everything except the sword"` yields `Noun = "sword"`. Checking the candidate against that didn't merely refuse a legitimate take — it re-resolved `"sword"` and took the very object the player excluded. Likewise `"take X and Y"` where only Y is present returns Y while `Noun` is X; a single candidate there is a legitimate partial resolution, not a substitution. These phrasings are supported — see `IntegrationTests/OpenAITakeAndDropParserTests.cs`. So the guard is gated to commands that name exactly one object: it bails on collective nouns (`all`, `everything`, `both`, …) and on any `OriginalInput` carrying a multi-object marker (` and `, ` , `, ` except `, ` but `, …). Markers are space-padded at the comparison site, so `"take the ball"` doesn't trip on `" all "` and `"press the button"` doesn't trip on `" but "`.

**`NounCouldName` — a matcher the container overrides don't shadow.** The word-boundary containment fallback that lets `"brass lantern"` match a bare `"lantern"` exists only on `ItemBase`; `ContainerBase` and `OpenAndCloseContainerBase` override `HasMatchingNoun` with plain exact equality. Routing the check through `HasMatchingNoun` therefore made it exact-match-only for every container-derived item (sack, bottle, canteen, coffin, survival kit…), refusing any adjective the player added but the parser didn't echo — `"take the elongated sack"`, `"drop the full canteen"`. `NounCouldName` instead compares the item's own `NounsForMatching` / `NounsForPreciseMatching` directly, with word-boundary containment in **both** directions so it doesn't matter which side carries the extra adjective. It looks only at the candidate's own nouns — a bag that happens to hold the named object is not itself the named object, which is exactly the `take medicine` case.

## Original behavior (ZIL, ground truth)

The original parser never substitutes an object: an unknown vocabulary word is rejected outright (`planetfall-source/parser.zil:509`), and a known word for an object not in scope gets the standard refusal (`planetfall-source/verbs.zil:48-50`). There is no path in which naming one object causes a different object to be taken.

## Tests (TDD)

Added to `UnitTests/SingleNounProcessors/TakeProcessorTests.cs`, deterministic — real `Repository`, stubbed `IAITakeAndAndDropParser`, no AI call. The stub is what makes the bug reproducible at all: the default test stub echoes the player's own word back, so only a stub that returns the room's lone item (what production really does) exposes it.

Red first for the bug itself, and confirmed red for the right reason — the take tests failed with `PositiveInteractionResult` where `NoNounMatchInteractionResult` was expected, i.e. the item really was taken:

- `Take_NounMatchesNothingInScope_DoesNotSilentlyTakeTheRoomsOnlyItem`
- `Take_NounNamesADifferentInScopeItem_TakesTheOneThePlayerNamed`
- `Drop_NounMatchesNothingHeld_DoesNotSilentlyDropTheOnlyItemCarried`

Red again for each regression code review identified, before narrowing the guard:

- `Take_QuantifiedRequest_StillTakesTheOneQualifyingItem` — failed by taking the excluded sword
- `Take_MultipleObjectsNamedButOnlyOnePresent_StillTakesThePresentOne`
- `Take_AdjectiveTheParserDidNotEcho_StillMatchesAContainerItem`

Guard rails pinning what the fix could plausibly break (green throughout):

- `Take_CompoundPhraseFromTheParser_StillResolvesToThePlayersNoun`
- `Take_TheItemThePlayerActuallyNamed_IsStillTaken`
- `Take_BareVerbWithTwoItemsPresent_StillAsksWhichOne`
- `Drop_TheItemThePlayerActuallyNamed_IsStillDropped`

## Verification

Every suite run separately, all green:

| Project | Result |
|---|---|
| `UnitTests` | 1095 passed, 1 skipped |
| `ZorkOne.Tests` | 1782 passed |
| `Planetfall.Tests` | 3216 passed |
| `Stationfall.Tests` | 4 passed |
| `EscapeRoom.Tests` | 9 passed |
| `Console.Tests` | 16 passed |

The Zork I and Planetfall walkthroughs lean heavily on `take`, so they are the real safety net here.

## Deliberately not done

- The issue raises, as a separate call, whether an unresolvable noun should get a deterministic "You can't see any &lt;noun&gt; here." instead of falling through to the narrator. This PR only stops the wrong-item take; the fall-through is unchanged.
- Because the guard now skips multi-object commands, `"take xyzzy and frobnitz"` in a one-item room can still take that item. That is the pre-existing multi-object behavior, unchanged here — narrowing it would require the intent to carry all of its nouns rather than just the first.