### PR TITLE
Teleport booths: bring the booth's contents along, as ROB does (#520)

### DIFF
--- a/Planetfall.Tests/BoothTests.cs
+++ b/Planetfall.Tests/BoothTests.cs
@@ -457,6 +457,66 @@ public class BoothTests : EngineTestsBase
         GetItem<Brush>().CurrentLocation.Should().BeOfType<BoothOne>();
     }
 
+    // Teleporting Floyd used to be a bare CurrentLocation assignment, so he was never removed from the
+    // departure booth's Items nor added to the destination's. CurrentLocation alone looked right, but
+    // everything that resolves nouns through the room - scope checks, ConversationHandler's
+    // CollectTalkableEntities - reads CurrentLocation.Items, so Floyd was unreachable in the room he
+    // had just arrived in, and a phantom Floyd lingered in the booth he left. FloydMovementManager
+    // can't self-heal it either: its isInTheRoom check compares CurrentLocation, which already agrees.
+    // Seed him the way HandleFollowingPlayer does, not by assignment, or the desync can't reproduce.
+    [Test]
+    public async Task Teleport_ReParentsFloydIntoTheDestinationsItemList()
+    {
+        var target = GetTarget();
+        StartHere<BoothThree>();
+        Take<TeleportationAccessCard>();
+        GetLocation<BoothThree>().ItemPlacedHere(GetItem<Floyd>());
+
+        await target.GetResponse("slide teleportation access card through slot");
+        await target.GetResponse("press one");
+
+        target.Context.CurrentLocation.Should().BeOfType<BoothOne>();
+        GetItem<Floyd>().CurrentLocation.Should().BeOfType<BoothOne>();
+        GetLocation<BoothOne>().Items.Should().Contain(GetItem<Floyd>());
+        GetLocation<BoothThree>().Items.Should().NotContain(GetItem<Floyd>());
+    }
+
+    // The player-visible half of the same defect: having arrived together, Floyd must still be
+    // addressable in the destination booth.
+    [Test]
+    public async Task Teleport_LeavesFloydReachableInTheDestination()
+    {
+        var target = GetTarget();
+        StartHere<BoothThree>();
+        Take<TeleportationAccessCard>();
+        GetLocation<BoothThree>().ItemPlacedHere(GetItem<Floyd>());
+
+        await target.GetResponse("slide teleportation access card through slot");
+        await target.GetResponse("press one");
+
+        var response = await target.GetResponse("examine floyd");
+        response.Should().Contain("robot");
+    }
+
+    // Booth 2's tan button is labelled "3", but its noun list carried "two" (a label Booth 2 does not
+    // have - that is Booth 1's beige button) and omitted the spelled-out "three". So "press three"
+    // cleared the outer guard, matched neither branch, and silently fell through to the narrator
+    // without teleporting. "press 3" and the disambiguation path both worked, which hid it; Booths 1
+    // and 3 list the spelled-out word correctly.
+    [Test]
+    public async Task BoothTwo_PressThree_Teleports()
+    {
+        var target = GetTarget();
+        StartHere<BoothTwo>();
+        Take<TeleportationAccessCard>();
+
+        await target.GetResponse("slide teleportation access card through slot");
+        var response = await target.GetResponse("press three");
+
+        response.Should().Contain("You experience a strange feeling in the pit of your stomach");
+        target.Context.CurrentLocation.Should().BeOfType<BoothThree>();
+    }
+
     // Re-sliding the card restarts the countdown (the original re-QUEUEs the turn-off daemon).
     [Test]
     public async Task Activation_ReslidingCard_RestartsCountdown()

--- a/Planetfall.Tests/BoothTests.cs
+++ b/Planetfall.Tests/BoothTests.cs
@@ -1,5 +1,7 @@
 using System.Text;
 using FluentAssertions;
+using Planetfall.Item;
+using Planetfall.Item.Feinstein;
 using Planetfall.Item.Kalamontee.Admin;
 using Planetfall.Item.Kalamontee.Mech;
 using Planetfall.Item.Kalamontee.Mech.FloydPart;
@@ -363,6 +365,96 @@ public class BoothTests : EngineTestsBase
         var response = await target.GetResponse("press 1");
         response.Should().Contain("not aktivaatid");
         target.Context.CurrentLocation.Should().BeOfType<BoothThree>();
+    }
+
+    // Issue #520 (second defect, same rooms): Booths 1 and 2 carried a stray "\n" in the middle of the
+    // panel sentence - a copy-paste artifact in the two booths that mention button "3" - so the room
+    // description broke mid-sentence on a line of its own. Booth 3, which has no "3" button, was
+    // always written without it.
+    [Test]
+    public async Task RoomDescription_HasNoStrayMidSentenceLineBreak()
+    {
+        var target = GetTarget();
+
+        foreach (var look in new List<Func<Task<string>>>
+                 {
+                     () => { StartHere<BoothOne>(); return target.GetResponse("look")!; },
+                     () => { StartHere<BoothTwo>(); return target.GetResponse("look")!; },
+                     () => { StartHere<BoothThree>(); return target.GetResponse("look")!; }
+                 })
+        {
+            var response = await look();
+            response.Should().Contain("This is a tiny room with a large");
+            response.Should().NotContain("labelled\n");
+        }
+    }
+
+    // Issue #520: the original's TELEPORT robs the booth into the destination
+    // (<ROB ,HERE .DEST>, globals.zil:1522), so anything lying on the booth floor travels with you.
+    // The port relocated only the player and Floyd, stranding dropped items - and Booth 3 is on a
+    // different continent from Booths 1 and 2.
+    [Test]
+    public async Task Teleport_TakesTheBoothsContentsWithYou()
+    {
+        var target = GetTarget();
+        StartHere<BoothTwo>();
+        Take<TeleportationAccessCard>();
+        Take<Brush>();
+
+        await target.GetResponse("drop brush");
+        GetItem<Brush>().CurrentLocation.Should().BeOfType<BoothTwo>();
+
+        await target.GetResponse("slide teleportation access card through slot");
+        var response = await target.GetResponse("press one");
+
+        response.Should().Contain("You experience a strange feeling in the pit of your stomach");
+        target.Context.CurrentLocation.Should().BeOfType<BoothOne>();
+
+        GetItem<Brush>().CurrentLocation.Should().BeOfType<BoothOne>();
+        GetLocation<BoothOne>().Items.Should().Contain(GetItem<Brush>());
+        GetLocation<BoothTwo>().Items.Should().NotContain(GetItem<Brush>());
+    }
+
+    // The subtlety in the fix: in the ZIL the card slot is a LOCAL-GLOBALS object without TAKEBIT, so
+    // ROB never picks it up. In the port each booth genuinely holds its own TeleportationSlot, so a
+    // naive move-all would drag the slot along and corrupt both rooms. Only takeable things travel.
+    [Test]
+    public async Task Teleport_LeavesTheBoothsOwnCardSlotBehind()
+    {
+        var target = GetTarget();
+        StartHere<BoothTwo>();
+        Take<TeleportationAccessCard>();
+        Take<Brush>();
+
+        await target.GetResponse("drop brush");
+        await target.GetResponse("slide teleportation access card through slot");
+        await target.GetResponse("press one");
+
+        GetItem<TeleportationSlot<BoothTwo>>().CurrentLocation.Should().BeOfType<BoothTwo>();
+        GetLocation<BoothTwo>().Items.Should().Contain(GetItem<TeleportationSlot<BoothTwo>>());
+        GetLocation<BoothOne>().Items.Should().NotContain(GetItem<TeleportationSlot<BoothTwo>>());
+        GetLocation<BoothOne>().Items.Should().Contain(GetItem<TeleportationSlot<BoothOne>>());
+    }
+
+    // Robbing the booth must not disturb what already worked: Floyd still comes along, and the
+    // teleport still reads as a single "strange feeling" line with no stray item chatter.
+    [Test]
+    public async Task Teleport_WithItemsAndFloyd_StillMovesFloydAndSaysNothingExtra()
+    {
+        var target = GetTarget();
+        StartHere<BoothThree>();
+        Take<TeleportationAccessCard>();
+        Take<Brush>();
+        GetItem<Floyd>().CurrentLocation = GetLocation<BoothThree>();
+
+        await target.GetResponse("drop brush");
+        await target.GetResponse("slide teleportation access card through slot");
+        var response = await target.GetResponse("press one");
+
+        response.Should().Contain("Floyd gives a terrified squeal, and clutches at his guidance mechanism");
+        response.Should().Contain("You experience a strange feeling in the pit of your stomach");
+        GetItem<Floyd>().CurrentLocation.Should().BeOfType<BoothOne>();
+        GetItem<Brush>().CurrentLocation.Should().BeOfType<BoothOne>();
     }
 
     // Re-sliding the card restarts the countdown (the original re-QUEUEs the turn-off daemon).

--- a/Planetfall.Tests/CourseControlTests.cs
+++ b/Planetfall.Tests/CourseControlTests.cs
@@ -516,4 +516,18 @@ public class CourseControlTests : EngineTestsBase
 
         response.Should().Contain("The brush doesn't fit");
     }
+
+    // Same stray mid-sentence "\n" artifact fixed in the Booth 1/2 descriptions under issue #520:
+    // this room's description broke in the middle of "to the north and south".
+    [Test]
+    public async Task SystemsCorridorEast_Description_HasNoStrayMidSentenceLineBreak()
+    {
+        var target = GetTarget();
+        StartHere<SystemsCorridorEast>();
+
+        var response = await target.GetResponse("look");
+
+        response.Should().Contain("smaller doorways to the north and south");
+        response.Should().NotContain("north\n");
+    }
 }

--- a/Planetfall.Tests/KitchenAndCanteenTests.cs
+++ b/Planetfall.Tests/KitchenAndCanteenTests.cs
@@ -368,4 +368,18 @@ public class KitchenAndCanteenTests : EngineTestsBase
         response.Should().Contain("brush");
         GetItem<Canteen>().Items.Should().BeEmpty();
     }
+
+    // Same stray mid-sentence "\n" artifact fixed in the Booth 1/2 descriptions under issue #520 -
+    // an identical "labelled\n" break, here in the dispenser's examination text.
+    [Test]
+    public async Task KitchenMachine_Description_HasNoStrayMidSentenceLineBreak()
+    {
+        var target = GetTarget();
+        StartHere<Kitchen>();
+
+        var response = await target.GetResponse("examine machine");
+
+        response.Should().Contain("The machine is labelled \"Hii Prooteen Likwid Dispensur.\"");
+        response.Should().NotContain("labelled\n");
+    }
 }

--- a/Planetfall/Item/Kalamontee/KitchenMachine.cs
+++ b/Planetfall/Item/Kalamontee/KitchenMachine.cs
@@ -23,7 +23,7 @@ internal class KitchenMachine : ContainerBase, ICanBeExamined
         "This wall-mounted unit contains an octagonal niche beneath a spout. " +
         (Items.Any() ? "A canteen is resting in the niche, its mouth lying just below the spout. " : "") +
         "Above the spout is a button. " +
-        "The machine is labelled\n\"Hii Prooteen Likwid Dispensur.\" ";
+        "The machine is labelled \"Hii Prooteen Likwid Dispensur.\" ";
 
     public override string GenericDescription(ILocation? currentLocation)
     {

--- a/Planetfall/Location/BoothBase.cs
+++ b/Planetfall/Location/BoothBase.cs
@@ -61,7 +61,20 @@ internal abstract class BoothBase : LocationBase, ICardActivatedDevice
         // Using the booth consumes the activation and cancels its expiry countdown, mirroring
         // <DISABLE <INT I-TURNOFF-TELEPORTATION>> on a successful teleport (globals.zil:1522).
         CardActivationTimer.Cancel(this, context);
-        context.CurrentLocation = Repository.GetLocation<T>();
+
+        ILocation destination = Repository.GetLocation<T>();
+
+        // Issue #520: the original robs the whole booth into the destination (<ROB ,HERE .DEST> in
+        // TELEPORT, globals.zil:1522), so anything set down on the booth floor travels with you.
+        // Without this it is stranded - and Booth 3 is on a different continent from Booths 1 and 2.
+        // ROB only carries TAKEBIT objects, and the booth's own card slot is a LOCAL-GLOBALS fixture
+        // that never had one; here it genuinely lives in the room's item list, so filter to takeable
+        // items or the slot rides along and corrupts both booths. Iterate a copy - ItemPlacedHere
+        // mutates the source collection as it re-parents each item.
+        foreach (var item in Items.OfType<ICanBeTakenAndDropped>().Cast<IItem>().ToList())
+            destination.ItemPlacedHere(item);
+
+        context.CurrentLocation = destination;
 
         sb.AppendLine("You experience a strange feeling in the pit of your stomach. ");
         return new PositiveInteractionResult(sb.ToString());

--- a/Planetfall/Location/BoothBase.cs
+++ b/Planetfall/Location/BoothBase.cs
@@ -51,28 +51,39 @@ internal abstract class BoothBase : LocationBase, ICardActivatedDevice
             return new PositiveInteractionResult("A sign flashes \"Teleportaashun buux not aktivaatid.\"");
 
         var sb = new StringBuilder();
+        ILocation destination = Repository.GetLocation<T>();
 
-        if (Repository.GetItem<Floyd>().CurrentLocation == context.CurrentLocation)
+        var floyd = Repository.GetItem<Floyd>();
+        if (floyd.CurrentLocation == context.CurrentLocation)
         {
             sb.AppendLine("Floyd gives a terrified squeal, and clutches at his guidance mechanism. ");
-            Repository.GetItem<Floyd>().CurrentLocation = Repository.GetLocation<T>();
+
+            // Re-parent Floyd, never just reassign CurrentLocation: everything that resolves a noun
+            // through the room - scope checks, ConversationHandler.CollectTalkableEntities - reads
+            // CurrentLocation.Items. A bare assignment left him listed in the booth he departed and
+            // absent from the one he arrived in, so "examine floyd" and talking to him came back
+            // empty in the destination. FloydMovementManager cannot repair it, because its
+            // isInTheRoom check compares CurrentLocation, which already agrees.
+            RemoveItem(floyd);
+            destination.ItemPlacedHere(floyd);
         }
-        
+
         // Using the booth consumes the activation and cancels its expiry countdown, mirroring
         // <DISABLE <INT I-TURNOFF-TELEPORTATION>> on a successful teleport (globals.zil:1522).
         CardActivationTimer.Cancel(this, context);
 
-        ILocation destination = Repository.GetLocation<T>();
-
         // Issue #520: the original robs the whole booth into the destination (<ROB ,HERE .DEST> in
         // TELEPORT, globals.zil:1522), so anything set down on the booth floor travels with you.
         // Without this it is stranded - and Booth 3 is on a different continent from Booths 1 and 2.
-        // ROB only carries TAKEBIT objects, and the booth's own card slot is a LOCAL-GLOBALS fixture
-        // that never had one; here it genuinely lives in the room's item list, so filter to takeable
-        // items or the slot rides along and corrupts both booths. Iterate a copy - ItemPlacedHere
-        // mutates the source collection as it re-parents each item.
+        // The booth's card slot must stay put, though: in the original it is a LOCAL-GLOBALS fixture
+        // and so was never part of the room's contents for ROB to move, whereas here it genuinely
+        // lives in the room's item list. Filtering to takeable items reproduces that; a move-all
+        // would drag the slot along and corrupt both booths. Iterate a copy - the loop mutates Items.
         foreach (var item in Items.OfType<ICanBeTakenAndDropped>().Cast<IItem>().ToList())
+        {
+            RemoveItem(item);
             destination.ItemPlacedHere(item);
+        }
 
         context.CurrentLocation = destination;
 

--- a/Planetfall/Location/Kalamontee/BoothOne.cs
+++ b/Planetfall/Location/Kalamontee/BoothOne.cs
@@ -23,7 +23,7 @@ internal class BoothOne : BoothBase
     {
         return
             "This is a tiny room with a large \"1\" painted on the wall. A panel contains a slot about ten centimeters " +
-            "wide, a beige button labelled \"2\" and a tan button labelled\n\"3.\"";
+            "wide, a beige button labelled \"2\" and a tan button labelled \"3.\"";
     }
 
     public override async Task<InteractionResult> RespondToSimpleInteraction(SimpleIntent action, IContext context, IGenerationClient client,

--- a/Planetfall/Location/Kalamontee/BoothTwo.cs
+++ b/Planetfall/Location/Kalamontee/BoothTwo.cs
@@ -40,7 +40,10 @@ internal class BoothTwo : BoothBase
         if (action.Match(Verbs.PushVerbs, ["brown button", "brown", "tan button", "tan", "1", 
                 "3", "one", "three", "1 button", "3 button", "one button", "three button"]))
         {
-            if (action.MatchNoun(["tan button", "tan", "3", "two", "3 button", "three button"]))
+            // "three", not "two": this booth's tan button is labelled "3". Booth 2 has no "2" button
+            // at all, so matching "two" here both answered a noun that does not exist and left the
+            // spelled-out "three" falling through to the narrator without teleporting.
+            if (action.MatchNoun(["tan button", "tan", "3", "three", "3 button", "three button"]))
                 return GoThree(context);
 
             if (action.MatchNoun(["brown button", "brown", "1", "one", "1 button", "one button"]))

--- a/Planetfall/Location/Kalamontee/BoothTwo.cs
+++ b/Planetfall/Location/Kalamontee/BoothTwo.cs
@@ -17,7 +17,7 @@ internal class BoothTwo : BoothBase
     protected override string GetContextBasedDescription(IContext context)
     {
         return "This is a tiny room with a large \"2\" painted on the wall. A panel contains a " +
-               "slot about ten centimeters wide, a brown button labelled \"1\" and a tan button labelled\n\"3.\"";
+               "slot about ten centimeters wide, a brown button labelled \"1\" and a tan button labelled \"3.\"";
     }
     
     public override async Task<InteractionResult> RespondToSimpleInteraction(SimpleIntent action, IContext context, IGenerationClient client,

--- a/Planetfall/Location/Lawanda/SystemsCorridorEast.cs
+++ b/Planetfall/Location/Lawanda/SystemsCorridorEast.cs
@@ -21,7 +21,7 @@ internal class SystemsCorridorEast : LocationWithNoStartingItems
     {
         return
             "The hallway ends here with a large doorway leading east, and smaller doorways " +
-            "to the north\nand south. The northern doorway is labelled \"Planateree Kors Kontrool.\" " +
+            "to the north and south. The northern doorway is labelled \"Planateree Kors Kontrool.\" " +
             "The hallway itself leads west. ";
     }
 }


### PR DESCRIPTION
Fixes #520.

## The bug

Teleporting between booths relocated only the player and Floyd. Anything lying on the booth floor stayed behind:

```
[Booth 2] > drop brush
Dropped
> slide teleportation card through slot
Nothing happens for a moment. Then a light flashes "Redee."
> push brown button
You experience a strange feeling in the pit of your stomach.
[Booth 1] > look
Booth 1
This is a tiny room ...          <-- no brush; it is still in Booth 2
```

## Original behavior (ZIL, per the issue)

`TELEPORT` (`planetfall-source/globals.zil:1510-1527`) robs the booth into the destination — moving the *entire contents of the room* — before relocating the player. `BoothBase.Go` had already replicated the two neighbouring lines of `TELEPORT` (the Floyd branch, and the activation reset from #399); the rob step was the one that had been dropped.

This matters beyond the cosmetic because of *where* the booths are: Booths 1 and 2 are in Kalamontee, Booth 3 is in Lawanda. Something set down in Booth 3 was stranded on the other continent, recoverable only by the shuttle round-trip. Carrying capacity in Planetfall shrinks as the disease progresses, so "put a couple of things down, teleport, come back for them" is a plausible thing to try.

## The fix

`Planetfall/Location/BoothBase.cs` — move the booth's contents to the destination alongside the player.

The one subtlety is that the booth's card slot must stay put. In the original it is a `LOCAL-GLOBALS` fixture, so it was never part of the room's contents for the rob to move; in the port it genuinely *does* live in the room's item list (registered per booth via `StartWithItem`). Filtering to `ICanBeTakenAndDropped` reproduces the original outcome — a move-all would drag `TeleportationSlot<T>` into the destination and corrupt both rooms. The loop iterates a copy, since it mutates `Items` as it re-parents.

## Also fixed (surfaced by review of the above)

**Floyd was left out of the destination's item list.** He was teleported by a bare `CurrentLocation =` assignment while every other item is re-parented via `ItemPlacedHere`, so he was never removed from the departure booth's `Items` nor added to the destination's. `CurrentLocation` alone looked right, but everything that resolves a noun through the room — `Repository.GetItemInScope`, `ConversationHandler.CollectTalkableEntities` — reads `CurrentLocation.Items`. So Floyd was unreachable in the booth he had just arrived in (`examine floyd` returned a blank line) and a phantom Floyd lingered in the booth he left. `FloydMovementManager` could not self-heal it: its `isInTheRoom` check compares `CurrentLocation`, which already agreed.

Pre-existing, but it directly contradicts this PR's premise that the booth's occupants travel with you.

**`press three` did nothing in Booth 2.** Its tan button is labelled "3", but the noun list carried `"two"` — a label Booth 2 does not have; that is Booth 1's beige button — and omitted the spelled-out `"three"`. So `press three` cleared the outer guard, matched neither branch, and fell through to the narrator without teleporting. `press 3` and the disambiguation path both worked, which hid it; Booths 1 and 3 list the spelled-out word correctly.

## Stray mid-sentence line breaks

The issue noted a stray `\n` mid-sentence in the Booth 1 and Booth 2 descriptions — a copy-paste artifact in the two booths that mention button "3" (Booth 3, which has no such button, was always written correctly). Sweeping for the same artifact found two more:

| File | Text |
| --- | --- |
| `BoothOne.cs:26`, `BoothTwo.cs:20` | `a tan button labelled\n"3."` |
| `SystemsCorridorEast.cs:24` | `smaller doorways to the north\nand south` |
| `KitchenMachine.cs:26` | `The machine is labelled\n"Hii Prooteen Likwid Dispensur."` |

`CommRoom.cs:148` has one too, but inside a quoted alien distress transmission where the break may be deliberate formatting — left alone deliberately.

## TDD

Nine tests, all in the projects' normal test commands, all deterministic (real `Repository`, no randomness/clock/network/AI). Each was confirmed red for the right reason before its fix — assertion diffs read, not just non-zero exits.

In `Planetfall.Tests/BoothTests.cs`:

- `Teleport_TakesTheBoothsContentsWithYou` — drop the brush in Booth 2, activate, press "1"; the brush is now in Booth 1. *Red on the brush's `CurrentLocation`.*
- `Teleport_LeavesTheBoothsOwnCardSlotBehind` — the regression guard for the filter: Booth 2 keeps its own slot, Booth 1 has only its own.
- `Teleport_WithItemsAndFloyd_StillMovesFloydAndSaysNothingExtra` — pins what already worked: Floyd still comes along, response unchanged.
- `Teleport_ReParentsFloydIntoTheDestinationsItemList` — Floyd is in the destination's `Items` and gone from the source's. Seeds him via `ItemPlacedHere`, the way `HandleFollowingPlayer` does; seeding by assignment (as an earlier version of the Floyd test did) cannot reproduce the desync.
- `Teleport_LeavesFloydReachableInTheDestination` — the player-visible half: `examine floyd` still works after arriving. *Red with an empty response.*
- `BoothTwo_PressThree_Teleports` — *red with an empty response and no teleport.*
- `RoomDescription_HasNoStrayMidSentenceLineBreak` — covers all three booths.

Plus `SystemsCorridorEast_Description_HasNoStrayMidSentenceLineBreak` in `CourseControlTests.cs` and `KitchenMachine_Description_HasNoStrayMidSentenceLineBreak` in `KitchenAndCanteenTests.cs`.

## Verification

All suites run separately, all green:

| Project | Result |
| --- | --- |
| Planetfall.Tests | 3282 passed |
| UnitTests | 1130 passed, 1 skipped |
| ZorkOne.Tests | 1782 passed |
| EscapeRoom.Tests | 9 passed |
| Console.Tests | 16 passed |
| Stationfall.Tests | 4 passed |