### PR TITLE
Lab Office: describe the west door's actual open/closed state

### DIFF
--- a/Planetfall.Tests/ChaseSceneTests.cs
+++ b/Planetfall.Tests/ChaseSceneTests.cs
@@ -728,11 +728,18 @@ public class ChaseSceneTests : EngineTestsBase
             var target = GetTarget();
             await SetupChaseInBioLab(target);
 
-            // Try to go back East to LabOffice - door should be closed
+            // Shut the office door behind us -- the setup opened it to get in here.
+            // (This assertion used to pass against an open door, because the Lab Office
+            // room description hardcoded "A closed door to the west"; the player was in
+            // fact walking straight back into the office.)
+            GetItem<OfficeDoor>().IsOpen = false;
+
+            // Try to go back East to LabOffice - the closed door blocks it
             var response = await target.GetResponse("e");
 
             // Should not be able to escape this way - trapped
-            response.Should().Contain("closed");
+            response.Should().Contain("The office door is closed");
+            response.Should().NotContain("Lab Office");
         }
 
         [Test]

--- a/Planetfall.Tests/LabsAndDoorsTests.cs
+++ b/Planetfall.Tests/LabsAndDoorsTests.cs
@@ -467,6 +467,49 @@ public class LabsAndDoorsTests : EngineTestsBase
     }
 
     [Test]
+    public async Task LabOffice_Look_WhenDoorClosed_DescribesAClosedDoor()
+    {
+        var target = GetTarget();
+        StartHere<LabOffice>();
+        GetItem<OfficeDoor>().IsOpen = false;
+
+        var response = await target.GetResponse("look");
+
+        response.Should().Contain("A closed door to the west");
+        response.Should().NotContain("An open door to the west");
+    }
+
+    [Test]
+    public async Task LabOffice_Look_WhenDoorOpen_DescribesAnOpenDoor()
+    {
+        // The room description asserts a mutable fact, so it has to be interpolated from
+        // OfficeDoor.IsOpen -- it used to hardcode "A closed door", contradicting both
+        // "examine door" and the live West exit on the very same screen.
+        var target = GetTarget();
+        StartHere<LabOffice>();
+        GetItem<OfficeDoor>().IsOpen = true;
+
+        var response = await target.GetResponse("look");
+
+        response.Should().Contain("An open door to the west");
+        response.Should().NotContain("A closed door to the west");
+    }
+
+    [Test]
+    public async Task LabOffice_Look_AndExamineDoor_AgreeThatDoorIsOpen()
+    {
+        var target = GetTarget();
+        StartHere<LabOffice>();
+        GetItem<OfficeDoor>().IsOpen = true;
+
+        var look = await target.GetResponse("look");
+        var examine = await target.GetResponse("examine door");
+
+        look.Should().Contain("An open door to the west");
+        examine.Should().Contain("The office door is open");
+    }
+
+    [Test]
     public async Task LabOffice_PressRedButton_ActivatesFungicide()
     {
         var target = GetTarget();

--- a/Planetfall/Location/Lawanda/LabOffice/LabOffice.cs
+++ b/Planetfall/Location/Lawanda/LabOffice/LabOffice.cs
@@ -10,9 +10,16 @@ internal class LabOffice : LocationBase
 
     protected override string GetContextBasedDescription(IContext context)
     {
+        // The door state is mutable, so this sentence has to be interpolated rather than
+        // hardcoded: the original branches on the door's OPENBIT and varies both the article
+        // and the adjective ("An open" / "A closed"). Hardcoding "A closed" made the room
+        // description contradict "examine door" and the live West exit on the same screen.
+        var doorDescription = Repository.GetItem<OfficeDoor>().IsOpen ? "An open" : "A closed";
+
         return
             "This is the office for storing files on Bio Lab experiments. A large and messy desk is surrounded by " +
-            "locked files. A small booth lies to the south. A closed door to the west is labelled \"Biioo Lab.\" " +
+            $"locked files. A small booth lies to the south. {doorDescription} door to the west is labelled " +
+            "\"Biioo Lab.\" " +
             "You realize with shock and horror that the only way out is through the mutant-infested Bio Lab. " +
             "\nOn the wall are three buttons: a white button labelled \"Lab Liits On\", a black button labelled " +
             "\"Lab Liits Of\", and a red button labelled \"Eemurjensee Sistum.\" ";


### PR DESCRIPTION
Fixes #512.

## The bug

The Lab Office room description hardcoded `A closed door to the west`, asserting a *mutable* fact. Once the office door was opened, a single screen reported it three contradictory ways:

- room description → "A closed door to the west"
- `examine door` → "The office door is open."
- the room's own follow-up text → "Through the open doorway you can see the Bio Lab."

…while `W` was simultaneously exposed as a live exit.

## The fix

`Planetfall/Location/Lawanda/LabOffice/LabOffice.cs` — `GetContextBasedDescription` now interpolates the article + adjective from `OfficeDoor.IsOpen`, the same state the West `MovementParameters` (`LabOffice.cs:40`) and `OfficeDoor.ExaminationDescription` already consult.

The original branches on the door's `OPENBIT` in `LAB-OFFICE-F`'s `M-LOOK` and varies both the article and the adjective (`An open` / `A closed`), so this restores the original wording rather than inventing a phrasing.

## TDD

Three tests added to `Planetfall.Tests/LabsAndDoorsTests.cs`, following the plan in the issue:

| Test | Before | After |
|---|---|---|
| `LabOffice_Look_WhenDoorClosed_DescribesAClosedDoor` | pass (pins the shut wording so the fix can't invert it) | pass |
| `LabOffice_Look_WhenDoorOpen_DescribesAnOpenDoor` | **fail** — `to contain "An open door to the west"` | pass |
| `LabOffice_Look_AndExamineDoor_AgreeThatDoorIsOpen` | **fail** — the player-visible invariant being violated | pass |

## One existing test corrected

`ChaseSceneTests.GoEastFromBioLab_ToLabOffice_IsTrapped` was only passing *because of* this bug. Its setup (`SetupChaseInBioLab`) opens the office door to get into the Bio Lab and never closes it, so its `Contain("closed")` was matching the hardcoded room text while the player actually walked straight back into the Lab Office — it never verified being trapped at all, and duplicated its sibling `..._WithDoorOpen_IsTrapped`.

It now closes the door, as its name and comment always claimed, and asserts the move is genuinely blocked (`"The office door is closed"`, and no Lab Office description).

## Verification

All suites run separately, all green:

| Suite | Result |
|---|---|
| `Planetfall.Tests` | 3256 passed, 0 failed |
| `UnitTests` | 1130 passed, 0 failed (1 skipped) |
| `ZorkOne.Tests` | 1782 passed, 0 failed |
| `EscapeRoom.Tests` | 9 passed |
| `Stationfall.Tests` | 4 passed |
| `Console.Tests` | 16 passed |

Not addressed here: the issue's closing suggestion to sweep the remaining `GetContextBasedDescription` literals for other un-interpolated state words. That's a broader audit and is left out of this focused fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RhenMxCsTXUssTXXjX1hKZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01RhenMxCsTXUssTXXjX1hKZ)_