### PR TITLE
Medicine bottle: look in / examine lists the contents, not the label

### DIFF
--- a/Planetfall.Tests/InfirmaryTests.cs
+++ b/Planetfall.Tests/InfirmaryTests.cs
@@ -107,17 +107,61 @@ public class InfirmaryTests : EngineTestsBase
         response.Should().Contain("A quantity of medicine");
     }
     
+    // Issue #514: "look in <noun>" is normalized to "examine <noun>" by the engine, so the bottle's
+    // examine text IS its container listing. Aliasing ExaminationDescription to ReadDescription made
+    // both verbs print the label, byte-identical whether the bottle was full or empty. The label now
+    // lives only on the READ path (and on "examine label"), matching every sibling container.
     [Test]
-    public async Task Examine_MedicineBottle()
+    public async Task Examine_MedicineBottle_ListsTheContents()
     {
         var target = GetTarget();
         StartHere<Infirmary>();
-        
+
         var response = await target.GetResponse("examine bottle");
+
+        response.Should().Contain("The medicine bottle contains:");
+        response.Should().Contain("A quantity of medicine");
+        response.Should().NotContain("Dizeez supreshun medisin -- eksperimentul");
+    }
+
+    [Test]
+    public async Task LookInMedicineBottle_ListsTheContents()
+    {
+        var target = GetTarget();
+        StartHere<Infirmary>();
+
+        var response = await target.GetResponse("look in bottle");
+
+        response.Should().Contain("The medicine bottle contains:");
+        response.Should().Contain("A quantity of medicine");
+        response.Should().NotContain("Dizeez supreshun medisin -- eksperimentul");
+    }
+
+    [Test]
+    public async Task LookInsideMedicineBottle_WhenEmpty_SaysSo()
+    {
+        var target = GetTarget();
+        StartHere<Infirmary>();
+        GetItem<MedicineBottle>().Items.Clear();
+
+        var response = await target.GetResponse("look inside bottle");
+
+        response.Should().Contain("The medicine bottle is empty.");
+        response.Should().NotContain("A quantity of medicine");
+        response.Should().NotContain("Dizeez supreshun medisin -- eksperimentul");
+    }
+
+    [Test]
+    public async Task Examine_Label_StillReadsTheLabel()
+    {
+        var target = GetTarget();
+        StartHere<Infirmary>();
+
+        var response = await target.GetResponse("examine label");
 
         response.Should().Contain("Dizeez supreshun medisin -- eksperimentul");
     }
-    
+
     [Test]
     public async Task Read_MedicineBottle()
     {

--- a/Planetfall/Item/Lawanda/MedicineBottle.cs
+++ b/Planetfall/Item/Lawanda/MedicineBottle.cs
@@ -2,7 +2,7 @@ using Model.AIGeneration;
 
 namespace Planetfall.Item.Lawanda;
 
-internal class MedicineBottle : OpenAndCloseContainerBase, ICanBeTakenAndDropped, ICanBeRead, ICanBeExamined
+internal class MedicineBottle : OpenAndCloseContainerBase, ICanBeTakenAndDropped, ICanBeRead
 {
     public override string[] NounsForMatching => ["medicine bottle", "bottle", "vial"];
 
@@ -17,8 +17,14 @@ internal class MedicineBottle : OpenAndCloseContainerBase, ICanBeTakenAndDropped
 
     public override bool IsTransparent => true;
 
-    public string ExaminationDescription => ReadDescription;
-
+    // Issue #514: do NOT re-implement ICanBeExamined here. The engine normalizes "look in <noun>" /
+    // "look inside <noun>" to "examine <noun>" (GameEngine.NormalizeLookAt, issue #396), so the examine
+    // text IS this container's contents listing. Aliasing ExaminationDescription to ReadDescription made
+    // both verbs print the label - byte-identical whether the bottle was full or empty, the one container
+    // in the game that would not say what was inside it. Inheriting OpenAndCloseContainerBase's explicit
+    // ICanBeExamined member gives the sibling-container behavior: "The medicine bottle contains: ..." or
+    // "The medicine bottle is empty." (always visible - the bottle is transparent). The label stays on
+    // the READ path below and on "read/examine label" in RespondToSimpleInteraction.
     public string ReadDescription => "\"Dizeez supreshun medisin -- eksperimentul\"";
 
     public string OnTheGroundDescription(ILocation currentLocation)


### PR DESCRIPTION
Fixes #514.

## The bug

The medicine bottle was the one container in Planetfall that would not tell you what was inside it. `look in bottle` / `look inside bottle` returned the bottle's **label text**, and because the label is a constant the response was **byte-identical whether the bottle was full or empty**:

```
> look in bottle
"Dizeez supreshun medisin -- eksperimentul"    <-- the label, not the contents

> drink medicine
The medicine tasted extremely bitter.

> look in bottle
"Dizeez supreshun medisin -- eksperimentul"    <-- IDENTICAL. bottle is now empty.
```

## Root cause

`GameEngine.NormalizeLookAt` rewrites `look in <noun>` / `look inside <noun>` to `examine <noun>` (issue #396), so for a container the **examine text *is* its contents listing** — that is exactly why `look in cube` works. `MedicineBottle` re-implemented `ICanBeExamined` with `ExaminationDescription => ReadDescription`, which shadowed `OpenAndCloseContainerBase`'s explicit `ICanBeExamined` member (the one that lists contents) and put the label on both verbs, in every state.

The bottle's *other* descriptions (`GenericDescription`, `OnTheGroundDescription`, `NeverPickedUpDescription`) already branch on `Items.Any()`, which is why the bottle reported its contents correctly on the ground and in `i`. Only the examine/look-in path was hardcoded.

## The fix

Drop the re-implementation (and the redundant `ICanBeExamined` from the class declaration) so the base member applies. The bottle is transparent, so it now answers:

- full → `The medicine bottle contains:` / `   A quantity of medicine`
- empty → `The medicine bottle is empty.`

the same shape every sibling container gives (`Canteen`, `FromitzAccessPanel`, `LargeMetalCube`). This matches the original: `MEDICINE-BOTTLE` (`comptwo.zil`) is a plain readable, transparent container with **no `ACTION` routine**, so `LOOK IN` dispatches to the standard `V-LOOK-INSIDE` — which inspects the contents, not the readable text.

The label is untouched on the READ path (`read bottle`) and on `read label` / `examine label`, which `RespondToSimpleInteraction` still intercepts.

## TDD

Written test-first in `Planetfall.Tests/InfirmaryTests.cs`; all three new/changed assertions failed with the label text before the fix, for the right reason:

- `Examine_MedicineBottle_ListsTheContents` — replaces `Examine_MedicineBottle`, which codified the bug (asserted the label). Since `look in` is normalized to `examine`, the two verbs cannot diverge, and the issue's expected behavior is the contents.
- `LookInMedicineBottle_ListsTheContents` — the reported repro.
- `LookInsideMedicineBottle_WhenEmpty_SaysSo` — the state distinction that was impossible before.
- `Examine_Label_StillReadsTheLabel` — new guard; passed before and after, proving the label path is preserved.

`Read_MedicineBottle` and `Read_Label` are unchanged and still green.

## Verification

- `dotnet test Planetfall.Tests` → 3256 passed, 0 failed
- `dotnet test UnitTests` → 1130 passed, 0 failed

---
_Generated by [Claude Code](https://claude.ai/code/session_01MDnFgbZfTh2jUfdWJtHW72)_