### PR TITLE
Fix #523: state each elevator door once, as a Doorway

### DIFF
--- a/Planetfall.Tests/ReactorElevatorTests.cs
+++ b/Planetfall.Tests/ReactorElevatorTests.cs
@@ -161,4 +161,117 @@ public class ReactorElevatorTests : EngineTestsBase
 
         GetItem<ReactorElevatorDoor>().IsOpen.Should().BeTrue();
     }
+
+    /// <summary>
+    ///     Issue #523. The room description hardcoded "currently open" while both of the room's exits
+    ///     gate on the door's actual state, so a closed door made the room advertise a way out that the
+    ///     player could not take. Same shape as #450 / #505 / #512 / #518: a state word copied into a
+    ///     literal beside a Map that reads the real thing.
+    /// </summary>
+    [Test]
+    public async Task Look_DoorClosed_DescribesTheDoorAsClosed()
+    {
+        var target = GetTarget();
+        StartHere<ReactorElevator>();
+        GetItem<ReactorElevatorDoor>().IsOpen = false;
+
+        var response = await target.GetResponse("look");
+
+        response.Should().Contain("door to the west, currently closed");
+        response.Should().NotContain("currently open");
+    }
+
+    /// <summary>
+    ///     The invariant the room has to keep, in both door states: whatever word the description uses,
+    ///     walking west must agree with it. This is the generalised form of the lobby's
+    ///     Look_BlueDoorWording_AlwaysAgreesWithWhetherNorthIsPassable.
+    /// </summary>
+    [Test]
+    [TestCase(true)]
+    [TestCase(false)]
+    public async Task Look_DoorWording_AlwaysAgreesWithWhetherWestIsPassable(bool isOpen)
+    {
+        var target = GetTarget();
+        StartHere<ReactorElevator>();
+        GetItem<ReactorElevatorDoor>().IsOpen = isOpen;
+
+        var look = await target.GetResponse("look");
+        var describedAsOpen = look!.Contains("door to the west, currently open");
+        look.Should().Contain(describedAsOpen ? "currently open" : "currently closed");
+
+        var move = await target.GetResponse("west");
+
+        move!.Contains("Reactor Control").Should().Be(describedAsOpen);
+    }
+
+    /// <summary>
+    ///     "examine door" is the natural way to double-check the room description, so the two must never
+    ///     disagree - that was consequence two of #505 in the Elevator Lobby.
+    /// </summary>
+    [Test]
+    [TestCase(true)]
+    [TestCase(false)]
+    public async Task ExamineDoor_AgreesWithTheRoomDescription(bool isOpen)
+    {
+        var target = GetTarget();
+        StartHere<ReactorElevator>();
+        GetItem<ReactorElevatorDoor>().IsOpen = isOpen;
+
+        var look = await target.GetResponse("look");
+        var examine = await target.GetResponse("examine door");
+
+        look!.Contains("currently open").Should().Be(examine!.Contains("The door is open"));
+        look.Contains("currently closed").Should().Be(examine.Contains("The door is closed"));
+    }
+
+    /// <summary>
+    ///     Stating the door as a <see cref="Doorway" /> declares it as the GatingItem of the passage it
+    ///     gates, which is what lets "enter/exit door" resolve to that exit (DoorReroute, issue #262).
+    ///     Both sides of this door had hand-rolled MovementParameters that omitted it.
+    /// </summary>
+    [Test]
+    public async Task EnterDoor_FromReactorControl_WalksIntoTheCar()
+    {
+        var target = GetTarget();
+        StartHere<ReactorControl>();
+
+        var response = await target.GetResponse("enter door");
+
+        response.Should().Contain("Reactor Elevator");
+        target.Context.CurrentLocation.Should().BeOfType<ReactorElevator>();
+    }
+
+    [Test]
+    public async Task ExitDoor_FromTheCar_WalksBackToReactorControl()
+    {
+        var target = GetTarget();
+        StartHere<ReactorElevator>();
+
+        var response = await target.GetResponse("exit door");
+
+        response.Should().Contain("Reactor Control");
+        target.Context.CurrentLocation.Should().BeOfType<ReactorControl>();
+    }
+
+    /// <summary>
+    ///     The far side of the same door. Reactor Control's description makes no claim about the door's
+    ///     state, so nothing there can drift - but the exit still gates on it, and "examine door" has to
+    ///     agree with whether east is passable.
+    /// </summary>
+    [Test]
+    [TestCase(true)]
+    [TestCase(false)]
+    public async Task FromReactorControl_ExamineDoor_AgreesWithWhetherEastIsPassable(bool isOpen)
+    {
+        var target = GetTarget();
+        StartHere<ReactorControl>();
+        GetItem<ReactorElevatorDoor>().IsOpen = isOpen;
+
+        var examine = await target.GetResponse("examine door");
+        var describedAsOpen = examine!.Contains("The door is open");
+
+        var move = await target.GetResponse("east");
+
+        move!.Contains("Reactor Elevator").Should().Be(describedAsOpen);
+    }
 }

--- a/Planetfall/Item/Doorway.cs
+++ b/Planetfall/Item/Doorway.cs
@@ -1,0 +1,117 @@
+namespace Planetfall.Item;
+
+/// <summary>
+///     A door <i>as seen from one particular room</i>: the door object paired with the predicate that
+///     says whether it counts as open from where the asking room stands.
+///     <para>
+///         Every elevator-door bug this game has had — #450, #454, #456, #505, #512, #518, #523 — is the
+///         same defect. A door's state is answered by up to four surfaces of a room: the exit in its
+///         <c>Map</c>, the sentence in its description, <c>examine door</c>, and <c>open/close door</c>.
+///         Each surface used to re-derive that state independently, one of them would be written as a
+///         plain literal or read the raw flag, and the room would then contradict itself — describing a
+///         door as open while walking that way answered "The door is closed."
+///     </para>
+///     <para>
+///         So a room states its door exactly once, as a Doorway, and asks this object for each surface:
+///         <see cref="StateWord" /> for the description, <see cref="Passage" /> for the map, and
+///         <see cref="Answer" /> for the verbs. They cannot disagree, because there is only one
+///         predicate. A new room gets the invariant for free; drifting from it now takes deliberate
+///         effort rather than a copied string.
+///     </para>
+/// </summary>
+public sealed class Doorway
+{
+    /// <summary>
+    ///     What every one of these passages says when the door is shut. Shared so the map and any custom
+    ///     refusal stay in step.
+    /// </summary>
+    public const string ClosedMessage = "The door is closed. ";
+
+    // ExamineInteractionProcessor answers a wider set than Verbs.ExamineVerbs lists - "check", "look in"
+    // and "peek at" appear only in its own switch. Matching just the array would let "check blue door"
+    // reach the door item and report the raw flag, reopening the contradiction for that one phrasing.
+    private static readonly string[] ExamineDoorVerbs = [..Verbs.ExamineVerbs, "check", "look in", "peek at"];
+
+    private readonly Func<bool> _isOpenHere;
+
+    /// <param name="door">The door, which owns all of the wording.</param>
+    /// <param name="isOpenHere">
+    ///     Whether the door counts as open from the room holding this Doorway. Omit it when the door's own
+    ///     flag is the whole truth, which is the usual case; supply it when the flag is shared between two
+    ///     vantage points and therefore cannot answer "open <i>here</i>" on its own.
+    /// </param>
+    public Doorway(IDoor door, Func<bool>? isOpenHere = null)
+    {
+        Door = door;
+        _isOpenHere = isOpenHere ?? (() => door.IsOpen);
+    }
+
+    public IDoor Door { get; }
+
+    /// <summary>
+    ///     The single fact every surface below is derived from.
+    /// </summary>
+    public bool IsOpen => _isOpenHere();
+
+    /// <summary>
+    ///     The word a room description must use for this door: "open" or "closed".
+    /// </summary>
+    public string StateWord => IsOpen ? "open" : "closed";
+
+    /// <summary>
+    ///     The passage through this door, gated on the same predicate the description reports. Declaring
+    ///     the door as the <see cref="MovementParameters.GatingItem" /> also lets "enter/exit door"
+    ///     resolve to this exit (DoorReroute, issue #262).
+    /// </summary>
+    public MovementParameters Passage(ILocation? destination, string closedMessage = ClosedMessage)
+    {
+        return new MovementParameters
+        {
+            GatingItem = Door,
+            CanGo = _ => IsOpen,
+            Location = destination,
+            CustomFailureMessage = closedMessage
+        };
+    }
+
+    /// <summary>
+    ///     Answers "examine/open/close &lt;door&gt;" from <see cref="IsOpen" /> instead of the raw flag,
+    ///     re-stating exactly what the examine and open/close processors would say. Returns null for any
+    ///     other verb, any other noun, or any case where the door would really open or close — those must
+    ///     reach the normal processors so the state change actually happens.
+    ///     <para>
+    ///         Only a room whose vantage point differs from the flag needs to call this; elsewhere the
+    ///         processors already read the one true state. Nothing is lost by intercepting for such a room:
+    ///         a door with a shared flag is one the player cannot work by hand anyway, so these paths never
+    ///         mutate state for it.
+    ///     </para>
+    /// </summary>
+    public InteractionResult? Answer(SimpleIntent action, IContext context)
+    {
+        if (!action.MatchNounAndAdjective(Door.NounsForMatching))
+            return null;
+
+        if (action.MatchVerb(ExamineDoorVerbs))
+            return new PositiveInteractionResult(Door.DescribeAs(IsOpen));
+
+        if (action.MatchVerb(Verbs.OpenVerbs))
+        {
+            if (IsOpen)
+                return new PositiveInteractionResult(Door.AlreadyOpen);
+
+            var refusal = Door.CannotBeOpenedDescription(context);
+            return refusal is null ? null : new PositiveInteractionResult(refusal);
+        }
+
+        if (action.MatchVerb(Verbs.CloseVerbs))
+        {
+            if (!IsOpen)
+                return new PositiveInteractionResult(Door.AlreadyClosed);
+
+            var refusal = Door.CannotBeClosedDescription(context);
+            return refusal is null ? null : new PositiveInteractionResult(refusal);
+        }
+
+        return null;
+    }
+}

--- a/Planetfall/Item/IDoor.cs
+++ b/Planetfall/Item/IDoor.cs
@@ -1,0 +1,22 @@
+namespace Planetfall.Item;
+
+/// <summary>
+///     A door that owns the wording for its own open/closed state.
+///     <para>
+///         The point of <see cref="DescribeAs" /> taking the state as a parameter rather than reading
+///         <see cref="IOpenAndClose.IsOpen" /> is that a room sometimes knows the effective state better
+///         than the raw flag does — the Elevator Lobby is the standing example, where one OPENBIT flag is
+///         shared by both ends of a shaft and only means "open here" when the car is parked here (#505).
+///         Such a room needs the door's phrasing without the door's answer, and this is how it gets it
+///         instead of copying the literal. <see cref="Doorway" /> is the intended caller.
+///     </para>
+/// </summary>
+public interface IDoor : IItem, IOpenAndClose, ICanBeExamined
+{
+    /// <summary>
+    ///     How this door words the given state, e.g. "The door is closed. ". Implementations should define
+    ///     <see cref="ICanBeExamined.ExaminationDescription" /> as <c>DescribeAs(IsOpen)</c> so that
+    ///     examining the door and reading about it in a room description can never phrase it differently.
+    /// </summary>
+    string DescribeAs(bool isOpen);
+}

--- a/Planetfall/Item/Kalamontee/Admin/ElevatorDoorBase.cs
+++ b/Planetfall/Item/Kalamontee/Admin/ElevatorDoorBase.cs
@@ -1,20 +1,17 @@
 
 namespace Planetfall.Item.Kalamontee.Admin;
 
-public abstract class ElevatorDoorBase : ItemBase, ICanBeExamined, IOpenAndClose
+public abstract class ElevatorDoorBase : ItemBase, IDoor
 {
+    // Defined in terms of DescribeAs so examining the door and reading a room description that reports
+    // it can never phrase the state differently. See IDoor.
     public string ExaminationDescription => DescribeAs(IsOpen);
 
-    /// <summary>
-    ///     The door's own wording for a given state, so a caller that knows better than the raw flag can
-    ///     reuse it instead of copying the literal. The Elevator Lobby needs this: the flag is shared by
-    ///     both ends of the shaft, so from there the answer depends on which end the car is at (#505).
-    /// </summary>
     public string DescribeAs(bool isOpen)
     {
         return $"The door is {(isOpen ? "open" : "closed")}. ";
     }
-    
+
     public bool IsOpen { get; set; }
 
     public string NowOpen(ILocation currentLocation)

--- a/Planetfall/Item/Kalamontee/Mech/ReactorElevatorDoor.cs
+++ b/Planetfall/Item/Kalamontee/Mech/ReactorElevatorDoor.cs
@@ -11,18 +11,22 @@ namespace Planetfall.Item.Kalamontee.Mech;
 ///     close it yields "You can't close it yourself." The elevator beyond is a flavor dead-end whose
 ///     buttons go nowhere.
 /// </summary>
-public class ReactorElevatorDoor : ItemBase, ICanBeExamined, IOpenAndClose
+public class ReactorElevatorDoor : ItemBase, IDoor
 {
     public override string[] NounsForMatching =>
         ["reactor elevator door", "elevator door", "metal door", "door"];
 
-    // The door is "currently open" per the elevator description, and there is no mechanism in the
-    // original game to ever change that state.
+    // The door starts open and there is no mechanism in the original game to ever change that state.
+    // The rooms on both sides still ask the door rather than assume it - see Doorway for why.
     public bool IsOpen { get; set; } = true;
 
     public bool HasEverBeenOpened { get; set; } = true;
 
-    public string ExaminationDescription => $"The door is {(IsOpen ? "open" : "closed")}. ";
+    // Defined in terms of DescribeAs so examining the door and reading a room description that reports
+    // it can never phrase the state differently. See IDoor.
+    public string ExaminationDescription => DescribeAs(IsOpen);
+
+    public string DescribeAs(bool isOpen) => $"The door is {(isOpen ? "open" : "closed")}. ";
 
     public string AlreadyOpen => "It is already open. ";
 

--- a/Planetfall/Location/Kalamontee/ElevatorBase.cs
+++ b/Planetfall/Location/Kalamontee/ElevatorBase.cs
@@ -35,6 +35,14 @@ internal abstract class ElevatorBase<TDoor, TSlot, TCard> : FloydSpecialInteract
     /// </summary>
     public bool IsOpenAtTheFarEnd => GetItem<TDoor>().IsOpen && !InLobby;
 
+    /// <summary>
+    ///     The door as seen from inside the car, where the raw flag <i>is</i> the whole truth: the car is
+    ///     by definition at whichever end its own door opens onto. The two vantage points that need a
+    ///     narrower predicate build their own Doorway from <see cref="IsOpenAtTheLobby" /> /
+    ///     <see cref="IsOpenAtTheFarEnd" />.
+    /// </summary>
+    private Doorway Door => new(GetItem<TDoor>());
+
     [UsedImplicitly] public int TurnsSinceSummoned { get; set; }
 
     [UsedImplicitly] public int TurnsSinceEnabled { get; set; }
@@ -208,13 +216,12 @@ internal abstract class ElevatorBase<TDoor, TSlot, TCard> : FloydSpecialInteract
 
     protected override string GetContextBasedDescription(IContext context)
     {
-        // Interpolate the door's actual state (issue #450). Hardcoding "open" contradicted the
-        // "elevator door slides shut" message from Move() and "examine door" during the ~3 turns
-        // the car is in motion with the door closed. Mirrors RecArea / the #438 Mess Hall fix.
+        // Report the door's actual state (issue #450). Hardcoding "open" contradicted the "elevator door
+        // slides shut" message from Move() and "examine door" during the ~3 turns the car is in motion
+        // with the door closed. Mirrors RecArea / the #438 Mess Hall fix.
         return
-            $"This is a {Size} room with a sliding door to the {ExitDirection} which is " +
-            $"{(GetItem<TDoor>().IsOpen ? "open" : "closed")}. " +
-            $"A control panel contains an Up button, a Down button, and a narrow slot. ";
+            $"This is a {Size} room with a sliding door to the {ExitDirection} which is {Door.StateWord}. " +
+            "A control panel contains an Up button, a Down button, and a narrow slot. ";
     }
 
     public override void Init()
@@ -225,6 +232,8 @@ internal abstract class ElevatorBase<TDoor, TSlot, TCard> : FloydSpecialInteract
 
     protected override Dictionary<Direction, MovementParameters> Map(IContext context)
     {
+        var outThroughTheDoor = Door.Passage(Exit());
+
         return new Dictionary<Direction, MovementParameters>
         {
             {
@@ -237,22 +246,8 @@ internal abstract class ElevatorBase<TDoor, TSlot, TCard> : FloydSpecialInteract
                 new MovementParameters
                     { CanGo = _ => false, CustomFailureMessage = "You'll have to use the elevator controls. " }
             },
-            {
-                DirectionParser.ParseDirection(ExitDirection), new MovementParameters
-                {
-                    CustomFailureMessage = "The door is closed. ",
-                    CanGo = _ => Repository.GetItem<TDoor>().IsOpen,
-                    Location = Exit()
-                }
-            },
-            {
-                Direction.Out, new MovementParameters
-                {
-                    CustomFailureMessage = "The door is closed. ",
-                    CanGo = _ => Repository.GetItem<TDoor>().IsOpen,
-                    Location = Exit()
-                }
-            }
+            { DirectionParser.ParseDirection(ExitDirection), outThroughTheDoor },
+            { Direction.Out, outThroughTheDoor }
         };
     }
 

--- a/Planetfall/Location/Kalamontee/ElevatorLobby.cs
+++ b/Planetfall/Location/Kalamontee/ElevatorLobby.cs
@@ -10,16 +10,13 @@ internal class ElevatorLobby : LocationBase
 
     // Every surface in this room - the two entrances, the description, and "examine <colour> door" -
     // must answer from the effective state, never from the shared OPENBIT flag on its own. See
-    // ElevatorBase.IsOpenAtTheLobby for why, and issue #505 for what happens when they disagree.
-    private bool BlueDoorIsOpen => GetLocation<UpperElevator>().IsOpenAtTheLobby;
+    // ElevatorBase.IsOpenAtTheLobby for why, and issue #505 for what happens when they disagree. Stating
+    // each door once as a Doorway is what makes "must" enforceable rather than a convention.
+    private Doorway BlueDoor =>
+        new(GetItem<UpperElevatorDoor>(), () => GetLocation<UpperElevator>().IsOpenAtTheLobby);
 
-    private bool RedDoorIsOpen => GetLocation<LowerElevator>().IsOpenAtTheLobby;
-
-    // ExamineInteractionProcessor answers a wider set than Verbs.ExamineVerbs lists - "check", "look in"
-    // and "peek at" appear only in its own switch. Matching just the array would let "check blue door"
-    // reach the door item and report the shared flag, reopening the contradiction for that one phrasing.
-    private static readonly string[] ExamineDoorVerbs =
-        [..Verbs.ExamineVerbs, "check", "look in", "peek at"];
+    private Doorway RedDoor =>
+        new(GetItem<LowerElevatorDoor>(), () => GetLocation<LowerElevator>().IsOpenAtTheLobby);
 
     public override void Init()
     {
@@ -36,24 +33,9 @@ internal class ElevatorLobby : LocationBase
             // Both entrances need the car to be standing at the lobby as well as the door being open
             // (compone.zil, ELEVATOR-ENTER-F tests *-ELEVATOR-UP alongside OPENBIT). The door flag is
             // shared by both ends of the shaft, so on its own it cannot say which floor the car is on.
-            {
-                Direction.S,
-                new MovementParameters
-                {
-                    CanGo = _ => RedDoorIsOpen,
-                    CustomFailureMessage = "The door is closed.",
-                    Location = GetLocation<LowerElevator>()
-                }
-            },
-            {
-                Direction.N,
-                new MovementParameters
-                {
-                    CanGo = _ => BlueDoorIsOpen,
-                    CustomFailureMessage = "The door is closed.",
-                    Location = GetLocation<UpperElevator>()
-                }
-            }
+            // That two-part test lives in the Doorway, so the exit and the description share it.
+            { Direction.S, RedDoor.Passage(GetLocation<LowerElevator>(), "The door is closed.") },
+            { Direction.N, BlueDoor.Passage(GetLocation<UpperElevator>(), "The door is closed.") }
         };
     }
 
@@ -65,19 +47,9 @@ internal class ElevatorLobby : LocationBase
         // door" and "open red door" corroborate a state the room text and the exit both deny (#505).
         // The bare nouns ("door", "elevator door") never reach this: both doors match them, so
         // SimpleInteractionEngine disambiguates first.
-        if (action.MatchNounAndAdjective(GetItem<UpperElevatorDoor>().NounsForMatching))
-        {
-            var answer = AnswerForDoor(action, GetItem<UpperElevatorDoor>(), BlueDoorIsOpen, context);
-            if (answer is not null)
-                return answer;
-        }
-
-        if (action.MatchNounAndAdjective(GetItem<LowerElevatorDoor>().NounsForMatching))
-        {
-            var answer = AnswerForDoor(action, GetItem<LowerElevatorDoor>(), RedDoorIsOpen, context);
-            if (answer is not null)
-                return answer;
-        }
+        var doorAnswer = BlueDoor.Answer(action, context) ?? RedDoor.Answer(action, context);
+        if (doorAnswer is not null)
+            return doorAnswer;
 
         if (action.Match(Verbs.PushVerbs, ["button", "elevator button"]))
             return new DisambiguationInteractionResult("Which button do you mean, the red button or the blue button",
@@ -104,41 +76,17 @@ internal class ElevatorLobby : LocationBase
         return await base.RespondToSimpleInteraction(action, context, client, itemProcessorFactory);
     }
 
-    /// <summary>
-    ///     Re-states what OpenAndCloseInteractionProcessor and the examine processor would say for this
-    ///     door, but keyed on <paramref name="isOpenHere" /> instead of the shared flag. The messages stay
-    ///     owned by the door, and nothing is lost by bypassing the processors: an elevator door always
-    ///     refuses to be opened or closed by hand, so those paths never mutate state for it. Returns null
-    ///     for any other verb, which then falls through to normal handling.
-    /// </summary>
-    private InteractionResult? AnswerForDoor(SimpleIntent action, ElevatorDoorBase door, bool isOpenHere,
-        IContext context)
-    {
-        if (action.MatchVerb(ExamineDoorVerbs))
-            return new PositiveInteractionResult(door.DescribeAs(isOpenHere));
-
-        if (action.MatchVerb(Verbs.OpenVerbs))
-            return new PositiveInteractionResult(isOpenHere ? door.AlreadyOpen : door.CannotBeOpenedDescription(context));
-
-        if (action.MatchVerb(Verbs.CloseVerbs))
-            return new PositiveInteractionResult(
-                isOpenHere ? door.CannotBeClosedDescription(context) : door.AlreadyClosed);
-
-        return null;
-    }
-
     protected override string GetContextBasedDescription(IContext context)
     {
-        // Read the effective state, not the raw flag: the lobby used to announce a door as open while
-        // walking that way answered "The door is closed." The "also" clause means "both doors are in the
-        // same state", so it has to compare the effective states too - on the raw flags it could say
-        // "also" when they differ and omit it when they match (issue #505).
-        var blueOpen = BlueDoorIsOpen;
-        var redOpen = RedDoorIsOpen;
+        // The "also" clause means "both doors are in the same state", so it has to compare the effective
+        // states too - on the raw flags it could say "also" when they differ and omit it when they match
+        // (issue #505). Both Doorways answer effectively, so comparing them is enough.
+        var blueOpen = BlueDoor.IsOpen;
+        var redOpen = RedDoor.IsOpen;
 
         return
-            $"This is a wide, brightly lit lobby. A blue metal door to the north is {(blueOpen ? "open" : "closed")} and a larger red metal " +
-            $"door to the south is {(redOpen == blueOpen ? "also " : "")}{(redOpen ? "open" : "closed")}. " +
-            $"Beside the blue door is a blue button, and beside the red door is a red button. A corridor leads west. To the east is a small room about the size of a telephone booth. ";
+            $"This is a wide, brightly lit lobby. A blue metal door to the north is {BlueDoor.StateWord} and a larger red metal " +
+            $"door to the south is {(redOpen == blueOpen ? "also " : "")}{RedDoor.StateWord}. " +
+            "Beside the blue door is a blue button, and beside the red door is a red button. A corridor leads west. To the east is a small room about the size of a telephone booth. ";
     }
 }

--- a/Planetfall/Location/Kalamontee/Mech/ReactorControl.cs
+++ b/Planetfall/Location/Kalamontee/Mech/ReactorControl.cs
@@ -8,30 +8,20 @@ internal class ReactorControl : LocationWithNoStartingItems
 {
     public override string Name => "Reactor Control";
 
-    private ReactorElevatorDoor Door => Repository.GetItem<ReactorElevatorDoor>();
+    // The far side of the Reactor Elevator's door. Nothing in this room's description claims a state for
+    // it, so there is nothing here to drift - but the exits still gate on it, via the same Doorway.
+    private Doorway Door => new(Repository.GetItem<ReactorElevatorDoor>());
 
     protected override Dictionary<Direction, MovementParameters> Map(IContext context)
     {
+        var intoTheCar = Door.Passage(GetLocation<ReactorElevator>());
+
         return new Dictionary<Direction, MovementParameters>
         {
             { Direction.W, Go<MechCorridor>() },
             { Direction.Down, Go<ReactorAccessStairs>() },
-            {
-                Direction.E, new MovementParameters
-                {
-                    CanGo = _ => Door.IsOpen,
-                    Location = GetLocation<ReactorElevator>(),
-                    CustomFailureMessage = "The door is closed. "
-                }
-            },
-            {
-                Direction.In, new MovementParameters
-                {
-                    CanGo = _ => Door.IsOpen,
-                    Location = GetLocation<ReactorElevator>(),
-                    CustomFailureMessage = "The door is closed. "
-                }
-            }
+            { Direction.E, intoTheCar },
+            { Direction.In, intoTheCar }
         };
     }
 

--- a/Planetfall/Location/Kalamontee/Mech/ReactorElevator.cs
+++ b/Planetfall/Location/Kalamontee/Mech/ReactorElevator.cs
@@ -13,36 +13,26 @@ internal class ReactorElevator : LocationWithNoStartingItems
 {
     public override string Name => "Reactor Elevator";
 
-    private ReactorElevatorDoor Door => Repository.GetItem<ReactorElevatorDoor>();
+    // The door and the exits it gates, stated once. Both exits and the description below read this one
+    // predicate, so the room cannot describe a door the player is then refused (issue #523).
+    private Doorway Door => new(Repository.GetItem<ReactorElevatorDoor>());
 
     protected override Dictionary<Direction, MovementParameters> Map(IContext context)
     {
+        var outThroughTheDoor = Door.Passage(GetLocation<ReactorControl>());
+
         return new Dictionary<Direction, MovementParameters>
         {
-            {
-                Direction.W, new MovementParameters
-                {
-                    CanGo = _ => Door.IsOpen,
-                    Location = GetLocation<ReactorControl>(),
-                    CustomFailureMessage = "The door is closed. "
-                }
-            },
-            {
-                Direction.Out, new MovementParameters
-                {
-                    CanGo = _ => Door.IsOpen,
-                    Location = GetLocation<ReactorControl>(),
-                    CustomFailureMessage = "The door is closed. "
-                }
-            }
+            { Direction.W, outThroughTheDoor },
+            { Direction.Out, outThroughTheDoor }
         };
     }
 
     protected override string GetContextBasedDescription(IContext context)
     {
         return
-            "This is an elevator with a door to the west, currently open. A control panel contains " +
-            "an Up button, a Down button, and a small slot. ";
+            $"This is an elevator with a door to the west, currently {Door.StateWord}. A control panel " +
+            "contains an Up button, a Down button, and a small slot. ";
     }
 
     public override void Init()

--- a/Planetfall/Location/Kalamontee/Tower/TowerCore.cs
+++ b/Planetfall/Location/Kalamontee/Tower/TowerCore.cs
@@ -7,21 +7,16 @@ internal class TowerCore : LocationWithNoStartingItems
 {
     public override string Name => "Tower Core";
 
-    private UpperElevatorDoor Door => Repository.GetItem<UpperElevatorDoor>();
+    // This is the far end of the upper shaft, so the entrance needs the same two-part test the Waiting
+    // Area uses on the lower one: the door open *and* the car standing at this end. A bare
+    // Go<UpperElevator>() let you walk into a car parked down at the lobby, because the door flag is
+    // shared by both ends of the shaft (issue #505).
+    private Doorway Door =>
+        new(Repository.GetItem<UpperElevatorDoor>(), () => GetLocation<UpperElevator>().IsOpenAtTheFarEnd);
 
     protected override Dictionary<Direction, MovementParameters> Map(IContext context)
     {
-        // This is the far end of the upper shaft, so the entrance needs the same two-part test the
-        // Waiting Area uses on the lower one: the door open *and* the car standing at this end. A bare
-        // Go<UpperElevator>() let you walk into a car parked down at the lobby, because the door flag
-        // is shared by both ends of the shaft (issue #505).
-        var intoTheCar = new MovementParameters
-        {
-            GatingItem = Door,
-            CanGo = _ => GetLocation<UpperElevator>().IsOpenAtTheFarEnd,
-            Location = GetLocation<UpperElevator>(),
-            CustomFailureMessage = "The door is closed. "
-        };
+        var intoTheCar = Door.Passage(GetLocation<UpperElevator>());
 
         return new Dictionary<Direction, MovementParameters>
         {

--- a/Planetfall/Location/Shuttle/WaitingArea.cs
+++ b/Planetfall/Location/Shuttle/WaitingArea.cs
@@ -10,21 +10,16 @@ public class WaitingArea : LocationWithNoStartingItems
 
     public override string[] NounsForMatching => ["waiting room", "lounge"];
 
-    private LowerElevatorDoor Door => Repository.GetItem<LowerElevatorDoor>();
+    // The original gates this entrance on the door being open *and* the car actually being at this end
+    // of the shaft (compone.zil, OTHER-ELEVATOR-ENTER-F, which also makes the door the implicit "it" -
+    // hence the Doorway's GatingItem). A bare Go<LowerElevator>() let you walk into a car parked up at
+    // the lobby, and then be sealed in, since the car's own exits gate on the door.
+    private Doorway Door =>
+        new(Repository.GetItem<LowerElevatorDoor>(), () => GetLocation<LowerElevator>().IsOpenAtTheFarEnd);
 
     protected override Dictionary<Direction, MovementParameters> Map(IContext context)
     {
-        // The original gates this entrance on the door being open *and* the car actually being at
-        // this end of the shaft (compone.zil, OTHER-ELEVATOR-ENTER-F, which also makes the door the
-        // implicit "it" - hence GatingItem). A bare Go<LowerElevator>() let you walk into a car
-        // parked up at the lobby, and then be sealed in, since the car's own exits gate on the door.
-        var intoTheCar = new MovementParameters
-        {
-            GatingItem = Door,
-            CanGo = _ => GetLocation<LowerElevator>().IsOpenAtTheFarEnd,
-            Location = GetLocation<LowerElevator>(),
-            CustomFailureMessage = "The door is closed. "
-        };
+        var intoTheCar = Door.Passage(GetLocation<LowerElevator>());
 
         return new Dictionary<Direction, MovementParameters>
         {


### PR DESCRIPTION
Closes #523.

## The fix

`ReactorElevator.GetContextBasedDescription` hardcoded `currently open` while both of the room's own exits gate on `Door.IsOpen`. Close the door and the room advertised a way out the player was then refused. It now reports the door's actual state.

Issue #523 filed this as latent, since `ReactorElevatorDoor` is immutable in practice. It stays latent — nothing in the game closes that door — so this is the robustness resolution the issue asked for a decision on, plus the structural change below so the next room doesn't have to make the same decision.

## The refactor

That literal is the sixth instance of one defect. A door's state is answered by up to four surfaces of a room:

- the exit in its `Map` (`CanGo` + `CustomFailureMessage`)
- the sentence in its `GetContextBasedDescription`
- `examine <door>`
- `open <door>` / `close <door>`

Each surface re-derived that state independently, one of them would be a plain literal or read a flag that doesn't mean what the room needs, and the room would contradict itself. #450, #454, #456, #505, #512, #518 and now #523 are all two of those four disagreeing.

So a room now states its door **exactly once**, as a `Doorway` (`Planetfall/Item/Doorway.cs`) — the door object paired with the predicate for whether it counts as open *from where that room stands*. `Doorway` hands out each surface from that single predicate:

| surface | before | now |
|---|---|---|
| description | interpolated literal, or just a literal | `Door.StateWord` |
| map exit | hand-rolled `MovementParameters` per direction | `Door.Passage(destination)` |
| examine / open / close | `ElevatorLobby.AnswerForDoor`, private to that room | `Door.Answer(action, context)` |

The three vantage points that used to be three hand-rolled conventions are now three predicates handed to the same object:

- **inside a car** — the raw flag; the car is by definition at whichever end its own door opens onto
- **Elevator Lobby** — `IsOpenAtTheLobby`, because one OPENBIT flag is shared by both ends of the shaft
- **Tower Core / Waiting Area** — `IsOpenAtTheFarEnd`, the mirror of the same problem

`DescribeAs` moves from `ElevatorDoorBase` onto a new `IDoor` interface, and both door classes define `ExaminationDescription` as `DescribeAs(IsOpen)`. Examining a door and reading about it in a room description now share one string.

`ElevatorLobby` loses ~35 lines: its `AnswerForDoor`, its `ExamineDoorVerbs` list (the "check"/"look in"/"peek at" widening that #505 needed is now in `Doorway`, where every room gets it), and both hand-rolled entrance passages.

## Behavior change beyond the fix

Every passage built by `Doorway.Passage` declares the door as its `GatingItem`, which the Reactor Elevator's two sides, the lobby's two entrances and the cars' exits had all omitted. `enter door` / `exit door` now resolve through those passages as issue #262 intends — `exit door` from inside a car used to answer "You can't exit that." Pinned by two new tests.

## TDD

Red first, in `Planetfall.Tests/ReactorElevatorTests.cs`, against the real `Repository`:

1. `Look_DoorClosed_DescribesTheDoorAsClosed` — failed with `to contain "door to the west, currently closed"` against a response reading `currently open`.
2. `Look_DoorWording_AlwaysAgreesWithWhetherWestIsPassable(true|false)` — the invariant, generalised from the lobby's `Look_BlueDoorWording_AlwaysAgreesWithWhetherNorthIsPassable`. The `false` case failed: described open, west blocked.
3. `ExamineDoor_AgreesWithTheRoomDescription(true|false)` — the `false` case failed; examine was already honest, so it disagreed with the room.
4. `FromReactorControl_ExamineDoor_AgreesWithWhetherEastIsPassable` — passed before and after; the far side makes no claim, so nothing there could drift. Kept as a guard.

All green after. Full suites, run per project: **Planetfall.Tests 3891**, **UnitTests 1130**, **ZorkOne.Tests 1782**, **Stationfall.Tests 4**, **EscapeRoom.Tests 9**, **Console.Tests 16** — 0 failures.

## What this deliberately does not fix — now filed as #532

`push blue door` in the Elevator Lobby, and `examine door` at the Tower Core and Waiting Area, all print a **blank line**. Verified byte-identical on `92a1e22` (this branch's base) and on this branch, so it predates the refactor.

The shaft door is one object seeded into two rooms, so its `CurrentLocation` points at whichever `Init` ran last — and building the lobby's own `Map` instantiates both cars, which is enough to trigger it. `Repository.GetItemInScope` then rejects the door in the lobby, and the force-verb path short-circuits to `string.Empty`. `examine`/`open`/`close` are masked because #505 made the lobby intercept them, so only force verbs, `enter`, and the un-intercepted far-end rooms are exposed.

`Doorway` makes the per-room workarounds uniform; it does not remove the reason they are needed. That's a change of object identity or of engine-level accessibility, and it wants its own red test and its own decision — see #532 for the full diagnosis, both candidate fixes, and a TDD plan.