### PR TITLE
Make Planetfall possession gates container-aware (fixes #503)

### DIFF
--- a/GameEngine/Context.cs
+++ b/GameEngine/Context.cs
@@ -296,6 +296,29 @@ public abstract class Context<T> : IContext where T : IInfocomGame, new()
         return Items.OfType<TItem>().Any();
     }
 
+    /// <summary>
+    ///     Checks whether the adventurer is carrying an item of type T, <b>including</b> inside any
+    ///     container they are carrying or wearing - the Patrol uniform pocket above all.
+    /// </summary>
+    /// <remarks>
+    ///     This is the check a gameplay gate almost always wants. <see cref="HasItem{TItem}" /> is
+    ///     deliberately flat (it answers "is this at the top level of my inventory"), so gating an
+    ///     action on it silently breaks the moment the player pockets the item: the handler returns
+    ///     <c>NoNounMatchInteractionResult</c> and the turn goes to the narrator, giving the player no
+    ///     hint that where they are carrying the thing is the problem. That was issue #503 - a card in
+    ///     the uniform pocket wouldn't slide, and the key in the pocket wouldn't unlock the padlock.
+    ///     The original games are, if anything, more permissive: the parser's <c>(HAVE)</c> flag
+    ///     reaches into open carried containers.
+    /// </remarks>
+    /// <typeparam name="TItem">The type of item to check.</typeparam>
+    /// <returns>True if the item is in inventory or nested in something in inventory.</returns>
+    public bool IsCarrying<TItem>() where TItem : IItem, new()
+    {
+        // Strictly a superset of HasItem: a top-level item's CurrentLocation can be stale (see the
+        // note in RemoveItem), so check flat membership first and only then walk the container chain.
+        return HasItem<TItem>() || Repository.IsItemPossessedBy(Repository.GetItem<TItem>(), this);
+    }
+
     public (bool HasItem, IItem? TheItem) HasMatchingNoun(string? noun, bool lookInsideContainers = true)
     {
         foreach (var i in Items)

--- a/Model/Interface/IContext.cs
+++ b/Model/Interface/IContext.cs
@@ -26,6 +26,20 @@ public interface IContext : ICanContainItems
     List<T> GetItems<T>();
 
     /// <summary>
+    /// Determines whether the adventurer is carrying an item of the given type, including nested inside
+    /// any container they carry or wear (the Patrol uniform pocket, a sack, and so on).
+    /// </summary>
+    /// <remarks>
+    /// Prefer this over <see cref="ICanContainItems.HasItem{T}" /> when gating a player action on
+    /// possession. HasItem is flat - top level of inventory only - so a pocketed item fails it and the
+    /// action falls silently through to the narrator (issue #503). Use HasItem only when you genuinely
+    /// mean "in your hands, not in a container".
+    /// </remarks>
+    /// <typeparam name="TItem">The type of item to look for.</typeparam>
+    /// <returns>True if the item is carried, directly or nested; otherwise false.</returns>
+    bool IsCarrying<TItem>() where TItem : IItem, new();
+
+    /// <summary>
     /// Sometimes, a major event in the game will change the circumstances so drastically that we need to update the
     /// system prompt with this new information. For example, after the explosion of the Feinstein in Planetfall, we no
     /// longer want the AI to think the player is in space. 

--- a/Planetfall.Tests/AdminCorridorSouthTests.cs
+++ b/Planetfall.Tests/AdminCorridorSouthTests.cs
@@ -27,6 +27,23 @@ public class AdminCorridorSouthTests : EngineTestsBase
         GetLocation<AdminCorridorSouth>().HasTakenTheKey.Should().BeTrue();
     }
 
+    // Issue #503: the magnet is size 1, so it fits the Patrol uniform pocket - and the flat
+    // context.HasItem<Magnet>() said you weren't carrying it, sending the fishing attempt to the
+    // narrator instead of pulling the key out of the crevice.
+    [Test]
+    public async Task UseMagnetOnCrevice_MagnetInUniformPocket_RetrievesKey()
+    {
+        var target = GetTarget();
+        StartHere<AdminCorridorSouth>();
+        Pocket<Magnet>();
+
+        var response = await target.GetResponse("use magnet on crevice");
+
+        response.Should().Contain("a piece of metal leaps from the crevice");
+        Context.HasItem<Key>().Should().BeTrue();
+        GetLocation<AdminCorridorSouth>().HasTakenTheKey.Should().BeTrue();
+    }
+
     [Test]
     public async Task UseMagnetOnKey_RetrievesKey()
     {

--- a/Planetfall.Tests/AdminCorridorSouthTests.cs
+++ b/Planetfall.Tests/AdminCorridorSouthTests.cs
@@ -677,4 +677,45 @@ public class AdminCorridorSouthTests : EngineTestsBase
 
         GetItem<KitchenAccessCard>().Scrambled.Should().BeFalse();
     }
+
+    // Issue #503 follow-up: the possession GATE that lets you fish with the magnet reaches into carried
+    // containers, so the magnet's own hazard daemon must too. While it tested CurrentLocation == context
+    // it deregistered itself the moment the magnet went into the uniform pocket, which made the pocket a
+    // free way to keep the magnet's use and opt out of its entire downside.
+    [Test]
+    public async Task MagnetInUniformPocket_StillScramblesCards()
+    {
+        var target = GetTarget();
+        StartHere<ToolRoom>();
+
+        // Wear the uniform (the harness doesn't run PlanetfallContext.Init) and empty its one-slot
+        // pocket so the magnet can go in it.
+        Take<PatrolUniform>();
+        Take<IdCard>();
+
+        // Take it for real, so OnBeingTaken registers it as an actor, then pocket it.
+        await target.GetResponse("take bar");
+        await target.GetResponse("put bar in pocket");
+        GetItem<Magnet>().CurrentLocation.Should().BeOfType<PatrolUniformPocket>();
+
+        Take<KitchenAccessCard>();
+        await target.GetResponse("look");
+
+        GetItem<KitchenAccessCard>().Scrambled.Should().BeTrue();
+    }
+
+    // The mirror image: a card in the pocket is no safer than one in your hand. Otherwise the implicit
+    // take in SlotBase would be a trap - sliding a pocketed card would haul it up to the top level and
+    // into the magnet's reach on that very turn, destroying a card that had been safe a moment earlier.
+    [Test]
+    public async Task CardInUniformPocket_IsStillScrambled()
+    {
+        var target = GetTarget();
+        StartHere<ToolRoom>();
+        Pocket<KitchenAccessCard>();
+
+        await target.GetResponse("take bar");
+
+        GetItem<KitchenAccessCard>().Scrambled.Should().BeTrue();
+    }
 }

--- a/Planetfall.Tests/CardTests.cs
+++ b/Planetfall.Tests/CardTests.cs
@@ -5,6 +5,7 @@ using Model.AIGeneration;
 using Model.AIParsing;
 using Model.Intent;
 using Moq;
+using Planetfall.Item.Feinstein;
 using Planetfall.Item.Kalamontee.Admin;
 using Planetfall.Location.Kalamontee;
 
@@ -24,6 +25,48 @@ public class CardTests : EngineTestsBase
         var response = await engine.GetResponse("slide kitchen access card through slot");
 
         response.Should().Contain("The kitchen door quietly slides open");
+    }
+
+    // Issue #503: a card in the Patrol uniform pocket - the game's starting container, and where the
+    // ID card ships - must still slide. The success path used to gate on the flat, top-level-only
+    // context.HasItem<T>(), so pocketing a card silently sent the turn to the narrator.
+    [Test]
+    public async Task Kitchen_HappyPath_CardInUniformPocket()
+    {
+        var engine = GetTarget();
+        var room = Repository.GetLocation<MessHall>();
+        engine.Context.CurrentLocation = room;
+
+        var card = Pocket<KitchenAccessCard>();
+        card.CurrentLocation.Should().BeOfType<PatrolUniformPocket>();
+        engine.Context.Items.Should().NotContain(card);
+
+        var response = await engine.GetResponse("slide kitchen access card through slot");
+
+        response.Should().Contain("The kitchen door quietly slides open");
+        Repository.GetItem<KitchenDoor>().IsOpen.Should().BeTrue();
+
+        // The original's SLOT-F performs an implicit take before acting, so the card ends up in hand.
+        engine.Context.Items.Should().Contain(card);
+    }
+
+    // Issue #503 regression pin: SlotBase resolves the card by TYPE from the repository, so the
+    // possession check is the only thing scoping it. A card lying somewhere else in the game must not
+    // open the door (the unscoped-lookup class of bug from #423).
+    [Test]
+    public async Task Kitchen_CardNotCarried_DoesNotOpenTheDoor()
+    {
+        var engine = GetTarget();
+        var room = Repository.GetLocation<MessHall>();
+        engine.Context.CurrentLocation = room;
+
+        // The card is across the map, not on the player.
+        Repository.GetLocation<MessCorridor>().ItemPlacedHere(Repository.GetItem<KitchenAccessCard>());
+
+        var response = await engine.GetResponse("slide kitchen access card through slot");
+
+        response.Should().NotContain("The kitchen door quietly slides open");
+        Repository.GetItem<KitchenDoor>().IsOpen.Should().BeFalse();
     }
 
     [Test]

--- a/Planetfall.Tests/CommRoomAndMachineRoomTests.cs
+++ b/Planetfall.Tests/CommRoomAndMachineRoomTests.cs
@@ -23,6 +23,22 @@ public class CommRoomAndMachineRoomTests : EngineTestsBase
         GetLocation<MachineShop>().HasItem<Flask>().Should().BeTrue();
     }
     
+    // Issue #503: the flask is size 1 and fits the Patrol uniform pocket, where the flat
+    // context.HasItem<Flask>() counted it as "not carried" and the command fell to the narrator.
+    [Test]
+    public async Task PutFlaskUnderSpout_FlaskInUniformPocket_Success()
+    {
+        var target = GetTarget();
+        Pocket<Flask>();
+        StartHere<MachineShop>();
+
+        var response = await target.GetResponse("put flask under spout");
+
+        response.Should().Contain("The glass flask is now sitting under the spout.");
+        GetLocation<MachineShop>().FlaskUnderSpout.Should().BeTrue();
+        GetLocation<MachineShop>().HasItem<Flask>().Should().BeTrue();
+    }
+
     [Test]
     public async Task PutFlaskUnderSpout_Look()
     {

--- a/Planetfall.Tests/CourseControlTests.cs
+++ b/Planetfall.Tests/CourseControlTests.cs
@@ -409,6 +409,23 @@ public class CourseControlTests : EngineTestsBase
         GetItem<LargeMetalCube>().HasItem<FusedBedistor>().Should().BeFalse();
     }
 
+    // Issue #503: the pliers are size 1 and fit the Patrol uniform pocket. The flat
+    // context.HasItem<Pliers>() refused the whole removal while they sat there.
+    [Test]
+    public async Task UsePliersOnBedistor_PliersInUniformPocket_RemovesBedistor()
+    {
+        var target = GetTarget();
+        StartHere<CourseControl>();
+        Pocket<Pliers>();
+        GetItem<LargeMetalCube>().IsOpen = true;
+
+        var response = await target.GetResponse("use pliers on bedistor");
+
+        response.Should().Contain("With a tug, you manage to remove the fused bedistor");
+        target.Context.HasItem<FusedBedistor>().Should().BeTrue();
+        GetItem<LargeMetalCube>().HasItem<FusedBedistor>().Should().BeFalse();
+    }
+
     [Test]
     public async Task UsePliersOnFused_RemovesBedistor()
     {

--- a/Planetfall.Tests/EngineTestsBase.cs
+++ b/Planetfall.Tests/EngineTestsBase.cs
@@ -11,6 +11,7 @@ using Model.Item;
 using Model.Location;
 using Moq;
 using Planetfall.GlobalCommand;
+using Planetfall.Item.Feinstein;
 using Planetfall.Location.Feinstein;
 using UnitTests;
 
@@ -44,6 +45,25 @@ public class EngineTestsBase
     {
         var item = GetItem<T>();
         Context.ItemPlacedHere(item);
+        return item;
+    }
+
+    /// <summary>
+    /// Carries an item the way a player naturally does: nested in the pocket of the worn Patrol
+    /// uniform, rather than at the top level of inventory. This is the arrangement that used to break
+    /// every possession gate written with the flat <c>Context.HasItem&lt;T&gt;()</c> (issue #503).
+    /// </summary>
+    /// <remarks>
+    /// The harness never runs <c>PlanetfallContext.Init</c>, so the uniform is put on the player here.
+    /// The pocket holds exactly one thing and ships with the ID card, so that comes out into your
+    /// hands first — precisely the inventory the bug report showed.
+    /// </remarks>
+    protected T Pocket<T>() where T : IItem, new()
+    {
+        Context.ItemPlacedHere(GetItem<PatrolUniform>());
+        Context.ItemPlacedHere(GetItem<IdCard>());
+        var item = GetItem<T>();
+        GetItem<PatrolUniformPocket>().ItemPlacedHere(item);
         return item;
     }
 

--- a/Planetfall.Tests/FloydTests.cs
+++ b/Planetfall.Tests/FloydTests.cs
@@ -188,6 +188,25 @@ public class FloydTests : EngineTestsBase
         response.Should().Contain("thoughtfulness");
     }
 
+    // Issue #503: the original's (HAVE) flag reaches into open carried containers, so an oil can in
+    // the Patrol uniform pocket satisfies it. The flat context.HasItem<OilCan>() did not, and asked
+    // "Oil it with what?" while you were carrying the can.
+    [Test]
+    [TestCase("oil floyd")]
+    [TestCase("oil floyd with oil can")]
+    public async Task OilFloyd_OilCanInUniformPocket_Thanks(string command)
+    {
+        var target = GetTarget();
+        StartHere<RobotShop>();
+        GetItem<Floyd>().IsOn = true;
+        Pocket<OilCan>();
+
+        var response = await target.GetResponse(command);
+
+        response.Should().Contain("thoughtfulness");
+        response.Should().NotContain("Oil it with what?");
+    }
+
     [Test]
     public async Task OilFloyd_WithOilCan_NotHeld_DoesNotThank()
     {

--- a/Planetfall.Tests/MessHallPadlockedDoorTests.cs
+++ b/Planetfall.Tests/MessHallPadlockedDoorTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using GameEngine;
+using Planetfall.Item.Feinstein;
 using Planetfall.Item.Kalamontee;
 using Planetfall.Item.Kalamontee.Admin;
 using Planetfall.Item.Kalamontee.Mech.FloydPart;
@@ -97,6 +98,54 @@ public class MessHallPadlockedDoorTests : EngineTestsBase
         response.Should().Contain("springs open");
         Repository.GetItem<Padlock>().Locked.Should().BeFalse();
         Repository.GetItem<Padlock>().AttachedToDoor.Should().BeTrue();
+    }
+
+    // Issue #503: the steel key is a tiny thing you have just fished out of a crevice, so pocketing it
+    // is the natural move - and the padlock gated on the flat, top-level-only context.HasItem<Key>(),
+    // which sent the whole turn to the narrator instead of unlocking anything.
+    [Test]
+    public async Task UnlockPadlockWithKey_KeyInUniformPocket()
+    {
+        var target = GetTarget();
+        target.Context.CurrentLocation = Repository.GetLocation<MessCorridor>();
+
+        var key = Pocket<Key>();
+        key.CurrentLocation.Should().BeOfType<PatrolUniformPocket>();
+        target.Context.Items.Should().NotContain(key);
+
+        var response = await target.GetResponse("unlock padlock with key");
+        response.Should().Contain("springs open");
+        Repository.GetItem<Padlock>().Locked.Should().BeFalse();
+    }
+
+    // Same defect on the delegating path: "unlock door with key" routes through MessDoor, which had
+    // the identical flat check before handing off to the padlock.
+    [Test]
+    public async Task UnlockDoorWithKey_KeyInUniformPocket()
+    {
+        var target = GetTarget();
+        target.Context.CurrentLocation = Repository.GetLocation<MessCorridor>();
+
+        Pocket<Key>();
+
+        var response = await target.GetResponse("unlock door with key");
+        response.Should().Contain("springs open");
+        Repository.GetItem<Padlock>().Locked.Should().BeFalse();
+    }
+
+    // Issue #503 regression pin: the padlock resolves the key by TYPE from the repository, so the
+    // possession check is the only thing scoping it. A key sitting in another room must not unlock it.
+    [Test]
+    public async Task UnlockPadlockWithKey_KeyNotCarried_StaysLocked()
+    {
+        var target = GetTarget();
+        target.Context.CurrentLocation = Repository.GetLocation<MessCorridor>();
+        Repository.GetLocation<MessHall>().ItemPlacedHere(Repository.GetItem<Key>());
+
+        var response = await target.GetResponse("unlock padlock with key");
+
+        response.Should().NotContain("springs open");
+        Repository.GetItem<Padlock>().Locked.Should().BeTrue();
     }
 
     [Test]

--- a/Planetfall/Item/Feinstein/Blather.cs
+++ b/Planetfall/Item/Feinstein/Blather.cs
@@ -57,12 +57,19 @@ internal class Blather : QuirkyCompanion, IAmANamedPerson, ITurnBasedActor, ICan
         if (action.MatchNounOne(Repository.GetItem<Brush>().NounsForMatching) &&
             action.MatchVerb(Verbs.ThrowVerbs))
         {
-            if (!context.HasItem<Brush>())
+            // Container-aware possession, like every other gate of its kind (issue #503). The brush is
+            // size 2 and so can't fit the one-slot uniform pocket today, but the gate should express
+            // "are you carrying it", not "is it at the top level" - a distinction that silently sends
+            // the turn to the narrator the moment some container can hold it.
+            if (!context.IsCarrying<Brush>())
             {
                 return await base.RespondToMultiNounInteraction(action, context);
             }
 
-            context.Drop<Brush>();
+            // Drop the instance, not Drop<Brush>(): the generic overload looks only at the top level of
+            // inventory, so a pocketed brush would have "bounced off Blather" while staying in your
+            // pocket. Context.Drop -> RemoveItem detaches it from whatever container holds it.
+            context.Drop(Repository.GetItem<Brush>());
 
             var result =
                 "The Patrol-issue self-contained multi-purpose scrub brush bounces off Blather's bulbous nose. " +

--- a/Planetfall/Item/Kalamontee/Admin/SlotBase.cs
+++ b/Planetfall/Item/Kalamontee/Admin/SlotBase.cs
@@ -42,8 +42,21 @@ internal abstract class SlotBase<TAccessCard, TAccessSlot> : ItemBase, ICanBeExa
 
         if (action.Match<TAccessCard, TAccessSlot>(verbs, prepositions))
         {
-            if (!context.HasItem<TAccessCard>())
+            // Possession must be container-aware, exactly like the wrong-card branch below (which uses
+            // HasMatchingNoun). context.HasItem<T>() is top-level-only, so a card in the Patrol uniform
+            // pocket - the game's starting container, and where the ID card ships - failed this check
+            // and the turn fell through to the narrator with no hint that pocketing the card was the
+            // problem (issue #503). The check itself must stay: the card is resolved by TYPE from the
+            // repository, so this is the only thing stopping a card lying across the map from working.
+            if (!context.IsCarrying<TAccessCard>())
                 return new NoNounMatchInteractionResult();
+
+            // The original slides a card you are merely carrying: SLOT-F performs an implicit take
+            // (globals.zil:1375) before any of the per-card branches run, so mirror that and put the
+            // card in hand either way.
+            var card = Repository.GetItem<TAccessCard>();
+            if (!context.Items.Contains(card))
+                context.ItemPlacedHere(card);
 
             // Deliberate deviation from the original (issue #211 follow-up): the ZIL's WRONG-CARD
             // (globals.zil:1438) doesn't distinguish "wrong card" from "corrupted card" - a scrambled
@@ -52,7 +65,7 @@ internal abstract class SlotBase<TAccessCard, TAccessSlot> : ItemBase, ICanBeExa
             // way to tell "wrong card" (try a different one) apart from "your card is ruined" (the
             // magnet did this - stop carrying it with your cards). We judged that ambiguity unfair and
             // gave the scrambled case its own message instead of matching the original verbatim.
-            if (Repository.GetItem<TAccessCard>().Scrambled)
+            if (card.Scrambled)
                 return new PositiveInteractionResult(
                     "A sign flashes \"Damejd kard...akses deeniid.\"");
 
@@ -63,7 +76,14 @@ internal abstract class SlotBase<TAccessCard, TAccessSlot> : ItemBase, ICanBeExa
 
         var nounOne = Repository.GetItem(action.NounOne);
 
-        // Right idea, wrong card. 
+        // Right idea, wrong card. NOTE (found while fixing #503, left alone deliberately): this global
+        // Repository.GetItem(noun) returns the first LOADED item whose nouns loosely match, and the ID
+        // card's bare noun "card" swallows every "<x> access card" phrase - so once the ID card exists
+        // (it starts in the uniform pocket) this branch can resolve to the ID card, which isn't an
+        // AccessCard, and the wrong-card message never fires. That's a separate noun-resolution defect,
+        // not the possession bug above; fixing it here is not safe by inspection, because the obvious
+        // scope-aware replacements resolve through CurrentLocation, which for an inventory item can be
+        // stale (Floyd's Init re-seeds the lower elevator card singleton and steals its CurrentLocation).
         if (action.MatchVerb(verbs) && action.MatchPreposition(prepositions) && nounOne is AccessCard)
         {
             if (!context.HasMatchingNoun(action.NounOne).HasItem)

--- a/Planetfall/Item/Kalamontee/Mech/FloydPart/Floyd.cs
+++ b/Planetfall/Item/Kalamontee/Mech/FloydPart/Floyd.cs
@@ -333,17 +333,19 @@ public class Floyd : QuirkyCompanion, IAmANamedPerson, ICanHoldItems, ICanBeGive
         // V-OIL with an explicit indirect object (syntax.zil:446-448, verbs.zil:1738-1757):
         // "oil floyd with oil can". Only the oil can counts as the oiling instrument; oiling a
         // living Floyd with it gives the same thank-you as the no-indirect-object form. The ZIL
-        // grammar is OIL OBJECT WITH OBJECT (HAVE) — the (HAVE) flag requires the can be HELD, so
-        // gate on context.HasItem<OilCan>() (matching the single-noun branch), not merely
+        // grammar is OIL OBJECT WITH OBJECT (HAVE) — the (HAVE) flag requires the can be carried, so
+        // gate on context.IsCarrying<OilCan>() (matching the single-noun branch), not merely
         // GetItemInScope, which would also resolve a can sitting in the room.
         // Both checks are needed and not redundant: GetItemInScope(NounTwo) is OilCan verifies the
         // *named* indirect object is the can (so "oil floyd with sword" is rejected even while a can
-        // is held), and HasItem<OilCan>() enforces the (HAVE) flag (the can must be in inventory).
+        // is carried), and IsCarrying<OilCan>() enforces the (HAVE) flag (the can must be on you).
+        // IsCarrying, not the flat HasItem<T>(): (HAVE) reaches into open carried containers, so a can
+        // in the uniform pocket satisfies the original's grammar too (issue #503).
         // MatchPreposition(["with"]) keeps us faithful to the WITH grammar — the parser passes through
         // whatever connector it extracts, so this rejects e.g. "oil floyd using/near oil can".
         if (action.MatchVerb(FloydSocialResponses.OilVerbs) && action.MatchNounOne(NounsForMatching) &&
             action.MatchPreposition(["with"]) &&
-            Repository.GetItemInScope(action.NounTwo, context) is OilCan && context.HasItem<OilCan>())
+            Repository.GetItemInScope(action.NounTwo, context) is OilCan && context.IsCarrying<OilCan>())
             return new PositiveInteractionResult(FloydConstants.Oil);
 
         // SHOW is handled before GIVE: in the original, "show <x> to floyd" drives several reactions

--- a/Planetfall/Item/Kalamontee/Mech/FloydPart/FloydSocialResponses.cs
+++ b/Planetfall/Item/Kalamontee/Mech/FloydPart/FloydSocialResponses.cs
@@ -14,12 +14,14 @@ public class FloydSocialResponses(Floyd floyd)
             return null;
 
         // V-OIL (verbs.zil:1738-1757): oiling a living Floyd is a flavor thank-you. The original
-        // requires the oil can — "oil floyd" with no can in hand prompts "Oil it with what?" rather
+        // requires the oil can — "oil floyd" with no can on you prompts "Oil it with what?" rather
         // than oiling. Dead Floyd never reaches here (Floyd.RespondToSimpleInteraction returns to
-        // base when HasDied), matching the RLANDBIT "alive" check.
+        // base when HasDied), matching the RLANDBIT "alive" check. Possession is container-aware: the
+        // original's (HAVE) reaches into open carried containers, so a can in the uniform pocket
+        // counts — the flat HasItem<T>() would wrongly ask "with what?" (issue #503).
         if (action.Match(OilVerbs, floyd.NounsForMatching))
             return new PositiveInteractionResult(
-                context.HasItem<OilCan>() ? FloydConstants.Oil : FloydConstants.OilWithWhat);
+                context.IsCarrying<OilCan>() ? FloydConstants.Oil : FloydConstants.OilWithWhat);
 
         if (action.Match(["play"], floyd.NounsForMatching))
             return new PositiveInteractionResult(FloydConstants.Play);

--- a/Planetfall/Item/Kalamontee/Mech/Magnet.cs
+++ b/Planetfall/Item/Kalamontee/Mech/Magnet.cs
@@ -33,18 +33,25 @@ public class Magnet : ItemBase, ICanBeTakenAndDropped, ITurnBasedActor
     /// port instead scrambles whichever unscrambled AccessCard the player happens to be holding first -
     /// an acceptable simplification per issue #211 that also lets any future AccessCard subtype
     /// participate automatically, with no hardcoded list to extend. Scrambling is permanent (no
-    /// un-scramble, matching the original). Dropping the magnet (CurrentLocation no longer the player)
-    /// deregisters it so no further cards are scrambled.
+    /// un-scramble, matching the original). Dropping the magnet (no longer carried) deregisters it so no
+    /// further cards are scrambled.
+    ///
+    /// Both possession tests are container-aware, and must stay that way (issue #503 follow-up). The
+    /// gate that lets you fish the key with the magnet reaches into carried containers, so this daemon
+    /// has to use the same definition of "carrying" or the uniform pocket becomes a free way to keep the
+    /// magnet's use while opting out of its entire downside. The card side matters for the same reason
+    /// in reverse: a pocketed card must be exactly as exposed as one in your hand, or SlotBase's implicit
+    /// take turns into a trap that hauls a safe card up into the magnet's reach mid-slide.
     /// </summary>
     public Task<string> Act(IContext context, IGenerationClient client)
     {
-        if (CurrentLocation != context)
+        if (!context.IsCarrying<Magnet>())
         {
             context.RemoveActor(this);
             return Task.FromResult(string.Empty);
         }
 
-        var card = context.Items.OfType<AccessCard>().FirstOrDefault(c => !c.Scrambled);
+        var card = context.GetAllItemsRecursively.OfType<AccessCard>().FirstOrDefault(c => !c.Scrambled);
         if (card is not null)
             card.Scrambled = true;
 

--- a/Planetfall/Item/Kalamontee/MessDoor.cs
+++ b/Planetfall/Item/Kalamontee/MessDoor.cs
@@ -9,9 +9,11 @@ public class MessDoor : ItemBase, IOpenAndClose, ICanBeExamined
     public override async Task<InteractionResult?> RespondToMultiNounInteraction(MultiNounIntent action,
         IContext context)
     {
-        // "unlock door with key" should unlock the padlock when it's attached
+        // "unlock door with key" should unlock the padlock when it's attached. Possession is
+        // container-aware (issue #503) so the key works from the uniform pocket here too - otherwise
+        // this path would refuse before the padlock, which does the same check, ever saw the command.
         var padlock = Repository.GetItem<Padlock>();
-        if (padlock.AttachedToDoor && context.HasItem<Key>())
+        if (padlock.AttachedToDoor && context.IsCarrying<Key>())
         {
             if (action.Match<Key>(["unlock", "open"], NounsForMatching, ["with", "using"]))
             {

--- a/Planetfall/Item/Kalamontee/Padlock.cs
+++ b/Planetfall/Item/Kalamontee/Padlock.cs
@@ -62,9 +62,6 @@ public class Padlock : ItemBase, ICanBeTakenAndDropped
     public override async Task<InteractionResult?> RespondToMultiNounInteraction(MultiNounIntent action,
         IContext context)
     {
-        if (!context.HasItem<Key>())
-            return new NoNounMatchInteractionResult();
-
         // Allow "unlock door with key" when padlock is attached to the door
         var nounsToMatch = AttachedToDoor
             ? [..NounsForMatching, "door"]
@@ -75,6 +72,15 @@ public class Padlock : ItemBase, ICanBeTakenAndDropped
 
         if (match)
         {
+            // Possession is checked here, after the match, and with the container-aware IsCarrying:
+            // context.HasItem<Key>() is top-level only, so the steel key sitting in the Patrol uniform
+            // pocket - the natural place to put a tiny key you just fished out of a crevice - failed
+            // it and the turn fell through to the narrator instead of unlocking anything (issue #503).
+            // The check must stay: the key is resolved by TYPE from the repository, so it is the only
+            // thing stopping a key lying in another room from springing this padlock.
+            if (!context.IsCarrying<Key>())
+                return new NoNounMatchInteractionResult();
+
             // Guard on Locked state, not just the command phrasing — otherwise "unlock padlock with key"
             // re-narrates "springs open" on an already-open padlock. Mirrors the simple-interaction path.
             if (!Locked)

--- a/Planetfall/Item/Lawanda/FusedBedistor.cs
+++ b/Planetfall/Item/Lawanda/FusedBedistor.cs
@@ -31,9 +31,6 @@ public class FusedBedistor : BedistorBase, ICanBeTakenAndDropped
         if (CurrentLocation is not LargeMetalCube cube)
             return await base.RespondToMultiNounInteraction(action, context);
 
-        if (!context.HasItem<Pliers>())
-            return new NoNounMatchInteractionResult();
-
         var match = action.Match<Pliers>(["take", "remove"], NounsForMatching, ["with", "using"]);
 
         // Also support "use pliers on bedistor"
@@ -41,6 +38,12 @@ public class FusedBedistor : BedistorBase, ICanBeTakenAndDropped
 
         if (match)
         {
+            // Container-aware possession (issue #503): the pliers are small enough to pocket, and the
+            // flat context.HasItem<T>() would refuse the whole action if they were. Checked after the
+            // match, since the pliers are resolved by type - this is what scopes them to the player.
+            if (!context.IsCarrying<Pliers>())
+                return new NoNounMatchInteractionResult();
+
             // Remove from the cube and place in the player's inventory
             cube.RemoveItem(this);
             context.ItemPlacedHere(this);

--- a/Planetfall/Location/Kalamontee/Admin/AdminCorridorSouth.cs
+++ b/Planetfall/Location/Kalamontee/Admin/AdminCorridorSouth.cs
@@ -129,8 +129,10 @@ public class AdminCorridorSouth : LocationBase, ITurnBasedActor
         if (!match)
             return await base.RespondToMultiNounInteraction(action, context);
 
-        // It's a genuine fishing attempt, but the player isn't holding the magnet.
-        if (!context.HasItem<Magnet>())
+        // It's a genuine fishing attempt, but the player isn't carrying the magnet. Container-aware
+        // (issue #503): with the flat check, a magnet inside something you carry counted as "not
+        // yours" and the fishing attempt fell through to the narrator.
+        if (!context.IsCarrying<Magnet>())
             return Repository.GetItem<Magnet>().CurrentLocation == this
                 ? new PositiveInteractionResult("You don't have the curved metal bar. ")
                 : new NoNounMatchInteractionResult();

--- a/Planetfall/Location/Kalamontee/Mech/MachineShop.cs
+++ b/Planetfall/Location/Kalamontee/Mech/MachineShop.cs
@@ -38,7 +38,9 @@ internal class MachineShop : LocationWithNoStartingItems
                 return Task.FromResult<InteractionResult?>(new PositiveInteractionResult(
                     "You don't have the flask. "));
 
-            if (!context.HasItem<Flask>())
+            // Container-aware possession (issue #503) - the flat HasItem<T>() refuses the action when
+            // the flask is inside something you're carrying, and the turn falls to the narrator.
+            if (!context.IsCarrying<Flask>())
                 return Task.FromResult<InteractionResult?>(new NoNounMatchInteractionResult());
 
             FlaskUnderSpout = true;


### PR DESCRIPTION
Fixes #503.

## The bug

`Context.HasItem<T>()` is a flat, top-level-only inventory check (`Items.OfType<T>().Any()`). Gameplay gates written with it read a **pocketed** item as "not carried", return `NoNounMatchInteractionResult`, and hand the turn to the narrator — so the player gets invented prose instead of any hint that *where* they are carrying the thing is the problem.

Both sites from the issue reproduce for exactly that reason:

- **`SlotBase`** — every card-activated device (kitchen door, both elevators, shuttle, teleportation booths, miniaturization booth) refused a card sitting in the Patrol uniform pocket. The giveaway the issue called out is real: the wrong-card branch twenty lines below already used the container-aware `HasMatchingNoun`, so the two possession checks in one method disagreed, and the stricter one guarded the path that matters.
- **`Padlock`** (from the issue comment) — same defect on the Mess Corridor padlock, which gates the Mess Hall route, with a key the player has just fished out of a crevice with the magnet.

The pocket is the game's *starting* container — the ID card ships in it — so this hits the arrangement the game itself teaches.

## The fix

Fixed at the seam, per the issue comment's suggestion, rather than per caller: a new container-aware `IContext.IsCarrying<T>()`.

```csharp
public bool IsCarrying<TItem>() where TItem : IItem, new()
{
    // Strictly a superset of HasItem: a top-level item's CurrentLocation can be stale (see the
    // note in RemoveItem), so check flat membership first and only then walk the container chain.
    return HasItem<TItem>() || Repository.IsItemPossessedBy(Repository.GetItem<TItem>(), this);
}
```

`Repository.IsItemPossessedBy` is what GIVE/SHOW already use for the "reach into worn containers" semantic, so the gates now agree with each other. `HasItem<T>()` keeps its "in your hands, not in a container" meaning and is left alone for callers that genuinely want it — the flat check is deliberately tried **first** so the fix can never be *less* permissive than what it replaces (a top-level item's `CurrentLocation` can be stale, per the existing note in `Context.RemoveItem`).

Migrated every Planetfall gate that blocks a player action on a pocketable (size‑1, pocket-capable) item:

| Site | Item |
|---|---|
| `SlotBase` | every access card |
| `Padlock`, `MessDoor` | steel key |
| `FusedBedistor` | pliers |
| `MachineShop` | flask |
| `AdminCorridorSouth` | magnet |
| `Floyd` (multi-noun) + `FloydSocialResponses` | oil can |
| `Blather` | brush (defensive — see below) |

This is also *closer* to the original, not further: the parser's `(HAVE)` flag reaches into open carried containers. The comment on Floyd's oil-can gate claimed the flat check enforced `(HAVE)`; that reasoning is updated — `(HAVE)` is satisfied by a can in your pocket.

Three related changes fell out of the same handlers:

- **`SlotBase` implicit take.** Mirrors the original's `SLOT-F`, which relocates the card into your hands (`globals.zil:1375`) before any per-card branch runs, so the card ends up in hand either way.
- **`Padlock` / `FusedBedistor` guard placement.** The possession check moved *below* the verb/noun match, so it scopes the action rather than short-circuiting the whole handler.
- **`Blather` drop.** `context.Drop<Brush>()` only sees the top level of inventory, so a pocketed brush would have "bounced off Blather" while staying in the pocket; it now drops the instance. The brush is size 2 and can't fit the one-slot pocket today, so this one is consistency/defensive rather than a live reproduction — noted as such in the code comment.

## Second commit: the magnet's hazard daemon (review follow-up)

Reviewing the first commit surfaced one asymmetry it introduced: the possession *gates* became container-aware, but `Magnet.Act`'s own possession tests stayed flat. That cut both ways:

- A **pocketed magnet** still fished the key out of the crevice (the gate reaches into containers now) while `Act` deregistered it as an actor on the next turn, so it never scrambled anything — the magnet's entire downside became bypassable by pocketing it.
- A **pocketed card** was invisible to `Act`'s top-level-only scan, which made the new implicit take a trap: sliding a pocketed card hauled it up to the top level and into the magnet's reach on that very turn, destroying a card that had been safe a moment earlier.

Both tests now use the same definition of "carrying" as the gates (`context.IsCarrying<Magnet>()`, and `GetAllItemsRecursively` for the cards). Dropping the magnet still deregisters it, and the existing acquisition-order behaviour is unchanged — `GetAllItemsRecursively` preserves top-level order.

## Tests (TDD)

Each pocket-nested proof was written first and confirmed failing **for the right reason** — the empty narrator response, not a different refusal — then made to pass:

- `CardTests.Kitchen_HappyPath_CardInUniformPocket` (also asserts the implicit take puts the card in hand)
- `MessHallPadlockedDoorTests.UnlockPadlockWithKey_KeyInUniformPocket` / `UnlockDoorWithKey_KeyInUniformPocket`
- `CourseControlTests.UsePliersOnBedistor_PliersInUniformPocket_RemovesBedistor`
- `CommRoomAndMachineRoomTests.PutFlaskUnderSpout_FlaskInUniformPocket_Success`
- `AdminCorridorSouthTests.UseMagnetOnCrevice_MagnetInUniformPocket_RetrievesKey`
- `FloydTests.OilFloyd_OilCanInUniformPocket_Thanks` (both the bare and the `with oil can` phrasing)
- `AdminCorridorSouthTests.MagnetInUniformPocket_StillScramblesCards` / `CardInUniformPocket_IsStillScrambled` (both failed with the card left unscrambled before the second commit)

Plus the pins the issue asked for, because both handlers resolve their item **by type** from the repository and the possession check is the only thing scoping it:

- `CardTests.Kitchen_CardNotCarried_DoesNotOpenTheDoor`
- `MessHallPadlockedDoorTests.UnlockPadlockWithKey_KeyNotCarried_StaysLocked`

A shared `EngineTestsBase.Pocket<T>()` helper sets up the exact reported inventory (uniform worn, ID card out in your hands, the item in the pocket). All deterministic — real `Repository`, no AI, clock or network.

`Planetfall.Tests` (3228), `UnitTests` (1085), `ZorkOne.Tests` (1782), `Console.Tests`, `EscapeRoom.Tests` and `Stationfall.Tests` all pass, run per project. The two `*-Lambda.Tests` `ValuesControllerTests.TestGet` failures are pre-existing and environmental (`Missing environment variable OPEN_AI_KEY`), untouched by this diff.

## One thing deliberately left alone (separate defect)

While pinning the wrong-card message with the card in the pocket, I found that branch is **effectively dead in production**, for a reason unrelated to possession: it resolves the named card with the global `Repository.GetItem(noun)`, which returns the first *loaded* item whose nouns loosely match — and the ID card's bare noun `"card"` swallows every `"<x> access card"` phrase. Since the ID card exists from turn one (it starts in the pocket), `"slide shuttle access card through slot"` at the kitchen slot resolves to the ID card, which isn't an `AccessCard`, and the "Inkorekt awtharazaashun kard" message never fires. The existing `Kitchen_WrongCard` test only passes because the ID card is never instantiated in it.

I did not fix it here. The obvious scope-aware replacements (`GetItemInScope` / `GetPreciseMatchInScope`) resolve through `CurrentLocation`, which for an inventory item can be stale — Floyd's lazy `Init` re-seeds the lower-elevator-card singleton and steals its `CurrentLocation`, which made `SlideWrongCard_Upper` fail when I tried it. That deserves its own issue and its own TDD cycle rather than a drive-by in this one; there's a `NOTE` in `SlotBase` recording the finding and why. Happy to file it if you want.