### PR TITLE
Fix #513: stop printing "The card clicks neatly into the socket" twice for the shiny fromitz board

### DIFF
--- a/Planetfall.Tests/PlanetaryDefenseTests.cs
+++ b/Planetfall.Tests/PlanetaryDefenseTests.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+﻿using System.Text.RegularExpressions;
+using FluentAssertions;
 using GameEngine;
 using GameEngine.Item;
 using GameEngine.Item.ItemProcessor;
@@ -232,6 +233,46 @@ public class PlanetaryDefenseTests : EngineTestsBase
         var response = await target.GetResponse("put fried in panel");
 
         response.Should().Contain("The card clicks neatly into the socket");
+    }
+
+    [Test]
+    public async Task PutShinyInPanel_SaysTheCardClicksIntoTheSocketExactlyOnce()
+    {
+        // Issue #513: the shiny-board branch of FromitzAccessPanel.ItemPlacedHereResult appended a
+        // string that re-contained the unconditional base sentence, so solving the puzzle stuttered:
+        // "The card clicks neatly into the socket. The card clicks neatly into the socket. The warning
+        // lights stop flashing." The ZIL (comptwo.zil GOOD-BOARD arm) emits the socket sentence once and
+        // then the warning-lights clause. Count occurrences - a Contains assertion passes on the
+        // duplicate, which is why the existing tests stayed green.
+        var target = GetTarget();
+        StartHere<PlanetaryDefense>();
+        GetItem<FromitzAccessPanel>().IsOpen = true;
+        Take<ShinyFromitzBoard>();
+        await target.GetResponse("remove second");
+
+        var response = await target.GetResponse("put shiny in panel");
+
+        Regex.Matches(response!, Regex.Escape("The card clicks neatly into the socket.")).Count
+            .Should().Be(1);
+        response.Should().Contain("The warning lights stop flashing");
+        target.Context.Score.Should().Be(6);
+    }
+
+    [Test]
+    public async Task PutFriedInPanel_SaysTheCardClicksIntoTheSocketExactlyOnce_AndNothingElse()
+    {
+        // Issue #513: guards the other arm - a board that doesn't solve the puzzle gets the base
+        // sentence once and no warning-lights clause.
+        var target = GetTarget();
+        StartHere<PlanetaryDefense>();
+        GetItem<FromitzAccessPanel>().IsOpen = true;
+        Take<FriedFromitzBoard>();
+
+        var response = await target.GetResponse("put fried in panel");
+
+        Regex.Matches(response!, Regex.Escape("The card clicks neatly into the socket.")).Count
+            .Should().Be(1);
+        response.Should().NotContain("The warning lights stop flashing");
     }
 
     [Test]

--- a/Planetfall/Item/Lawanda/PlanetaryDefense/FromitzAccessPanel.cs
+++ b/Planetfall/Item/Lawanda/PlanetaryDefense/FromitzAccessPanel.cs
@@ -27,7 +27,10 @@ public class FromitzAccessPanel : OpenAndCloseContainerBase, ICanBeExamined
 
         if (item is ShinyFromitzBoard)
         {
-            response += "The card clicks neatly into the socket. The warning lights stop flashing. ";
+            // Issue #513: append only the extra clause. The socket sentence above is unconditional, so
+            // repeating it here made solving the puzzle stutter the line twice. The ZIL's GOOD-BOARD arm
+            // (comptwo.zil) emits the socket sentence once, then the warning-lights clause.
+            response += "The warning lights stop flashing. ";
             Repository.GetLocation<Location.Lawanda.PlanetaryDefense>().ItIsFixed(context);
         }
 


### PR DESCRIPTION
Fixes #513.

## The bug

`FromitzAccessPanel.ItemPlacedHereResult` emits `"The card clicks neatly into the socket. "` unconditionally, and the shiny-board branch then appended a string that **re-contained that same sentence**. So the scored planetary-defense step — the one every completed playthrough performs — stuttered:

```
> put shiny fromitz board in panel
The card clicks neatly into the socket. The card clicks neatly into the socket. The warning lights stop flashing.
```

Scoring (+6, once) and `ItIsFixed` were always correct; the defect was purely the duplicated sentence.

## The fix

The shiny branch now contributes only its own extra clause:

```csharp
if (item is ShinyFromitzBoard)
{
    response += "The warning lights stop flashing. ";
    Repository.GetLocation<Location.Lawanda.PlanetaryDefense>().ItIsFixed(context);
}
```

This matches the original — `planetfall-source/comptwo.zil:412-420`, the `GOOD-BOARD` arm of the `PUT` handler, calls the socket message **once** and then appends the warning-lights clause. The sibling half of this puzzle pair, `Planetfall/Item/Lawanda/LargeMetalCube.cs:68-76`, already has the correct shape: its `GoodBedistor` arm returns only its own extra text and never re-emits a base sentence.

## TDD

Red before, green after, in `Planetfall.Tests/PlanetaryDefenseTests.cs` against the real `Repository`:

1. `PutShinyInPanel_SaysTheCardClicksIntoTheSocketExactlyOnce` — with a socket freed, `put shiny in panel` asserts the socket sentence appears **exactly once** (occurrence count via `Regex.Matches`, not `Contains`), that the warning-lights clause is present, and that the score is 6. Confirmed failing for the right reason before the fix: *"Expected ... Count to be 1, but found 2."*
2. `PutFriedInPanel_SaysTheCardClicksIntoTheSocketExactlyOnce_AndNothingElse` — guards the other arm: base sentence once, no warning-lights clause.

The existing tests asserted with `Contains`, which passes on the duplicated string — that is why this slipped through.

## Verification

- `dotnet test Planetfall.Tests` — 3255 passed, 0 failed
- `dotnet test UnitTests` — 1130 passed, 0 failed, 1 skipped

---
_Generated by [Claude Code](https://claude.ai/code/session_011Mo5BVAAL7hjucTLQpqHMH)_