### PR TITLE
Fix #517: port the SPECK object so "shoot speck with laser" works

### DIFF
--- a/Planetfall.Tests/RelayTests.cs
+++ b/Planetfall.Tests/RelayTests.cs
@@ -427,6 +427,184 @@ public class RelayTests : EngineTestsBase
 
     #endregion
 
+    #region Speck Tests
+
+    // Issue #517: the SPECK is a first-class object in the original (comptwo.zil:2562-2567,
+    // SYNONYM SPECK BOULDER IMPURITY / ADJECTIVE BLUE) and the laser's SHOOT handler dispatches on
+    // it (comptwo.zil:2712). The port modelled the puzzle on the relay alone, so the canonical
+    // solution "shoot speck with laser" died on "You don't see any speck here." in production —
+    // hidden from CI only because the test fixture rewrote the noun to "relay".
+
+    [Test]
+    public void Speck_IsPresentInTheRelayRoom()
+    {
+        GetTarget();
+        var location = StartHere<StripNearRelay>();
+        var speck = GetItem<Speck>();
+
+        speck.CurrentLocation.Should().Be(location);
+        location.Items.Should().Contain(speck);
+    }
+
+    [Test]
+    public async Task Speck_IsNotListedInTheRoomDescription()
+    {
+        var target = GetTarget();
+        StartHere<StripNearRelay>();
+
+        var response = await target.GetResponse("look");
+
+        // NDESCBIT in the original — the speck is only visible through the relay's description.
+        response.Should().NotContain("There is a speck");
+    }
+
+    [Test]
+    public async Task ExamineSpeck_DescribesTheSpeck()
+    {
+        var target = GetTarget();
+        StartHere<StripNearRelay>();
+
+        var response = await target.GetResponse("examine speck");
+
+        response.Should().Contain("blue boulder");
+    }
+
+    [TestCase("boulder")]
+    [TestCase("impurity")]
+    public async Task ExamineSpeck_BySynonym_DescribesTheSpeck(string noun)
+    {
+        var target = GetTarget();
+        StartHere<StripNearRelay>();
+
+        var response = await target.GetResponse($"examine {noun}");
+
+        response.Should().Contain("blue boulder");
+    }
+
+    [Test]
+    public async Task ShootSpeck_WithRedLaser_FirstHit_SetsSpeckHit()
+    {
+        var target = GetTarget();
+        StartHere<StripNearRelay>();
+        Take<Laser>();
+        GetItem<OldBattery>().ChargesRemaining = 10;
+        GetItem<Laser>().Setting = 1; // Red
+        SetupMockRandomChooser(shouldHit: true);
+        var relay = GetItem<Relay>();
+
+        var response = await target.GetResponse("shoot speck with laser");
+
+        response.Should().NotContain("You don't see any speck here");
+        response.Should().Contain("The speck is hit by the beam!");
+        relay.SpeckHit.Should().BeTrue();
+        relay.SpeckDestroyed.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task ShootLaserAtSpeck_WithRedLaser_FirstHit_SetsSpeckHit()
+    {
+        var target = GetTarget();
+        StartHere<StripNearRelay>();
+        Take<Laser>();
+        GetItem<OldBattery>().ChargesRemaining = 10;
+        GetItem<Laser>().Setting = 1; // Red
+        SetupMockRandomChooser(shouldHit: true);
+        var relay = GetItem<Relay>();
+
+        var response = await target.GetResponse("shoot laser at speck");
+
+        response.Should().Contain("The speck is hit by the beam!");
+        relay.SpeckHit.Should().BeTrue();
+    }
+
+    [TestCase("boulder")]
+    [TestCase("impurity")]
+    public async Task ShootSpeck_BySynonym_WithRedLaser_HitsTheSpeck(string noun)
+    {
+        var target = GetTarget();
+        StartHere<StripNearRelay>();
+        Take<Laser>();
+        GetItem<OldBattery>().ChargesRemaining = 10;
+        GetItem<Laser>().Setting = 1; // Red
+        SetupMockRandomChooser(shouldHit: true);
+
+        var response = await target.GetResponse($"shoot {noun} with laser");
+
+        response.Should().Contain("The speck is hit by the beam!");
+    }
+
+    [Test]
+    public async Task ShootSpeck_WithRedLaser_SecondHit_DestroysSpeck()
+    {
+        var target = GetTarget();
+        StartHere<StripNearRelay>();
+        Take<Laser>();
+        GetItem<OldBattery>().ChargesRemaining = 10;
+        GetItem<Laser>().Setting = 1; // Red
+        SetupMockRandomChooser(shouldHit: true);
+        var relay = GetItem<Relay>();
+        relay.SpeckHit = true; // Already hit once
+
+        var response = await target.GetResponse("shoot speck with laser");
+
+        response.Should().Contain("The beam hits the speck again!");
+        response.Should().Contain("vaporizes into a fine cloud of ash");
+        relay.SpeckDestroyed.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task ShootSpeck_WithNonRedLaser_DestroysTheRelay()
+    {
+        var target = GetTarget();
+        StartHere<StripNearRelay>();
+        Take<Laser>();
+        GetItem<OldBattery>().ChargesRemaining = 10;
+        GetItem<Laser>().Setting = 3; // Yellow (non-red)
+
+        var response = await target.GetResponse("shoot speck with laser");
+
+        response.Should().Contain("slices through the red plastic");
+        GetItem<Relay>().RelayDestroyed.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task ShootSpeck_AfterSpeckDestroyed_SpeckIsGoneFromScope()
+    {
+        var target = GetTarget();
+        StartHere<StripNearRelay>();
+        Take<Laser>();
+        GetItem<OldBattery>().ChargesRemaining = 10;
+        GetItem<Laser>().Setting = 1; // Red
+        SetupMockRandomChooser(shouldHit: true);
+        GetItem<Relay>().SpeckHit = true; // Already hit once — this shot vaporizes it
+
+        await target.GetResponse("shoot speck with laser");
+        var response = await target.GetResponse("shoot speck with laser");
+
+        // <REMOVE ,SPECK> (comptwo.zil:2852) — the speck no longer exists to be shot at.
+        response.Should().Contain("You don't see any speck here");
+        GetItem<Speck>().CurrentLocation.Should().BeNull();
+    }
+
+    [Test]
+    public async Task ShootSpeck_AfterRelayDestroyed_SpeckIsGoneFromScope()
+    {
+        var target = GetTarget();
+        StartHere<StripNearRelay>();
+        Take<Laser>();
+        GetItem<OldBattery>().ChargesRemaining = 10;
+        GetItem<Laser>().Setting = 4; // Green (non-red) — shatters the relay
+
+        await target.GetResponse("shoot speck with laser");
+        var response = await target.GetResponse("shoot speck with laser");
+
+        // <REMOVE ,RELAY> (comptwo.zil:2867) takes the speck it contained out of scope with it.
+        response.Should().Contain("You don't see any speck here");
+        GetItem<Speck>().CurrentLocation.Should().BeNull();
+    }
+
+    #endregion
+
     #region Timer Tests
 
     [Test]

--- a/Planetfall/Item/Computer/Speck.cs
+++ b/Planetfall/Item/Computer/Speck.cs
@@ -1,0 +1,47 @@
+namespace Planetfall.Item.Computer;
+
+/// <summary>
+/// The impurity wedged into the microrelay's contact point — the actual target of the endgame
+/// laser puzzle.
+///
+/// Issue #517: this object was never ported. The relay's description tells the player, in detail,
+/// that a speck is what has jammed the relay, and the canonical solution (both the original
+/// walkthroughs' and this repo's own walkthrough tests') is "shoot speck with laser" — but with no
+/// Speck in the Repository, <c>GetItemInScope("speck")</c> returned null and the laser answered
+/// "You don't see any speck here." The only way through the puzzle was to name the *relay*, which
+/// on any non-red dial setting shatters it and silently makes the game unwinnable.
+///
+/// In the original the speck is a first-class object living inside the relay
+/// (comptwo.zil:2562-2567) with three synonyms and an adjective, and the laser's SHOOT handler
+/// dispatches on it (comptwo.zil:2712 -> SHOOT-SPECK).
+///
+/// The speck's *state* deliberately stays on <see cref="Relay" /> (SpeckHit / SpeckDestroyed /
+/// MarksmanshipCounter) so existing save games and the several consumers of
+/// <c>Relay.SpeckDestroyed</c> (hints, Station 384, the microbe) keep working unchanged. This class
+/// exists so the noun resolves.
+/// </summary>
+public class Speck : ItemBase, ICanBeExamined
+{
+    // SYNONYM SPECK BOULDER IMPURITY / ADJECTIVE BLUE (comptwo.zil:2565-2566).
+    public override string[] NounsForMatching =>
+        ["speck", "boulder", "impurity", "blue speck", "blue boulder", "blue impurity"];
+
+    // The original gives SPECK no ACTION routine, so examining it falls to the default
+    // "nothing special" message. That reads badly here — the engine builds that message from the
+    // item's longest noun ("blue impurity"), and the relay has just spent three sentences telling
+    // the player exactly what the speck looks like. Reuse the relay's own wording so examining the
+    // thing you have been told to shoot actually describes it.
+    public string ExaminationDescription =>
+        "The speck, presumably of microscopic size, resembles a blue boulder to you in your current size. ";
+
+    /// <summary>
+    /// Takes the speck out of play, mirroring &lt;REMOVE ,SPECK&gt; (comptwo.zil:2852). Once it has
+    /// been vaporized — or once the relay containing it has been shattered — naming it must fail
+    /// scope resolution rather than resolving to an object that is no longer there.
+    /// </summary>
+    public void RemoveFromPlay()
+    {
+        CurrentLocation?.RemoveItem(this);
+        CurrentLocation = null;
+    }
+}

--- a/Planetfall/Item/Computer/Speck.cs
+++ b/Planetfall/Item/Computer/Speck.cs
@@ -33,15 +33,4 @@ public class Speck : ItemBase, ICanBeExamined
     // thing you have been told to shoot actually describes it.
     public string ExaminationDescription =>
         "The speck, presumably of microscopic size, resembles a blue boulder to you in your current size. ";
-
-    /// <summary>
-    /// Takes the speck out of play, mirroring &lt;REMOVE ,SPECK&gt; (comptwo.zil:2852). Once it has
-    /// been vaporized — or once the relay containing it has been shattered — naming it must fail
-    /// scope resolution rather than resolving to an object that is no longer there.
-    /// </summary>
-    public void RemoveFromPlay()
-    {
-        CurrentLocation?.RemoveItem(this);
-        CurrentLocation = null;
-    }
 }

--- a/Planetfall/Item/Kalamontee/Mech/Laser.cs
+++ b/Planetfall/Item/Kalamontee/Mech/Laser.cs
@@ -198,10 +198,13 @@ public class Laser : ContainerBase, ICanBeTakenAndDropped, ICanBeExamined, ITurn
                 "\"Yow!\" yells Floyd. He jumps to the other end of the room and eyes you warily. ");
         }
 
-        // Special response for shooting the Relay
-        if (target is Relay relay)
+        // Special response for shooting the speck (SHOOT-SPECK, comptwo.zil:2712). Issue #517: the
+        // speck is the object the original dispatches on; Relay is kept as a lenient alias because
+        // the relay's description makes "shoot relay with laser" a natural thing for a player to
+        // type, and the port has always accepted it.
+        if (target is Speck or Relay)
         {
-            return LaserSpeckHelper.ShootRelay(relay, context, BeamDescription, Setting, Chooser);
+            return LaserSpeckHelper.ShootRelay(Repository.GetItem<Relay>(), context, BeamDescription, Setting, Chooser);
         }
 
         // Special response for shooting the Microbe (SHOOT-MICROBE, comptwo.zil:2991)

--- a/Planetfall/Item/Kalamontee/Mech/LaserSpeckHelper.cs
+++ b/Planetfall/Item/Kalamontee/Mech/LaserSpeckHelper.cs
@@ -24,7 +24,7 @@ public static class LaserSpeckHelper
             relay.RelayDestroyed = true;
             // <REMOVE ,RELAY> (comptwo.zil:2867). The speck lived inside the relay, so shattering the
             // relay takes the speck out of scope with it (issue #517).
-            Repository.GetItem<Speck>().RemoveFromPlay();
+            Repository.DestroyItem<Speck>();
             return new PositiveInteractionResult(
                 $"{beamDescription} which slices through the red plastic covering of the relay like a hot knife through butter. " +
                 "Air rushes into the relay, which collapses into a heap of plastic shards. ");
@@ -66,7 +66,7 @@ public static class LaserSpeckHelper
         // Second hit - destroy the speck!
         relay.SpeckDestroyed = true;
         // <REMOVE ,SPECK> (comptwo.zil:2852) — vaporized, so the noun must stop resolving (issue #517).
-        Repository.GetItem<Speck>().RemoveFromPlay();
+        Repository.DestroyItem<Speck>();
         context.AddPoints(8);
 
         // Start 200-turn timer to escape before sector activates

--- a/Planetfall/Item/Kalamontee/Mech/LaserSpeckHelper.cs
+++ b/Planetfall/Item/Kalamontee/Mech/LaserSpeckHelper.cs
@@ -22,6 +22,9 @@ public static class LaserSpeckHelper
         if (laserSetting != 1)
         {
             relay.RelayDestroyed = true;
+            // <REMOVE ,RELAY> (comptwo.zil:2867). The speck lived inside the relay, so shattering the
+            // relay takes the speck out of scope with it (issue #517).
+            Repository.GetItem<Speck>().RemoveFromPlay();
             return new PositiveInteractionResult(
                 $"{beamDescription} which slices through the red plastic covering of the relay like a hot knife through butter. " +
                 "Air rushes into the relay, which collapses into a heap of plastic shards. ");
@@ -62,6 +65,8 @@ public static class LaserSpeckHelper
 
         // Second hit - destroy the speck!
         relay.SpeckDestroyed = true;
+        // <REMOVE ,SPECK> (comptwo.zil:2852) — vaporized, so the noun must stop resolving (issue #517).
+        Repository.GetItem<Speck>().RemoveFromPlay();
         context.AddPoints(8);
 
         // Start 200-turn timer to escape before sector activates

--- a/Planetfall/Location/Computer/StripNearRelay.cs
+++ b/Planetfall/Location/Computer/StripNearRelay.cs
@@ -9,6 +9,11 @@ internal class StripNearRelay : LocationBase
     public override void Init()
     {
         StartWithItem<Relay>();
+        // Issue #517: the speck is what the laser puzzle actually targets. In the original it lives
+        // inside the (transparent) relay; the port's Relay is not a container, so seed the speck into
+        // the room alongside it. It is NDESC — ItemBase.GenericDescription is empty, so it never shows
+        // up in the room listing, exactly like the relay.
+        StartWithItem<Speck>();
     }
 
     public override string Name => "Strip Near Relay";

--- a/UnitTests/IntentMappings/base-mappings.json
+++ b/UnitTests/IntentMappings/base-mappings.json
@@ -317,8 +317,12 @@
     { "inputs": ["shoot laser at floyd"], "verb": "shoot", "nounOne": "laser", "nounTwo": "floyd", "preposition": "at", "originalInput": "shoot laser at floyd" },
     { "inputs": ["fire laser at flask"], "verb": "fire", "nounOne": "laser", "nounTwo": "flask", "preposition": "at", "originalInput": "fire laser at flask" },
 
-    { "inputs": ["shoot relay with laser", "shoot speck with laser"], "verb": "shoot", "nounOne": "relay", "nounTwo": "laser", "preposition": "with", "originalInput": "shoot relay with laser" },
-    { "inputs": ["shoot laser at relay", "shoot laser at speck"], "verb": "shoot", "nounOne": "laser", "nounTwo": "relay", "preposition": "at", "originalInput": "shoot laser at relay" },
+    { "inputs": ["shoot relay with laser"], "verb": "shoot", "nounOne": "relay", "nounTwo": "laser", "preposition": "with", "originalInput": "shoot relay with laser" },
+    { "inputs": ["shoot laser at relay"], "verb": "shoot", "nounOne": "laser", "nounTwo": "relay", "preposition": "at", "originalInput": "shoot laser at relay" },
+    { "inputs": ["shoot speck with laser"], "verb": "shoot", "nounOne": "speck", "nounTwo": "laser", "preposition": "with", "originalInput": "shoot speck with laser" },
+    { "inputs": ["shoot laser at speck"], "verb": "shoot", "nounOne": "laser", "nounTwo": "speck", "preposition": "at", "originalInput": "shoot laser at speck" },
+    { "inputs": ["shoot boulder with laser"], "verb": "shoot", "nounOne": "boulder", "nounTwo": "laser", "preposition": "with", "originalInput": "shoot boulder with laser" },
+    { "inputs": ["shoot impurity with laser"], "verb": "shoot", "nounOne": "impurity", "nounTwo": "laser", "preposition": "with", "originalInput": "shoot impurity with laser" },
     { "inputs": ["fire laser at relay"], "verb": "fire", "nounOne": "laser", "nounTwo": "relay", "preposition": "at", "originalInput": "fire laser at relay" },
 
     { "inputs": ["shoot microbe with laser"], "verb": "shoot", "nounOne": "microbe", "nounTwo": "laser", "preposition": "with", "originalInput": "shoot microbe with laser" },


### PR DESCRIPTION
Fixes #517.

## The bug

The microrelay puzzle's target object — the **speck** — was never ported. The relay's description tells the player, in detail, that a speck / impurity / blue boulder is what has wedged itself into the contact point, and then the engine recognised none of those three words. `Repository.GetItemInScope("speck", …)` returned null, and `Laser.ShootLaserAt` bailed out on its scope guard with **"You don't see any speck here."**

The only route through the puzzle was to name the **relay** — which reads to a player as "destroy the relay", and which on any non-red dial setting does exactly that and silently makes the game unwinnable.

## Why CI never caught it

The three walkthroughs drive this puzzle with `shoot speck with laser` — the command that fails in production. They passed because the deterministic fixture rewrote the noun before the engine ever saw it (`UnitTests/IntentMappings/base-mappings.json`):

```json
{ "inputs": ["shoot relay with laser", "shoot speck with laser"], "nounOne": "relay", … }
```

Same fixture-shaped blind spot as #423.

## Original behavior (ZIL — ground truth)

`SPECK` is a first-class object living inside the relay, with three synonyms and an adjective (`comptwo.zil:2562-2567`):

```
<OBJECT SPECK
	(IN RELAY)
	(DESC "speck")
	(SYNONYM SPECK BOULDER IMPURITY)
	(ADJECTIVE BLUE)
	(FLAGS NDESCBIT)>
```

`LASER-F` dispatches on it as the indirect object — `<COND (<EQUAL? ,PRSI ,SPECK> <SHOOT-SPECK>)>` (`comptwo.zil:2712`) — and `SHOOT-SPECK` removes it on the killing shot, `<REMOVE ,SPECK>` (`comptwo.zil:2852`). The non-red branch does `<REMOVE ,RELAY>` (`comptwo.zil:2867`), which takes the speck it contained out of scope with it.

## The fix

- **New `Planetfall/Item/Computer/Speck.cs`** — `Speck : ItemBase, ICanBeExamined`, nouns `speck` / `boulder` / `impurity`, each also accepted with the `blue` adjective. Seeded into `StripNearRelay` alongside the relay. It is NDESC (`ItemBase.GenericDescription` is empty), so it never shows up in the room listing — same as the relay.
- **`Laser.ShootLaserAt`** now dispatches on `target is Speck or Relay`. `Relay` is kept as a lenient alias: the relay's description makes `shoot relay with laser` a natural thing to type, and the port has always accepted it.
- **`LaserSpeckHelper`** takes the speck out of play when it is vaporized, and when a non-red beam shatters the relay containing it — so naming it afterwards fails scope resolution instead of resolving to something that isn't there.
- **The fixture no longer rewrites the noun.** `shoot speck with laser` now maps to `nounOne: "speck"`, so all three walkthroughs exercise the real command and this gap cannot hide from CI again.

The speck's *state* (`SpeckHit`, `SpeckDestroyed`, `MarksmanshipCounter`) deliberately stays on `Relay`, so existing save games and every consumer of `Relay.SpeckDestroyed` (hints, Station 384, the microbe) are unaffected.

### One deliberate divergence

The original gives `SPECK` no `ACTION` routine, so examining it falls through to the default "nothing special" message. In this engine that message is built from the item's **longest** noun, yielding "There is nothing special about the blue impurity." — which reads badly immediately after the relay has spent three sentences describing the speck. `examine speck` therefore reuses the relay's own wording instead. Flagged here so it's a review decision, not an accident.

## TDD

Red first: with the `Speck` type present but unwired, the new tests failed with exactly the production message from the issue —

```
Failed ShootLaserAtSpeck_WithRedLaser_FirstHit_SetsSpeckHit
   Expected response "You don't see any speck here.
Failed ShootSpeck_BySynonym_WithRedLaser_HitsTheSpeck("boulder")
   Expected response "You don't see any boulder here.
Failed ShootSpeck_BySynonym_WithRedLaser_HitsTheSpeck("impurity")
   Expected response "You don't see any impurity here.
Failed Speck_IsPresentInTheRelayRoom
   Expected speck.CurrentLocation to be StripNearRelay … but found <null>.
```

10 failed / 40 passed before the fix; 50 passed after.

New tests in `Planetfall.Tests/RelayTests.cs` (`#region Speck Tests`): presence and non-listing in the room, `examine speck` and both synonyms, `shoot speck with laser` and `shoot laser at speck` first/second hit, synonym shots, the non-red destroy-the-relay path, and both out-of-scope-after-destruction paths. All deterministic (`IRandomChooser` mocked, real `Repository` with `Reset()`), all in the normal test command.

## Verification

Every suite that touches the changed code, run separately — all green:

| Suite | Result |
|---|---|
| `Planetfall.Tests` | 3283 passed, 0 failed |
| `UnitTests` | 1130 passed, 0 failed |
| `ZorkOne.Tests` | 1782 passed, 0 failed |
| `EscapeRoom.Tests` | 9 passed, 0 failed |
| `Stationfall.Tests` | 4 passed, 0 failed |
| `Console.Tests` | 16 passed, 0 failed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JQR4n8dnPcVgbN19pMw7xC

---
_Generated by [Claude Code](https://claude.ai/code/session_01JQR4n8dnPcVgbN19pMw7xC)_