### PR TITLE
Elevator: answer every lobby surface from the car's effective position (#505)

### DIFF
--- a/Planetfall.Tests/ElevatorTests.cs
+++ b/Planetfall.Tests/ElevatorTests.cs
@@ -1034,4 +1034,210 @@ public class ElevatorTests : EngineTestsBase
         var response = await target.GetResponse("examine blue door");
         response.Should().Contain("The door is open");
     }
+
+    /// <summary>
+    ///     The two doors must not be transposed: with only one car at the lobby, each door has to report
+    ///     its own shaft. Both examine tests above use matching states, which would not catch a swap.
+    /// </summary>
+    [Test]
+    public async Task ExamineDoor_OnlyTheBlueCarIsHere_EachDoorReportsItsOwnShaft()
+    {
+        var target = GetTarget();
+        StartHere<ElevatorLobby>();
+        GetItem<UpperElevatorDoor>().IsOpen = true;
+        GetItem<LowerElevatorDoor>().IsOpen = true;
+        GetLocation<UpperElevator>().InLobby = true;
+        GetLocation<LowerElevator>().InLobby = false;
+
+        var response = await target.GetResponse("examine blue door");
+        response.Should().Contain("The door is open");
+
+        response = await target.GetResponse("examine red door");
+        response.Should().Contain("The door is closed");
+    }
+
+    /// <summary>
+    ///     The call button is how the player recovers from a car parked at the far end - the whole reason
+    ///     issue #505 was not a progression block. It gated on the raw shared flag, so in exactly the
+    ///     state the room now (correctly) calls closed it answered "has no effect" and never summoned.
+    /// </summary>
+    [Test]
+    public async Task PressButton_Blue_CarIsAwayWithTheSharedFlagStillOpen_RecallsTheCar()
+    {
+        var target = GetTarget();
+        StartHere<ElevatorLobby>();
+        // The state a completed ride leaves behind: the car is at the far end, and its arrival left the
+        // shared flag open there.
+        GetItem<UpperElevatorDoor>().IsOpen = true;
+        GetLocation<UpperElevator>().InLobby = false;
+
+        var response = await target.GetResponse("press blue button");
+        response.Should().Contain("You hear a faint whirring noise from behind the blue door");
+        response.Should().NotContain("no effect");
+        response.Should().NotContain("Patience");
+
+        await target.GetResponse("wait");
+        await target.GetResponse("wait");
+        response = await target.GetResponse("wait");
+        response.Should().Contain("The door at the north end of the room slides open");
+
+        response = await target.GetResponse("n");
+        response.Should().Contain("Upper Elevator");
+    }
+
+    [Test]
+    public async Task PressButton_Red_CarIsAwayWithTheSharedFlagStillOpen_RecallsTheCar()
+    {
+        var target = GetTarget();
+        StartHere<ElevatorLobby>();
+        GetItem<LowerElevatorDoor>().IsOpen = true;
+        GetLocation<LowerElevator>().InLobby = false;
+
+        var response = await target.GetResponse("press red button");
+        response.Should().Contain("The red door begins vibrating a bit");
+        response.Should().NotContain("no effect");
+        response.Should().NotContain("Patience");
+
+        await target.GetResponse("wait");
+        await target.GetResponse("wait");
+        response = await target.GetResponse("wait");
+        response.Should().Contain("The door at the south end of the room slides open");
+
+        response = await target.GetResponse("s");
+        response.Should().Contain("Lower Elevator");
+    }
+
+    /// <summary>
+    ///     The same recall, reached by ordinary play rather than by setting flags: ride the blue car up,
+    ///     step out at the Tower, and come back to the lobby. Only the player is moved back (as the
+    ///     issue's god-mode teleport did); every bit of the elevator's state is whatever the ride left.
+    /// </summary>
+    [Test]
+    public async Task PressButton_Blue_AfterRidingUpAndWalkingBack_RecallsTheCar()
+    {
+        var target = GetTarget();
+        StartHere<ElevatorLobby>();
+        Take<UpperElevatorAccessCard>();
+
+        await target.GetResponse("press blue button");
+        await target.GetResponse("wait");
+        await target.GetResponse("wait");
+        await target.GetResponse("wait");
+        await target.GetResponse("north");
+        await target.GetResponse("slide upper access card through slot");
+        await target.GetResponse("press up button");
+        await target.GetResponse("wait");
+        await target.GetResponse("wait");
+        var response = await target.GetResponse("south");
+        response.Should().Contain("Tower Core");
+
+        // Let the card's activation lapse, as it would while walking back.
+        await target.GetResponse("wait");
+        await target.GetResponse("wait");
+        GetLocation<UpperElevator>().IsEnabled.Should().BeFalse();
+
+        // The car is parked at the top with the shared flag left open by its arrival.
+        GetLocation<UpperElevator>().InLobby.Should().BeFalse();
+        GetItem<UpperElevatorDoor>().IsOpen.Should().BeTrue();
+
+        // Back at the lobby, on foot. Only the player moves - assigning CurrentLocation directly rather
+        // than via StartHere, which would clear the actor list and freeze the elevator's own timers.
+        Context.CurrentLocation = GetLocation<ElevatorLobby>();
+
+        response = await target.GetResponse("look");
+        response.Should().Contain("A blue metal door to the north is closed");
+
+        response = await target.GetResponse("press blue button");
+        response.Should().Contain("You hear a faint whirring noise from behind the blue door");
+
+        await target.GetResponse("wait");
+        await target.GetResponse("wait");
+        response = await target.GetResponse("wait");
+        response.Should().Contain("The door at the north end of the room slides open");
+
+        response = await target.GetResponse("north");
+        response.Should().Contain("Upper Elevator");
+    }
+
+    /// <summary>
+    ///     A fulfilled summon has to clear its own bookkeeping, or the "Patience, patience..." guard
+    ///     stays armed forever and every later summon of that car short-circuits without registering the
+    ///     actor - so the car still could never be recalled, even with the button's gate corrected.
+    /// </summary>
+    [Test]
+    public async Task Summon_OnceComplete_ClearsTheSummonBookkeeping()
+    {
+        var target = GetTarget();
+        StartHere<ElevatorLobby>();
+
+        await target.GetResponse("press blue button");
+        await target.GetResponse("wait");
+        await target.GetResponse("wait");
+        var response = await target.GetResponse("wait");
+        response.Should().Contain("The door at the north end of the room slides open");
+
+        GetLocation<UpperElevator>().HasBeenSummoned.Should().BeFalse();
+        GetLocation<UpperElevator>().TurnsSinceSummoned.Should().Be(0);
+    }
+
+    /// <summary>
+    ///     "open"/"close" are the third and fourth surfaces reading the shared flag: on the same turn the
+    ///     room, the examine and the exit all say closed, "open red door" used to answer "It is open."
+    /// </summary>
+    [Test]
+    [TestCase("blue")]
+    [TestCase("red")]
+    public async Task OpenDoor_CarIsAway_WontBudge(string door)
+    {
+        var target = GetTarget();
+        StartHere<ElevatorLobby>();
+        GetItem<UpperElevatorDoor>().IsOpen = true;
+        GetItem<LowerElevatorDoor>().IsOpen = true;
+        GetLocation<UpperElevator>().InLobby = false;
+        GetLocation<LowerElevator>().InLobby = false;
+
+        var response = await target.GetResponse($"open {door} door");
+        response.Should().Contain("It won't budge");
+        response.Should().NotContain("It is open");
+    }
+
+    [Test]
+    [TestCase("blue")]
+    [TestCase("red")]
+    public async Task CloseDoor_CarIsAway_AlreadyClosed(string door)
+    {
+        var target = GetTarget();
+        StartHere<ElevatorLobby>();
+        GetItem<UpperElevatorDoor>().IsOpen = true;
+        GetItem<LowerElevatorDoor>().IsOpen = true;
+        GetLocation<UpperElevator>().InLobby = false;
+        GetLocation<LowerElevator>().InLobby = false;
+
+        var response = await target.GetResponse($"close {door} door");
+        response.Should().Contain("It is closed");
+        response.Should().NotContain("designed to slide shut");
+    }
+
+    [Test]
+    public async Task OpenAndCloseDoor_OnlyTheBlueCarIsHere_EachDoorReportsItsOwnShaft()
+    {
+        var target = GetTarget();
+        StartHere<ElevatorLobby>();
+        GetItem<UpperElevatorDoor>().IsOpen = true;
+        GetItem<LowerElevatorDoor>().IsOpen = true;
+        GetLocation<UpperElevator>().InLobby = true;
+        GetLocation<LowerElevator>().InLobby = false;
+
+        var response = await target.GetResponse("open blue door");
+        response.Should().Contain("It is open");
+
+        response = await target.GetResponse("open red door");
+        response.Should().Contain("It won't budge");
+
+        response = await target.GetResponse("close blue door");
+        response.Should().Contain("designed to slide shut");
+
+        response = await target.GetResponse("close red door");
+        response.Should().Contain("It is closed");
+    }
 }

--- a/Planetfall.Tests/ElevatorTests.cs
+++ b/Planetfall.Tests/ElevatorTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using Planetfall.Item.Kalamontee.Admin;
 using Planetfall.Location.Kalamontee;
+using Planetfall.Location.Kalamontee.Tower;
 using Planetfall.Location.Shuttle;
 
 namespace Planetfall.Tests;
@@ -209,6 +210,53 @@ public class ElevatorTests : EngineTestsBase
         var response = await target.GetResponse("s");
         response.Should().Contain("The door is closed");
         response.Should().NotContain("Lower Elevator");
+    }
+
+    /// <summary>
+    ///     The Tower Core is the far end of the upper shaft, the mirror of the Waiting Area on the lower
+    ///     one - and it was still a bare Go&lt;UpperElevator&gt;(). With the shared flag left open by the car's
+    ///     arrival at the lobby, you could walk north into a car that is not there; stepping back out
+    ///     then landed you in the Elevator Lobby, having ridden nothing, because the car's own exit
+    ///     resolves against where the car is rather than where you got in.
+    /// </summary>
+    [Test]
+    public async Task Enter_FromTowerCore_CarIsDownAtTheLobby()
+    {
+        var target = GetTarget();
+        StartHere<TowerCore>();
+        // The car is down at the lobby with its door open at that end - there is nothing to step into here.
+        GetLocation<UpperElevator>().InLobby = true;
+        GetItem<UpperElevatorDoor>().IsOpen = true;
+
+        var response = await target.GetResponse("n");
+        response.Should().Contain("The door is closed");
+        response.Should().NotContain("Upper Elevator");
+        Context.CurrentLocation.Should().BeOfType<TowerCore>();
+    }
+
+    [Test]
+    public async Task Enter_FromTowerCore_DoorClosed()
+    {
+        var target = GetTarget();
+        StartHere<TowerCore>();
+        GetLocation<UpperElevator>().InLobby = false;
+        GetItem<UpperElevatorDoor>().IsOpen = false;
+
+        var response = await target.GetResponse("n");
+        response.Should().Contain("The door is closed");
+        response.Should().NotContain("Upper Elevator");
+    }
+
+    [Test]
+    public async Task Enter_FromTowerCore_CarIsHere()
+    {
+        var target = GetTarget();
+        StartHere<TowerCore>();
+        GetLocation<UpperElevator>().InLobby = false;
+        GetItem<UpperElevatorDoor>().IsOpen = true;
+
+        var response = await target.GetResponse("n");
+        response.Should().Contain("Upper Elevator");
     }
 
     [Test]

--- a/Planetfall.Tests/ElevatorTests.cs
+++ b/Planetfall.Tests/ElevatorTests.cs
@@ -24,7 +24,9 @@ public class ElevatorTests : EngineTestsBase
     {
         var target = GetTarget();
         StartHere<ElevatorLobby>();
+        // A door only reads as open from the lobby when its car is standing at the lobby (issue #505).
         GetItem<UpperElevatorDoor>().IsOpen = true;
+        GetLocation<UpperElevator>().InLobby = true;
 
         var response = await target.GetResponse("look");
         response.Should()
@@ -37,6 +39,7 @@ public class ElevatorTests : EngineTestsBase
         var target = GetTarget();
         StartHere<ElevatorLobby>();
         GetItem<LowerElevatorDoor>().IsOpen = true;
+        GetLocation<LowerElevator>().InLobby = true;
 
         var response = await target.GetResponse("look");
         response.Should()
@@ -50,6 +53,8 @@ public class ElevatorTests : EngineTestsBase
         StartHere<ElevatorLobby>();
         GetItem<LowerElevatorDoor>().IsOpen = true;
         GetItem<UpperElevatorDoor>().IsOpen = true;
+        GetLocation<LowerElevator>().InLobby = true;
+        GetLocation<UpperElevator>().InLobby = true;
 
         var response = await target.GetResponse("look");
         response.Should()
@@ -830,5 +835,203 @@ public class ElevatorTests : EngineTestsBase
         response.Should().Contain("Upper Elevator");
         response = await target.GetResponse("press up button");
         response.Should().Contain("Nothing happens");
+    }
+
+    /// <summary>
+    ///     Issue #505. The door flag is shared by both ends of the shaft, and the arrival code leaves it
+    ///     open at whichever end the car parked at. The lobby's description used to read that bare flag,
+    ///     so it announced a door as open while walking that way answered "The door is closed."
+    /// </summary>
+    [Test]
+    public async Task Look_Upper_CarIsAwayAtTheTower_ReportsTheBlueDoorClosed()
+    {
+        var target = GetTarget();
+        StartHere<ElevatorLobby>();
+        GetItem<UpperElevatorDoor>().IsOpen = true;
+        GetLocation<UpperElevator>().InLobby = false;
+
+        var response = await target.GetResponse("look");
+        response.Should().Contain("A blue metal door to the north is closed");
+        response.Should().NotContain("blue metal door to the north is open");
+    }
+
+    [Test]
+    public async Task Look_Lower_CarIsAwayAtTheWaitingArea_ReportsTheRedDoorClosed()
+    {
+        var target = GetTarget();
+        StartHere<ElevatorLobby>();
+        GetItem<LowerElevatorDoor>().IsOpen = true;
+        GetLocation<LowerElevator>().InLobby = false;
+
+        var response = await target.GetResponse("look");
+        response.Should().Contain("red metal door to the south is also closed");
+        response.Should().NotContain("door to the south is open");
+        response.Should().NotContain("door to the south is also open");
+    }
+
+    [Test]
+    public async Task Look_Upper_CarIsHere_ReportsTheBlueDoorOpen_AndNorthIsPassable()
+    {
+        var target = GetTarget();
+        StartHere<ElevatorLobby>();
+        GetItem<UpperElevatorDoor>().IsOpen = true;
+        GetLocation<UpperElevator>().InLobby = true;
+
+        var response = await target.GetResponse("look");
+        response.Should().Contain("A blue metal door to the north is open");
+
+        response = await target.GetResponse("n");
+        response.Should().Contain("Upper Elevator");
+    }
+
+    [Test]
+    public async Task Look_Lower_CarIsHere_ReportsTheRedDoorOpen_AndSouthIsPassable()
+    {
+        var target = GetTarget();
+        StartHere<ElevatorLobby>();
+        GetItem<LowerElevatorDoor>().IsOpen = true;
+        GetLocation<LowerElevator>().InLobby = true;
+
+        var response = await target.GetResponse("look");
+        response.Should().Contain("red metal door to the south is open");
+
+        response = await target.GetResponse("s");
+        response.Should().Contain("Lower Elevator");
+    }
+
+    /// <summary>
+    ///     The invariant behind issues #456, #450 and #505: whatever word the lobby uses for a door, the
+    ///     matching movement must agree. Covers all four (IsOpen x InLobby) states of each shaft.
+    /// </summary>
+    [Test]
+    [TestCase(false, false)]
+    [TestCase(false, true)]
+    [TestCase(true, false)]
+    [TestCase(true, true)]
+    public async Task Look_BlueDoorWording_AlwaysAgreesWithWhetherNorthIsPassable(bool isOpen, bool inLobby)
+    {
+        var target = GetTarget();
+        StartHere<ElevatorLobby>();
+        GetItem<UpperElevatorDoor>().IsOpen = isOpen;
+        GetLocation<UpperElevator>().InLobby = inLobby;
+
+        var look = await target.GetResponse("look");
+        var describedAsOpen = look!.Contains("blue metal door to the north is open");
+        look.Should().Contain(describedAsOpen ? "north is open" : "north is closed");
+
+        var move = await target.GetResponse("n");
+        var walkedIntoTheCar = move!.Contains("Upper Elevator");
+
+        describedAsOpen.Should().Be(walkedIntoTheCar);
+    }
+
+    [Test]
+    [TestCase(false, false)]
+    [TestCase(false, true)]
+    [TestCase(true, false)]
+    [TestCase(true, true)]
+    public async Task Look_RedDoorWording_AlwaysAgreesWithWhetherSouthIsPassable(bool isOpen, bool inLobby)
+    {
+        var target = GetTarget();
+        StartHere<ElevatorLobby>();
+        GetItem<LowerElevatorDoor>().IsOpen = isOpen;
+        GetLocation<LowerElevator>().InLobby = inLobby;
+
+        var look = await target.GetResponse("look");
+        var describedAsOpen = look!.Contains("door to the south is open") ||
+                              look.Contains("door to the south is also open");
+
+        var move = await target.GetResponse("s");
+        var walkedIntoTheCar = move!.Contains("Lower Elevator");
+
+        describedAsOpen.Should().Be(walkedIntoTheCar);
+    }
+
+    /// <summary>
+    ///     The "also" clause means "both doors are in the same state", so it has to be computed from the
+    ///     effective states too - not from the raw flags, which can agree while the effective states differ.
+    /// </summary>
+    [Test]
+    public async Task Look_RawFlagsAgreeButEffectiveStatesDiffer_OmitsAlso()
+    {
+        var target = GetTarget();
+        StartHere<ElevatorLobby>();
+        GetItem<UpperElevatorDoor>().IsOpen = true;
+        GetItem<LowerElevatorDoor>().IsOpen = true;
+        GetLocation<UpperElevator>().InLobby = true;
+        GetLocation<LowerElevator>().InLobby = false;
+
+        var response = await target.GetResponse("look");
+        response.Should()
+            .Contain("A blue metal door to the north is open and a larger red metal door to the south is closed");
+    }
+
+    [Test]
+    public async Task Look_RawFlagsDifferButBothEffectivelyClosed_SaysAlso()
+    {
+        var target = GetTarget();
+        StartHere<ElevatorLobby>();
+        GetItem<UpperElevatorDoor>().IsOpen = false;
+        GetItem<LowerElevatorDoor>().IsOpen = true;
+        GetLocation<LowerElevator>().InLobby = false;
+
+        var response = await target.GetResponse("look");
+        response.Should()
+            .Contain(
+                "A blue metal door to the north is closed and a larger red metal door to the south is also closed");
+    }
+
+    /// <summary>
+    ///     Issue #505, consequence two: "examine blue door" read the same shaft-wide flag, so the natural
+    ///     way to double-check the room description corroborated the wrong answer.
+    /// </summary>
+    [Test]
+    public async Task ExamineDoor_CarIsAway_ReportsClosed()
+    {
+        var target = GetTarget();
+        StartHere<ElevatorLobby>();
+        GetItem<UpperElevatorDoor>().IsOpen = true;
+        GetItem<LowerElevatorDoor>().IsOpen = true;
+        GetLocation<UpperElevator>().InLobby = false;
+        GetLocation<LowerElevator>().InLobby = false;
+
+        var response = await target.GetResponse("examine blue door");
+        response.Should().Contain("The door is closed");
+        response.Should().NotContain("The door is open");
+
+        response = await target.GetResponse("examine red door");
+        response.Should().Contain("The door is closed");
+        response.Should().NotContain("The door is open");
+    }
+
+    [Test]
+    public async Task ExamineDoor_CarIsHere_ReportsOpen()
+    {
+        var target = GetTarget();
+        StartHere<ElevatorLobby>();
+        GetItem<UpperElevatorDoor>().IsOpen = true;
+        GetItem<LowerElevatorDoor>().IsOpen = true;
+        GetLocation<UpperElevator>().InLobby = true;
+        GetLocation<LowerElevator>().InLobby = true;
+
+        var response = await target.GetResponse("examine blue door");
+        response.Should().Contain("The door is open");
+
+        response = await target.GetResponse("examine red door");
+        response.Should().Contain("The door is open");
+    }
+
+    /// <summary>
+    ///     Inside the car the flag *is* local, so the car's own door keeps reporting it directly.
+    /// </summary>
+    [Test]
+    public async Task ExamineDoor_InsideTheCar_StillReportsTheCarsOwnDoor()
+    {
+        var target = GetTarget();
+        StartHere<UpperElevator>().InLobby = false;
+        GetItem<UpperElevatorDoor>().IsOpen = true;
+
+        var response = await target.GetResponse("examine blue door");
+        response.Should().Contain("The door is open");
     }
 }

--- a/Planetfall.Tests/ElevatorTests.cs
+++ b/Planetfall.Tests/ElevatorTests.cs
@@ -1,4 +1,7 @@
 using FluentAssertions;
+using Model.AIGeneration;
+using Model.Intent;
+using Moq;
 using Planetfall.Item.Kalamontee.Admin;
 using Planetfall.Location.Kalamontee;
 using Planetfall.Location.Kalamontee.Tower;
@@ -1204,6 +1207,84 @@ public class ElevatorTests : EngineTestsBase
         response.Should().Contain("The door at the north end of the room slides open");
 
         response = await target.GetResponse("north");
+        response.Should().Contain("Upper Elevator");
+    }
+
+    /// <summary>
+    ///     ExamineInteractionProcessor answers a wider set of verbs than Verbs.ExamineVerbs lists -
+    ///     "check", "look in" and "peek at" appear only in its own switch. Any of them reaching the door
+    ///     item reports the shared flag, so "check blue door" would still answer "open" on the same turn
+    ///     the room, "examine" and the exit all say closed.
+    /// </summary>
+    [Test]
+    [TestCase("examine")]
+    [TestCase("x")]
+    [TestCase("check")]
+    [TestCase("look at")]
+    [TestCase("look in")]
+    [TestCase("peek at")]
+    public async Task ExamineDoor_EveryVerbTheExamineProcessorAnswers_CarIsAway_ReportsClosed(string verb)
+    {
+        GetTarget();
+        var lobby = StartHere<ElevatorLobby>();
+        GetItem<UpperElevatorDoor>().IsOpen = true;
+        GetLocation<UpperElevator>().InLobby = false;
+
+        var result = await lobby.RespondToSimpleInteraction(
+            new SimpleIntent { Verb = verb, Noun = "blue door" }, Context, Mock.Of<IGenerationClient>(), null!);
+
+        result.InteractionMessage.Should().Contain("The door is closed");
+    }
+
+    /// <summary>
+    ///     The arrival line describes the lobby's own doorway, so it must not print in whatever room the
+    ///     player wandered off to - ElevatorIsEnabled right below it already guards this way. Clearing
+    ///     the summon bookkeeping makes this repeatable rather than once per game.
+    /// </summary>
+    [Test]
+    public async Task Summon_PlayerHasLeftTheLobby_DoesNotAnnounceTheDoorElsewhere()
+    {
+        var target = GetTarget();
+        StartHere<ElevatorLobby>();
+
+        await target.GetResponse("press blue button");
+        await target.GetResponse("west");
+        await target.GetResponse("wait");
+        var response = await target.GetResponse("wait");
+
+        response.Should().NotContain("slides open");
+        // The car still arrived - it is only the announcement that is suppressed.
+        GetLocation<UpperElevator>().InLobby.Should().BeTrue();
+        GetItem<UpperElevatorDoor>().IsOpen.Should().BeTrue();
+    }
+
+    /// <summary>
+    ///     A summon must survive the card's activation lapsing. Act() prioritises the enabled countdown,
+    ///     which ends by removing the actor - that silently cancelled the pending summon and left
+    ///     HasBeenSummoned set forever, so every later press answered "Patience, patience..." and the car
+    ///     could never be recalled again.
+    /// </summary>
+    [Test]
+    public async Task PressButton_WhileTheCardIsStillActive_SummonStillCompletes()
+    {
+        var target = GetTarget();
+        StartHere<ElevatorLobby>();
+        GetItem<UpperElevatorDoor>().IsOpen = true;
+        GetLocation<UpperElevator>().InLobby = false;
+        // The car is away and still card-enabled, with its activation about to lapse.
+        GetLocation<UpperElevator>().IsEnabled = true;
+        GetLocation<UpperElevator>().TurnsSinceEnabled = 5;
+
+        var response = await target.GetResponse("press blue button");
+        response.Should().Contain("You hear a faint whirring noise from behind the blue door");
+
+        await target.GetResponse("wait");
+        await target.GetResponse("wait");
+        response = await target.GetResponse("wait");
+        response.Should().Contain("The door at the north end of the room slides open");
+
+        GetLocation<UpperElevator>().HasBeenSummoned.Should().BeFalse();
+        response = await target.GetResponse("n");
         response.Should().Contain("Upper Elevator");
     }
 

--- a/Planetfall/Item/Kalamontee/Admin/ElevatorDoorBase.cs
+++ b/Planetfall/Item/Kalamontee/Admin/ElevatorDoorBase.cs
@@ -3,7 +3,17 @@ namespace Planetfall.Item.Kalamontee.Admin;
 
 public abstract class ElevatorDoorBase : ItemBase, ICanBeExamined, IOpenAndClose
 {
-    public string ExaminationDescription => $"The door is {(IsOpen ? "open" : "closed")}. ";
+    public string ExaminationDescription => DescribeAs(IsOpen);
+
+    /// <summary>
+    ///     The door's own wording for a given state, so a caller that knows better than the raw flag can
+    ///     reuse it instead of copying the literal. The Elevator Lobby needs this: the flag is shared by
+    ///     both ends of the shaft, so from there the answer depends on which end the car is at (#505).
+    /// </summary>
+    public string DescribeAs(bool isOpen)
+    {
+        return $"The door is {(isOpen ? "open" : "closed")}. ";
+    }
     
     public bool IsOpen { get; set; }
 

--- a/Planetfall/Location/Kalamontee/ElevatorBase.cs
+++ b/Planetfall/Location/Kalamontee/ElevatorBase.cs
@@ -60,7 +60,11 @@ internal abstract class ElevatorBase<TDoor, TSlot, TCard> : FloydSpecialInteract
         if (TurnsSinceMoving > 0)
             return ElevatorIsMoving();
 
-        if (IsEnabled)
+        // A pending summon owns the actor slot. The enabled countdown ends by removing the actor, which
+        // would cancel the summon silently and strand HasBeenSummoned set forever - every later press
+        // would then answer "Patience, patience..." and the car could never be recalled. Let the summon
+        // finish first; the countdown resumes once it has.
+        if (IsEnabled && !HasBeenSummoned)
             return ElevatorIsEnabled(context);
 
         if (HasBeenSummoned)
@@ -168,7 +172,6 @@ internal abstract class ElevatorBase<TDoor, TSlot, TCard> : FloydSpecialInteract
             return Task.FromResult(string.Empty);
 
         GetItem<TDoor>().IsOpen = true;
-        context.RemoveActor(this);
         InLobby = true;
 
         // The summon is fulfilled, so clear its bookkeeping: HasBeenSummoned means "a call is in
@@ -178,7 +181,16 @@ internal abstract class ElevatorBase<TDoor, TSlot, TCard> : FloydSpecialInteract
         HasBeenSummoned = false;
         TurnsSinceSummoned = 0;
 
-        return Task.FromResult($"\n\nThe door at the {EntranceDirection} end of the room slides open. ");
+        // Only release the actor slot if nothing else still needs ticking - an activation that was
+        // paused for this summon has to be able to run its countdown down afterwards.
+        if (!IsEnabled)
+            context.RemoveActor(this);
+
+        // The doorway being described is the lobby's, so say so only to a player standing in it, the
+        // way ElevatorIsEnabled below guards its own recording.
+        return Task.FromResult(context.CurrentLocation is ElevatorLobby
+            ? $"\n\nThe door at the {EntranceDirection} end of the room slides open. "
+            : string.Empty);
     }
 
     private Task<string> ElevatorIsEnabled(IContext context)

--- a/Planetfall/Location/Kalamontee/ElevatorBase.cs
+++ b/Planetfall/Location/Kalamontee/ElevatorBase.cs
@@ -26,6 +26,15 @@ internal abstract class ElevatorBase<TDoor, TSlot, TCard> : FloydSpecialInteract
     /// </summary>
     public bool IsOpenAtTheLobby => GetItem<TDoor>().IsOpen && InLobby;
 
+    /// <summary>
+    ///     The same question asked from the shaft's other end - the Tower Core for the upper car, the
+    ///     Waiting Area for the lower one (compone.zil, OTHER-ELEVATOR-ENTER-F). Without the position
+    ///     half, that entrance lets you walk into a car standing at the lobby; stepping back out then
+    ///     lands you in the lobby, having ridden nothing, since the car's exit resolves against where
+    ///     the car actually is.
+    /// </summary>
+    public bool IsOpenAtTheFarEnd => GetItem<TDoor>().IsOpen && !InLobby;
+
     [UsedImplicitly] public int TurnsSinceSummoned { get; set; }
 
     [UsedImplicitly] public int TurnsSinceEnabled { get; set; }

--- a/Planetfall/Location/Kalamontee/ElevatorBase.cs
+++ b/Planetfall/Location/Kalamontee/ElevatorBase.cs
@@ -161,6 +161,14 @@ internal abstract class ElevatorBase<TDoor, TSlot, TCard> : FloydSpecialInteract
         GetItem<TDoor>().IsOpen = true;
         context.RemoveActor(this);
         InLobby = true;
+
+        // The summon is fulfilled, so clear its bookkeeping: HasBeenSummoned means "a call is in
+        // flight", which is what the "Patience, patience..." check below wants. Left set, a later
+        // summon of the same car short-circuited to "Patience" without ever registering the actor,
+        // so the car could never be called back a second time.
+        HasBeenSummoned = false;
+        TurnsSinceSummoned = 0;
+
         return Task.FromResult($"\n\nThe door at the {EntranceDirection} end of the room slides open. ");
     }
 
@@ -231,7 +239,11 @@ internal abstract class ElevatorBase<TDoor, TSlot, TCard> : FloydSpecialInteract
 
     internal InteractionResult SummonElevator(string response, IContext context)
     {
-        if (GetItem<TDoor>().IsOpen)
+        // The call button is only reachable from the lobby, so "the door is already open" has to mean
+        // open *here* - on the raw shared flag, a car parked at the far end refused the summon that is
+        // the player's only way to get it back, in exactly the state the lobby describes as closed
+        // (issue #505).
+        if (IsOpenAtTheLobby)
             return new PositiveInteractionResult($"Pushing the {Color} button has no effect. ");
 
         if (HasBeenSummoned)

--- a/Planetfall/Location/Kalamontee/ElevatorBase.cs
+++ b/Planetfall/Location/Kalamontee/ElevatorBase.cs
@@ -15,6 +15,17 @@ internal abstract class ElevatorBase<TDoor, TSlot, TCard> : FloydSpecialInteract
 
     [UsedImplicitly] public bool InLobby { get; set; }
 
+    /// <summary>
+    ///     Whether this car's door is open <i>as seen from the Elevator Lobby</i>. The OPENBIT flag is
+    ///     shared by both ends of the shaft, and the arrival path leaves it open at whichever end the car
+    ///     parked at, so the bare flag cannot say which floor the car is on. Every lobby-side surface -
+    ///     the entrance in <see cref="ElevatorLobby" />'s map, the lobby's description, and
+    ///     "examine blue/red door" - has to agree on this one predicate or the room contradicts itself
+    ///     (issues #456, #450, #505). compone.zil's ELEVATOR-LOBBY-F and ELEVATOR-ENTER-F both test the
+    ///     flag alongside *-ELEVATOR-UP for the same reason.
+    /// </summary>
+    public bool IsOpenAtTheLobby => GetItem<TDoor>().IsOpen && InLobby;
+
     [UsedImplicitly] public int TurnsSinceSummoned { get; set; }
 
     [UsedImplicitly] public int TurnsSinceEnabled { get; set; }

--- a/Planetfall/Location/Kalamontee/ElevatorLobby.cs
+++ b/Planetfall/Location/Kalamontee/ElevatorLobby.cs
@@ -15,6 +15,12 @@ internal class ElevatorLobby : LocationBase
 
     private bool RedDoorIsOpen => GetLocation<LowerElevator>().IsOpenAtTheLobby;
 
+    // ExamineInteractionProcessor answers a wider set than Verbs.ExamineVerbs lists - "check", "look in"
+    // and "peek at" appear only in its own switch. Matching just the array would let "check blue door"
+    // reach the door item and report the shared flag, reopening the contradiction for that one phrasing.
+    private static readonly string[] ExamineDoorVerbs =
+        [..Verbs.ExamineVerbs, "check", "look in", "peek at"];
+
     public override void Init()
     {
         StartWithItem<LowerElevatorDoor>();
@@ -108,8 +114,8 @@ internal class ElevatorLobby : LocationBase
     private InteractionResult? AnswerForDoor(SimpleIntent action, ElevatorDoorBase door, bool isOpenHere,
         IContext context)
     {
-        if (action.MatchVerb(Verbs.ExamineVerbs))
-            return new PositiveInteractionResult($"The door is {(isOpenHere ? "open" : "closed")}. ");
+        if (action.MatchVerb(ExamineDoorVerbs))
+            return new PositiveInteractionResult(door.DescribeAs(isOpenHere));
 
         if (action.MatchVerb(Verbs.OpenVerbs))
             return new PositiveInteractionResult(isOpenHere ? door.AlreadyOpen : door.CannotBeOpenedDescription(context));

--- a/Planetfall/Location/Kalamontee/ElevatorLobby.cs
+++ b/Planetfall/Location/Kalamontee/ElevatorLobby.cs
@@ -8,6 +8,13 @@ internal class ElevatorLobby : LocationBase
 {
     public override string Name => "Elevator Lobby";
 
+    // Every surface in this room - the two entrances, the description, and "examine <colour> door" -
+    // must answer from the effective state, never from the shared OPENBIT flag on its own. See
+    // ElevatorBase.IsOpenAtTheLobby for why, and issue #505 for what happens when they disagree.
+    private bool BlueDoorIsOpen => GetLocation<UpperElevator>().IsOpenAtTheLobby;
+
+    private bool RedDoorIsOpen => GetLocation<LowerElevator>().IsOpenAtTheLobby;
+
     public override void Init()
     {
         StartWithItem<LowerElevatorDoor>();
@@ -27,7 +34,7 @@ internal class ElevatorLobby : LocationBase
                 Direction.S,
                 new MovementParameters
                 {
-                    CanGo = _ => GetItem<LowerElevatorDoor>().IsOpen && GetLocation<LowerElevator>().InLobby,
+                    CanGo = _ => RedDoorIsOpen,
                     CustomFailureMessage = "The door is closed.",
                     Location = GetLocation<LowerElevator>()
                 }
@@ -36,7 +43,7 @@ internal class ElevatorLobby : LocationBase
                 Direction.N,
                 new MovementParameters
                 {
-                    CanGo = _ => GetItem<UpperElevatorDoor>().IsOpen && GetLocation<UpperElevator>().InLobby,
+                    CanGo = _ => BlueDoorIsOpen,
                     CustomFailureMessage = "The door is closed.",
                     Location = GetLocation<UpperElevator>()
                 }
@@ -47,6 +54,18 @@ internal class ElevatorLobby : LocationBase
     public override async Task<InteractionResult> RespondToSimpleInteraction(SimpleIntent action, IContext context,
         IGenerationClient client, IItemProcessorFactory itemProcessorFactory)
     {
+        // The door object reports the shaft-wide flag, which is only correct from inside the car. Answer
+        // for our own two doors here so "examine blue door" cannot corroborate a state the room text and
+        // the exits both deny (issue #505).
+        if (action.MatchVerb(Verbs.ExamineVerbs))
+        {
+            if (action.MatchNounAndAdjective(GetItem<UpperElevatorDoor>().NounsForMatching))
+                return new PositiveInteractionResult($"The door is {(BlueDoorIsOpen ? "open" : "closed")}. ");
+
+            if (action.MatchNounAndAdjective(GetItem<LowerElevatorDoor>().NounsForMatching))
+                return new PositiveInteractionResult($"The door is {(RedDoorIsOpen ? "open" : "closed")}. ");
+        }
+
         if (action.Match(Verbs.PushVerbs, ["button", "elevator button"]))
             return new DisambiguationInteractionResult("Which button do you mean, the red button or the blue button",
                 new Dictionary<string, string>
@@ -74,9 +93,16 @@ internal class ElevatorLobby : LocationBase
 
     protected override string GetContextBasedDescription(IContext context)
     {
+        // Read the effective state, not the raw flag: the lobby used to announce a door as open while
+        // walking that way answered "The door is closed." The "also" clause means "both doors are in the
+        // same state", so it has to compare the effective states too - on the raw flags it could say
+        // "also" when they differ and omit it when they match (issue #505).
+        var blueOpen = BlueDoorIsOpen;
+        var redOpen = RedDoorIsOpen;
+
         return
-            $"This is a wide, brightly lit lobby. A blue metal door to the north is {(GetItem<UpperElevatorDoor>().IsOpen ? "open" : "closed")} and a larger red metal " +
-            $"door to the south is {(GetItem<LowerElevatorDoor>().IsOpen == GetItem<UpperElevatorDoor>().IsOpen ? "also " : "")}{(GetItem<LowerElevatorDoor>().IsOpen ? "open" : "closed")}. " +
+            $"This is a wide, brightly lit lobby. A blue metal door to the north is {(blueOpen ? "open" : "closed")} and a larger red metal " +
+            $"door to the south is {(redOpen == blueOpen ? "also " : "")}{(redOpen ? "open" : "closed")}. " +
             $"Beside the blue door is a blue button, and beside the red door is a red button. A corridor leads west. To the east is a small room about the size of a telephone booth. ";
     }
 }

--- a/Planetfall/Location/Kalamontee/ElevatorLobby.cs
+++ b/Planetfall/Location/Kalamontee/ElevatorLobby.cs
@@ -54,16 +54,23 @@ internal class ElevatorLobby : LocationBase
     public override async Task<InteractionResult> RespondToSimpleInteraction(SimpleIntent action, IContext context,
         IGenerationClient client, IItemProcessorFactory itemProcessorFactory)
     {
-        // The door object reports the shaft-wide flag, which is only correct from inside the car. Answer
-        // for our own two doors here so "examine blue door" cannot corroborate a state the room text and
-        // the exits both deny (issue #505).
-        if (action.MatchVerb(Verbs.ExamineVerbs))
+        // The door object reports the shaft-wide flag, which is only correct from inside the car, so
+        // every verb that reads a door's state has to be answered here instead - otherwise "examine red
+        // door" and "open red door" corroborate a state the room text and the exit both deny (#505).
+        // The bare nouns ("door", "elevator door") never reach this: both doors match them, so
+        // SimpleInteractionEngine disambiguates first.
+        if (action.MatchNounAndAdjective(GetItem<UpperElevatorDoor>().NounsForMatching))
         {
-            if (action.MatchNounAndAdjective(GetItem<UpperElevatorDoor>().NounsForMatching))
-                return new PositiveInteractionResult($"The door is {(BlueDoorIsOpen ? "open" : "closed")}. ");
+            var answer = AnswerForDoor(action, GetItem<UpperElevatorDoor>(), BlueDoorIsOpen, context);
+            if (answer is not null)
+                return answer;
+        }
 
-            if (action.MatchNounAndAdjective(GetItem<LowerElevatorDoor>().NounsForMatching))
-                return new PositiveInteractionResult($"The door is {(RedDoorIsOpen ? "open" : "closed")}. ");
+        if (action.MatchNounAndAdjective(GetItem<LowerElevatorDoor>().NounsForMatching))
+        {
+            var answer = AnswerForDoor(action, GetItem<LowerElevatorDoor>(), RedDoorIsOpen, context);
+            if (answer is not null)
+                return answer;
         }
 
         if (action.Match(Verbs.PushVerbs, ["button", "elevator button"]))
@@ -89,6 +96,29 @@ internal class ElevatorLobby : LocationBase
                 .SummonElevator("You hear a faint whirring noise from behind the blue door. ", context);
 
         return await base.RespondToSimpleInteraction(action, context, client, itemProcessorFactory);
+    }
+
+    /// <summary>
+    ///     Re-states what OpenAndCloseInteractionProcessor and the examine processor would say for this
+    ///     door, but keyed on <paramref name="isOpenHere" /> instead of the shared flag. The messages stay
+    ///     owned by the door, and nothing is lost by bypassing the processors: an elevator door always
+    ///     refuses to be opened or closed by hand, so those paths never mutate state for it. Returns null
+    ///     for any other verb, which then falls through to normal handling.
+    /// </summary>
+    private InteractionResult? AnswerForDoor(SimpleIntent action, ElevatorDoorBase door, bool isOpenHere,
+        IContext context)
+    {
+        if (action.MatchVerb(Verbs.ExamineVerbs))
+            return new PositiveInteractionResult($"The door is {(isOpenHere ? "open" : "closed")}. ");
+
+        if (action.MatchVerb(Verbs.OpenVerbs))
+            return new PositiveInteractionResult(isOpenHere ? door.AlreadyOpen : door.CannotBeOpenedDescription(context));
+
+        if (action.MatchVerb(Verbs.CloseVerbs))
+            return new PositiveInteractionResult(
+                isOpenHere ? door.CannotBeClosedDescription(context) : door.AlreadyClosed);
+
+        return null;
     }
 
     protected override string GetContextBasedDescription(IContext context)

--- a/Planetfall/Location/Kalamontee/Tower/TowerCore.cs
+++ b/Planetfall/Location/Kalamontee/Tower/TowerCore.cs
@@ -1,4 +1,5 @@
 using GameEngine.Location;
+using Planetfall.Item.Kalamontee.Admin;
 
 namespace Planetfall.Location.Kalamontee.Tower;
 
@@ -6,12 +7,26 @@ internal class TowerCore : LocationWithNoStartingItems
 {
     public override string Name => "Tower Core";
 
+    private UpperElevatorDoor Door => Repository.GetItem<UpperElevatorDoor>();
+
     protected override Dictionary<Direction, MovementParameters> Map(IContext context)
     {
+        // This is the far end of the upper shaft, so the entrance needs the same two-part test the
+        // Waiting Area uses on the lower one: the door open *and* the car standing at this end. A bare
+        // Go<UpperElevator>() let you walk into a car parked down at the lobby, because the door flag
+        // is shared by both ends of the shaft (issue #505).
+        var intoTheCar = new MovementParameters
+        {
+            GatingItem = Door,
+            CanGo = _ => GetLocation<UpperElevator>().IsOpenAtTheFarEnd,
+            Location = GetLocation<UpperElevator>(),
+            CustomFailureMessage = "The door is closed. "
+        };
+
         return new Dictionary<Direction, MovementParameters>
         {
             { Direction.SW, Go<ObservationDeck>() },
-            { Direction.N, Go<UpperElevator>() },
+            { Direction.N, intoTheCar },
             { Direction.Up, Go<Helipad>() },
             { Direction.NE, Go<CommRoom>() }
         };

--- a/Planetfall/Location/Shuttle/WaitingArea.cs
+++ b/Planetfall/Location/Shuttle/WaitingArea.cs
@@ -21,7 +21,7 @@ public class WaitingArea : LocationWithNoStartingItems
         var intoTheCar = new MovementParameters
         {
             GatingItem = Door,
-            CanGo = _ => Door.IsOpen && !GetLocation<LowerElevator>().InLobby,
+            CanGo = _ => GetLocation<LowerElevator>().IsOpenAtTheFarEnd,
             Location = GetLocation<LowerElevator>(),
             CustomFailureMessage = "The door is closed. "
         };


### PR DESCRIPTION
Fixes #505.

## The bug

`ElevatorLobby.GetContextBasedDescription` read `Door.IsOpen` alone. That flag is shared by both ends of the shaft, and `ElevatorBase.ElevatorIsMoving` sets `InLobby = !InLobby` **and** `door.IsOpen = true` on arrival, so a car parked at its far end leaves the flag open with the car away. The lobby then announced a door as open while the matching movement — gated on both conditions since #456 — answered "The door is closed."

```
> look
... A blue metal door to the north is open ...   <- car is actually up at Tower Core
> n
The door is closed.                              <- contradicts the line above
> examine blue door
The door is open.                                <- and so does this
```

This is the third surface of the same raw-flag-vs-effective-state split: #456 fixed the entrances, #450 fixed the description inside the car, and the lobby's own text was passed over — the comment on `Map`'s `CanGo` already spelled out exactly why it was wrong. Review of the first fix then turned up four more surfaces reading the same flag, all fixed here.

## Original behavior (ZIL)

`compone.zil`, `ELEVATOR-LOBBY-F` computes each door's word from the flag **and** the car's position, and derives "also" from those same two-part conditions — the same test `ELEVATOR-ENTER-F` applies to the entrances, and `OTHER-ELEVATOR-ENTER-F` to the far-end ones. The position test differs per shaft (`UPPER-ELEVATOR-UP` false vs `LOWER-ELEVATOR-UP` true) because the lobby is the bottom of the upper shaft and the top of the lower one, which the port already models correctly as `InLobby` on each car.

## The fix

Two predicates on `ElevatorBase` replace the conjunction that was being spelled out (or forgotten) at each call site:

- `IsOpenAtTheLobby => door.IsOpen && InLobby`
- `IsOpenAtTheFarEnd => door.IsOpen && !InLobby`

Surfaces corrected, each of which previously read the bare flag:

| Surface | Symptom |
|---|---|
| Lobby description | Announced a door open with the car away; the "also" clause compared raw flags, so it could claim "also" when the effective states differed and omit it when they matched |
| `examine`/`x`/`check`/`look in`/`peek at` <colour> door | Corroborated the wrong answer — `check` and friends appear only in `ExamineInteractionProcessor`'s switch, not in `Verbs.ExamineVerbs` |
| `open`/`close` <colour> door | "It is open." on the same turn the room, the examine and the exit all said closed |
| Call button (`SummonElevator`) | **Progression block.** "Pushing the blue button has no effect." in exactly the state the room calls closed — the recall the issue assumed existed |
| Tower Core `north` | Bare `Go<UpperElevator>()`, the defect `WaitingArea`'s comment says was fixed for the lower shaft: you could walk into a car parked at the lobby, and stepping out landed you in the lobby having ridden nothing |

Two lifecycle defects surfaced by correcting the button, both of which would have made the recall fail anyway:

- `ElevatorIsSummoned` never cleared `HasBeenSummoned`/`TurnsSinceSummoned`, so a second summon fell into the "Patience, patience..." guard and never registered the actor.
- `Act()` prioritised the card-activation countdown, which ends by removing the actor — cancelling a pending summon silently and stranding `HasBeenSummoned` set forever. A pending summon now holds the actor slot; the countdown resumes once it lands.

Also: `ElevatorIsSummoned` announced the lobby's doorway with no location check (unlike `ElevatorIsEnabled` beside it), printing it in whatever room the player had walked to. `ElevatorDoorBase` gained `DescribeAs(bool)` so the lobby reuses the door's wording instead of copying the literal, and `WaitingArea` now routes through `IsOpenAtTheFarEnd` — a pure refactor.

Behavior is unchanged in every state where the flag and the car's position already agreed.

## Tests

TDD throughout, in `Planetfall.Tests/ElevatorTests.cs` — every fix was verified red against the code before it, each failing on its own assertion rather than erroring on setup. Beyond the reproducing cases:

- **The generalizing invariant:** for all four (`IsOpen` × `InLobby`) states of each shaft, the word in the room description must agree with whether that direction is actually passable. That is the property #456 and #450 each fixed one side of.
- Mixed-state coverage for examine and open/close (one car home, one away), so transposing the blue and red branches can no longer pass.
- "also" coverage where the raw flags agree while the effective states differ, and vice versa.
- The recall proven end-to-end through an actual ride up to the Tower and back on foot — which fails with "no effect" without the button fix and with "Patience, patience..." without the bookkeeping reset.
- Tower Core's entrance refused with the car at the lobby and with the door closed, allowed with the car standing there — mirroring the three `Enter_FromWaitingArea_*` cases.

Three existing `look` tests set `IsOpen = true` without `InLobby`, i.e. they asserted the buggy raw-flag wording; they now set `InLobby` for the state they meant to describe.

All deterministic — no AI, randomness, or god mode; state is set directly on the real `Repository` objects.

**No regressions.** Run separately (`dotnet test A B` errors with MSB1008): `Planetfall.Tests` 3258 passed (includes the walkthroughs, which ride both elevators), `UnitTests` 1085 passed / 1 skipped, `ZorkOne.Tests` 1782 passed, `EscapeRoom.Tests` 9 passed, `Console.Tests` 16 passed.