### PR TITLE
Kitchen dispenser: examine the machine and admit the canteen in the niche

### DIFF
--- a/Planetfall.Tests/KitchenAndCanteenTests.cs
+++ b/Planetfall.Tests/KitchenAndCanteenTests.cs
@@ -269,6 +269,89 @@ public class KitchenAndCanteenTests : EngineTestsBase
     // TODO: drink dont have it
 
     [Test]
+    public async Task ExamineMachine_EmptyNiche_DescribesAnEmptyNiche()
+    {
+        // Issue #504: the empty-niche wording must not leak the canteen sentence. Both fixed halves
+        // of the original description stay put; only the middle sentence is conditional.
+        var target = GetTarget();
+        StartHere<Kitchen>();
+
+        var response = await target.GetResponse("examine machine");
+
+        response.Should().Contain("This wall-mounted unit contains an octagonal niche beneath a spout");
+        response.Should().Contain("Above the spout is a button");
+        response.Should().Contain("Hii Prooteen Likwid Dispensur");
+        response.Should().NotContain("canteen");
+    }
+
+    [Test]
+    public async Task ExamineMachine_CanteenInNiche_MentionsTheCanteen()
+    {
+        // Issue #504: examining the machine used to return a constant, so it described an empty niche
+        // even with the canteen resting in it - contradicting the room listing in the very same turn.
+        // The original splices a canteen sentence between the two fixed halves.
+        var target = GetTarget();
+        StartHere<Kitchen>();
+        GetItem<KitchenMachine>().ItemPlacedHere<Canteen>();
+
+        var response = await target.GetResponse("examine machine");
+
+        response.Should().Contain("A canteen is resting in the niche, its mouth lying just below the spout");
+        response.Should().Contain("This wall-mounted unit contains an octagonal niche beneath a spout");
+        response.Should().Contain("Above the spout is a button");
+        response.Should().Contain("Hii Prooteen Likwid Dispensur");
+    }
+
+    [Test]
+    public async Task ExamineNiche_CanteenInNiche_MentionsTheCanteen()
+    {
+        // Issue #504: "examine niche" is the natural "where did my canteen go?" follow-up and routes to
+        // the same description, so it must admit what is in the niche too.
+        var target = GetTarget();
+        StartHere<Kitchen>();
+        GetItem<KitchenMachine>().ItemPlacedHere<Canteen>();
+
+        var response = await target.GetResponse("examine niche");
+
+        response.Should().Contain("A canteen is resting in the niche, its mouth lying just below the spout");
+    }
+
+    [Test]
+    public async Task LookInNiche_CanteenInNiche_MentionsTheCanteen()
+    {
+        // Issue #504: the machine is transparent (TRANSBIT in the original), so looking into the niche
+        // must reveal the canteen rather than repeating the empty-niche constant.
+        var target = GetTarget();
+        StartHere<Kitchen>();
+        GetItem<KitchenMachine>().ItemPlacedHere<Canteen>();
+
+        var response = await target.GetResponse("look in niche");
+
+        response.Should().Contain("canteen");
+    }
+
+    [Test]
+    public async Task PutCanteenInNiche_ThenExamineMachine_AgreesWithTheRoomDescription()
+    {
+        // Issue #504: the defect was a self-contradiction inside a single turn - "look" reported the
+        // canteen while "examine machine" denied it. Whenever the niche holds something, both views
+        // must agree. This is the assertion that would have caught the bug from the start, and it
+        // generalises to the #438 family of descriptions asserting a mutable fact as a literal.
+        var target = GetTarget();
+        StartHere<Kitchen>();
+        target.Context.ItemPlacedHere<Canteen>();
+
+        await target.GetResponse("put canteen in niche");
+        GetItem<KitchenMachine>().Items.Should().NotBeEmpty();
+
+        var roomDescription = await target.GetResponse("look");
+        var examineDescription = await target.GetResponse("examine machine");
+
+        roomDescription.Should().Contain("canteen");
+        examineDescription.Should().Contain("canteen");
+    }
+
+    [Test]
     public async Task PutBrushInCanteen_TypeRefusal_NamesTheItem_AndIsNotBlank()
     {
         var target = GetTarget();

--- a/Planetfall/Item/Kalamontee/KitchenMachine.cs
+++ b/Planetfall/Item/Kalamontee/KitchenMachine.cs
@@ -12,8 +12,17 @@ internal class KitchenMachine : ContainerBase, ICanBeExamined
 
     public override string CanOnlyHoldTheseTypesErrorMessage(string nameOfItemWeTriedToPlaceHere) => "It doesn't fit in the niche. ";
 
+    // Issue #504: this used to be a flat constant, so "examine machine" described an empty niche even
+    // with the canteen sitting in it - contradicting the room listing (GenericDescription, below) in the
+    // very same turn, on the one action the room description tells the player to take. The original
+    // splices a canteen sentence between the two fixed halves; keep the contents interpolated here so a
+    // mutable fact is never asserted as a literal. CanOnlyHoldTheseTypes is [Canteen], so Items.Any()
+    // implies the canteen and naming it directly is safe. "examine niche" and "look in niche" route
+    // here too, which is why the fix also fixes the "where did my canteen go?" follow-ups.
     public string ExaminationDescription =>
-        "This wall-mounted unit contains an octagonal niche beneath a spout. Above the spout is a button. " +
+        "This wall-mounted unit contains an octagonal niche beneath a spout. " +
+        (Items.Any() ? "A canteen is resting in the niche, its mouth lying just below the spout. " : "") +
+        "Above the spout is a button. " +
         "The machine is labelled\n\"Hii Prooteen Likwid Dispensur.\" ";
 
     public override string GenericDescription(ILocation? currentLocation)


### PR DESCRIPTION
Fixes #504.

## The bug

`KitchenMachine.ExaminationDescription` (`Planetfall/Item/Kalamontee/KitchenMachine.cs:15-17`) was a flat constant with no reference to `Items`, so `examine machine` described an empty niche even with the canteen resting in it:

```
> put canteen in niche
The canteen fits snugly into the octagonal niche, its mouth resting just below the spout of the machine.

> look
...
The dispenser unit contains:
   A canteen                                   <- the room knows

> examine machine
This wall-mounted unit contains an octagonal niche beneath a spout. Above the spout is a button.
The machine is labelled "Hii Prooteen Likwid Dispensur."      <- the machine does not
```

A self-contradiction inside a single turn, on the one action the room description explicitly tells the player to take ("You should probably examine it more closely"). The sibling `GenericDescription` in the same class interpolates the contents correctly, which is why `look` gets it right; only the examine path was left hardcoded. `examine niche` and `look in niche` — the natural "where did my canteen go?" follow-ups — route to the same description and were equally wrong, despite `IsTransparent => true`.

Filling the canteen is a mandatory survival step, so every playthrough passes through this exact state.

## The fix

The original splices a conditional canteen sentence between the two fixed halves of the description; the port reproduced both halves verbatim and dropped the middle. Interpolate the contents the same way, mirroring `GenericDescription` in this class:

```csharp
public string ExaminationDescription =>
    "This wall-mounted unit contains an octagonal niche beneath a spout. " +
    (Items.Any() ? "A canteen is resting in the niche, its mouth lying just below the spout. " : "") +
    "Above the spout is a button. " +
    "The machine is labelled\n\"Hii Prooteen Likwid Dispensur.\" ";
```

`CanOnlyHoldTheseTypes` is `[typeof(Canteen)]`, so `Items.Any()` implies the canteen and naming it directly is safe. A comment records the trap so the constant isn't reintroduced.

Same family as #438 (Mess Hall hardcoding "A door to the south is closed"): a description asserting a mutable fact as a literal.

## Tests (TDD)

Added to the existing `Planetfall.Tests/KitchenAndCanteenTests.cs`. All deterministic — real `Repository` with `Repository.Reset()` via `EngineTestsBase`, no AI, network, clock, or randomness — and all run in the project's normal `dotnet test` command.

- `ExamineMachine_CanteenInNiche_MentionsTheCanteen` — red before the fix, green after. Confirmed from the assertion diff that the failure was the empty-niche constant, not a wording mismatch.
- `ExamineNiche_CanteenInNiche_MentionsTheCanteen` and `LookInNiche_CanteenInNiche_MentionsTheCanteen` — the same for the two follow-up phrasings; also red before, green after.
- `PutCanteenInNiche_ThenExamineMachine_AgreesWithTheRoomDescription` — plays the reported sequence and asserts the room listing and the examine text agree whenever the niche holds something. This is the assertion that would have caught the bug from the start, and it generalises to the #438 family.
- `ExamineMachine_EmptyNiche_DescribesAnEmptyNiche` — pins the empty case (no "canteen", both fixed halves still present) so the new sentence can't leak into it. Passed before and after, as intended for a pin.

Verification, run separately (`dotnet test A B` errors with MSB1008):

- `dotnet test Planetfall.Tests` — 3221 passed, 0 failed
- `dotnet test UnitTests` — 1085 passed, 0 failed

## Note left open

Issue #504 also asks whether `look in niche` on a transparent container ought to go through the normal container-listing path rather than being routed to `ExaminationDescription`. That's a routing change in the shared engine rather than a bug in this item, so it isn't part of this fix — with the change above `look in niche` at least stops being wrong, and the new test pins that behavior wherever the routing ends up.

---
_Generated by [Claude Code](https://claude.ai/code/session_013cdaGhyLHmaGraiGa6h3V6)_