### PR TITLE
Fix #532: give each room its own elevator door over one shaft state

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -216,6 +216,15 @@ adding/reviewing room and item handlers:
    scope-rejected noun it short-circuits to `string.Empty` (a blank line) instead of the narrator. Fix:
    unhandled force verbs should fall through to the narrator in shared routing, not per-object.
 
+   That narrator fallback only stops the blank line — the object is still out of scope, so
+   `enter <door>`, `take`, and every other verb routed through `Repository.GetItemInScope` still find
+   nothing, and a room that never seeded the object at all can resolve it from nowhere. The real fix is
+   to **split identity and share state**: give each room its own object whose `CurrentLocation` is
+   honest, and have it read/write the one flag the shared object used to hold. The elevator shafts are
+   the worked example (issue #532, `Planetfall/Item/Kalamontee/Admin/ElevatorLandingDoor.cs`): three
+   rooms, three door objects, one `IsOpen`. Doing this also retires the "answer for the door by hand"
+   workaround such rooms accumulate, because each object's raw state is now its own room's truth.
+
 **God-mode setup trap (white-box):** `god mode take <item>` / `go <place>`
 (`GameEngine/StaticCommand/Implementation/GodModeProcessor.cs`) route through `Repository.LoadAllLocations`
 /`LoadAllItems`, which **deliberately rebuild the Repository without `Init()`** (per issue #241). A side

--- a/GameEngine/GameEngine.cs
+++ b/GameEngine/GameEngine.cs
@@ -726,6 +726,11 @@ public class GameEngine<TInfocomGame, TContext> : IGameEngine
         Context.Engine = this;
         Context.Game = new TInfocomGame();
 
+        // Let the game repair a blob written by an older build, before anything reads the restored
+        // state. Init() does not run again on restore, so a room whose starting items changed since the
+        // save keeps the old ones forever otherwise. No-op by default.
+        _gameInstance.AfterRestore(Context);
+
         // Migration safety net (issue #354 follow-up): a session saved before RequestSequence
         // existed deserializes it as the default 0. Left alone, the next WriteSessionStep call (a
         // DynamoDB sort key in ZorkOneController) would restart numbering from 1 and silently

--- a/GameEngine/IntentEngine/EnterSubLocationEngine.cs
+++ b/GameEngine/IntentEngine/EnterSubLocationEngine.cs
@@ -17,6 +17,13 @@ internal class EnterSubLocationEngine : IIntentEngine
         if (string.IsNullOrEmpty(enter.Noun))
             throw new ArgumentException("Null or empty noun. What's up with that?");
 
+        // Ask before resolving. GetItemInScope returns the FIRST match, so without this a room with two
+        // doors silently picked one for "enter door" while answering "Do you mean...?" to "examine door"
+        // (issue #532). The player gets the same question either way now.
+        var ambiguous = NounDisambiguator.Check(enter.Noun, context, "enter {0}");
+        if (ambiguous is not null)
+            return (ambiguous, ambiguous.InteractionMessage);
+
         IItem? subLocation = Repository.GetItemInScope(enter.Noun, context);
         if (subLocation == null)
         {

--- a/GameEngine/IntentEngine/ExitSubLocationEngine.cs
+++ b/GameEngine/IntentEngine/ExitSubLocationEngine.cs
@@ -21,6 +21,11 @@ internal class ExitSubLocationEngine : IIntentEngine
         if (context.CurrentLocation is ISubLocation currentAsSubLocation)
             return (null, currentAsSubLocation.GetOut(context));
 
+        // Symmetric to EnterSubLocationEngine: resolve only once the noun names one thing (issue #532).
+        var ambiguous = NounDisambiguator.Check(exit.NounOne, context, "exit {0}");
+        if (ambiguous is not null)
+            return (ambiguous, ambiguous.InteractionMessage);
+
         var subLocation = Repository.GetItemInScope(exit.NounOne, context);
         if (subLocation == null)
         {

--- a/GameEngine/IntentEngine/MultiNounEngine.cs
+++ b/GameEngine/IntentEngine/MultiNounEngine.cs
@@ -218,50 +218,9 @@ public class MultiNounEngine : IIntentEngine
         return result;
     }
 
-    private DisambiguationInteractionResult? CheckDisambiguation(MultiNounIntent intent,
+    private static DisambiguationInteractionResult? CheckDisambiguation(MultiNounIntent intent,
         IContext context, Func<string[], bool> matchFunction)
     {
-        var ambiguousItems = new List<IItem>();
-
-        List<IItem>? allItemsInLocation = (context.CurrentLocation as ICanContainItems)?.GetAllItemsRecursively;
-        if (allItemsInLocation is null)
-            return null;
-        
-        IEnumerable<IItem> allItemsInSight =
-            context.GetAllItemsRecursively
-                .Union(allItemsInLocation)
-                .ToList();
-        
-        foreach (var item in allItemsInSight)
-            if (matchFunction(item.NounsForMatching))
-                ambiguousItems.Add(item);
-
-        // We have one or fewer items that match the noun. Good to go. 
-        if (ambiguousItems.Count <= 1)
-            return null;
-
-        var itemNouns = ambiguousItems
-            .Select(s => s.NounsForMatching.MaxBy(n => n.Length))
-            .ToList()!
-            .SingleLineListWithOr();
-        var message = $"Do you mean {itemNouns}?";
-
-        // For each item, we need a map of all possible nouns, to the longest noun, and then 
-        // we will replace the matching noun with the longest noun. If we don't do
-        // this, we'll loop around disambiguating forever. 
-        var nounToLongestNounMap = new Dictionary<string, string>();
-        foreach (var item in ambiguousItems)
-        {
-            var longestNoun = item.NounsForPreciseMatching.MaxBy(noun => noun.Length);
-            foreach (var noun in item.NounsForPreciseMatching) nounToLongestNounMap[noun] = longestNoun ?? string.Empty;
-        }
-
-        var replacement = intent.OriginalInput.Replace(intent.NounOne, "{0}");
-
-        return new DisambiguationInteractionResult(
-            message,
-            nounToLongestNounMap,
-            replacement
-        );
+        return NounDisambiguator.Check(matchFunction, context, intent.OriginalInput.Replace(intent.NounOne, "{0}"));
     }
 }

--- a/GameEngine/IntentEngine/NounDisambiguator.cs
+++ b/GameEngine/IntentEngine/NounDisambiguator.cs
@@ -1,0 +1,82 @@
+using Model.Interface;
+using Model.Item;
+using Utilities;
+
+namespace GameEngine.IntentEngine;
+
+/// <summary>
+///     "Do you mean the lower elevator door or the upper elevator door?" — the one place that decides a
+///     noun in scope is ambiguous, and builds the prompt for it.
+///     <para>
+///         This used to be private and duplicated in <see cref="SimpleInteractionEngine" /> and
+///         <see cref="MultiNounEngine" />, which meant the engines that had no copy simply never asked:
+///         <see cref="EnterSubLocationEngine" /> and <see cref="ExitSubLocationEngine" /> resolved
+///         straight through <see cref="Repository.GetItemInScope" />, which returns the first match. So a
+///         room with two doors answered "Do you mean...?" to <c>examine door</c> and silently picked one
+///         for <c>enter door</c> — in the Planetfall Elevator Lobby, walking the player into whichever
+///         elevator happened to be seeded first (issue #532).
+///     </para>
+/// </summary>
+internal static class NounDisambiguator
+{
+    /// <summary>
+    ///     Returns the prompt to ask when more than one item in scope answers to the noun, or null when
+    ///     the noun is unambiguous and the caller should resolve it normally.
+    /// </summary>
+    /// <param name="context">The player, for inventory and the current room.</param>
+    /// <param name="matchesNoun">
+    ///     Whether an item's <see cref="IItem.NounsForMatching" /> answers to the noun the player typed.
+    ///     Supplied by the caller because each intent carries its noun differently — a
+    ///     <c>SimpleIntent</c> has an adjective to honour, a bare string does not.
+    /// </param>
+    /// <param name="replacement">
+    ///     The command to re-run once the player picks, with <c>{0}</c> where the noun goes — e.g.
+    ///     <c>"enter {0}"</c>.
+    /// </param>
+    public static DisambiguationInteractionResult? Check(Func<string[], bool> matchesNoun, IContext context,
+        string replacement)
+    {
+        // Production always gives a real room and a real inventory here; an under-configured IContext
+        // mock returns null for either, and nothing to look at is nothing to disambiguate against. Both
+        // sides need the guard - Union throws on a null argument, not just a null receiver.
+        var itemsInLocation = (context.CurrentLocation as ICanContainItems)?.GetAllItemsRecursively;
+        if (itemsInLocation is null)
+            return null;
+
+        var ambiguousItems = (context.GetAllItemsRecursively ?? [])
+            .Union(itemsInLocation)
+            .Where(item => matchesNoun(item.NounsForMatching))
+            .ToList();
+
+        // One or fewer items answer to the noun. Good to go.
+        if (ambiguousItems.Count <= 1)
+            return null;
+
+        var itemNouns = ambiguousItems
+            .Select(s => s.NounsForMatching.MaxBy(n => n.Length))
+            .ToList()!
+            .SingleLineListWithOr();
+
+        // Map every noun each item answers to onto that item's longest one, and replace what the player
+        // said with it. Without this the reply would be just as ambiguous as the question and we would
+        // loop around disambiguating forever.
+        var nounToLongestNounMap = new Dictionary<string, string>();
+        foreach (var item in ambiguousItems)
+        {
+            var longestNoun = item.NounsForPreciseMatching.MaxBy(noun => noun.Length);
+            foreach (var noun in item.NounsForPreciseMatching)
+                nounToLongestNounMap[noun] = longestNoun ?? string.Empty;
+        }
+
+        return new DisambiguationInteractionResult($"Do you mean {itemNouns}?", nounToLongestNounMap, replacement);
+    }
+
+    /// <summary>
+    ///     The common case: a bare noun with no adjective, matched exactly against an item's nouns.
+    /// </summary>
+    public static DisambiguationInteractionResult? Check(string noun, IContext context, string replacement)
+    {
+        return Check(nouns => nouns.Any(n => n.Equals(noun, StringComparison.InvariantCultureIgnoreCase)), context,
+            replacement);
+    }
+}

--- a/GameEngine/IntentEngine/SimpleInteractionEngine.cs
+++ b/GameEngine/IntentEngine/SimpleInteractionEngine.cs
@@ -81,49 +81,9 @@ internal class SimpleInteractionEngine(IItemProcessorFactory itemProcessorFactor
         return (null, await GetGeneratedNoOpResponse(simpleInteraction.OriginalInput ?? "", generationClient, context));
     }
 
-    private DisambiguationInteractionResult? CheckDisambiguation(SimpleIntent intent, IContext context)
+    private static DisambiguationInteractionResult? CheckDisambiguation(SimpleIntent intent, IContext context)
     {
-        var ambiguousItems = new List<IItem>();
-
-        IEnumerable<IItem> allItemsInSight =
-            context.GetAllItemsRecursively
-                .Union((context.CurrentLocation as ICanContainItems)!.GetAllItemsRecursively)
-                .ToList();
-
-        foreach (var item in allItemsInSight)
-            if (intent.MatchNounAndAdjective(item.NounsForMatching))
-                ambiguousItems.Add(item);
-
-        // We have one or fewer items that match the noun. Good to go. 
-        if (ambiguousItems.Count <= 1)
-            return null;
-
-        var itemNouns = ambiguousItems
-            .Select(s => s.NounsForMatching.MaxBy(n => n.Length))
-            .ToList()!
-            .SingleLineListWithOr();
-        var message = $"Do you mean {itemNouns}?";
-
-        // For each item, we need a map of all possible nouns, to the longest noun, and then 
-        // we will replace the matching noun with the longest noun. If we don't do
-        // this, we'll loop around disambiguating forever. 
-        var nounToLongestNounMap = new Dictionary<string, string>();
-        foreach (var item in ambiguousItems)
-        {
-            string? longestNoun = item.NounsForPreciseMatching.MaxBy(noun => noun.Length);
-            foreach (var noun in item.NounsForPreciseMatching)
-            {
-                nounToLongestNounMap[noun] = longestNoun ?? string.Empty;
-            }
-        }
-
-        var replacement = intent.Verb + " {0}";
-        
-        return new DisambiguationInteractionResult(
-            message,
-            nounToLongestNounMap,
-            replacement
-        );
+        return NounDisambiguator.Check(intent.MatchNounAndAdjective, context, intent.Verb + " {0}");
     }
 
     private static async Task<string> GetGeneratedNoMatchingVerbResponse(string? noun, string verb,

--- a/Model/Interface/IInfocomGame.cs
+++ b/Model/Interface/IInfocomGame.cs
@@ -81,4 +81,20 @@ public interface IInfocomGame
     /// Defaults to none.
     /// </summary>
     IReadOnlyList<Type> TalkableCharacterTypes => [];
+
+    /// <summary>
+    ///     Called once per restore, immediately after the saved <see cref="Repository" /> state has been
+    ///     installed, so a game can migrate a blob written by an older build. Defaults to doing nothing.
+    /// </summary>
+    /// <remarks>
+    ///     A location's <c>Init()</c> never runs again on restore — the saved <c>Items</c> list IS the
+    ///     room's contents. So whenever a release changes which object a room starts with, every
+    ///     in-flight session keeps the old one forever, and in the stateless deployment (which rehydrates
+    ///     from the session blob every turn) that is permanent rather than merely stale. This is the hook
+    ///     for repairing that. Implementations must be idempotent: it also runs on blobs that are already
+    ///     current.
+    /// </remarks>
+    void AfterRestore(IContext context)
+    {
+    }
 }

--- a/Planetfall.Tests/ElevatorTests.cs
+++ b/Planetfall.Tests/ElevatorTests.cs
@@ -1491,6 +1491,49 @@ public class ElevatorTests : EngineTestsBase
     }
 
     /// <summary>
+    ///     The lobby has two doors, so the bare noun names neither of them. "examine door" always asked
+    ///     which one; the enter path resolved through GetItemInScope, which returns the FIRST match, and
+    ///     so silently picked whichever door was seeded first - answering "the door is closed" about the
+    ///     red one on a turn the player was plainly looking at an open blue one, or walking them into the
+    ///     wrong elevator outright. Both surfaces ask the same question now (#532).
+    /// </summary>
+    [Test]
+    public async Task EnterDoor_FromTheLobby_BareNoun_AsksWhichDoor()
+    {
+        var target = GetTarget();
+        StartHere<ElevatorLobby>();
+        // Blue open with its car here, red closed - the state where picking the wrong one is visible.
+        GetItem<UpperElevatorDoor>().IsOpen = true;
+        GetLocation<UpperElevator>().InLobby = true;
+        GetItem<LowerElevatorDoor>().IsOpen = false;
+
+        var response = await target.GetResponse("enter door");
+
+        response.Should().Contain("Do you mean");
+        response.Should().Contain("upper elevator door");
+        response.Should().Contain("lower elevator door");
+        Context.CurrentLocation.Should().BeOfType<ElevatorLobby>();
+    }
+
+    /// <summary>
+    ///     And answering it walks the player through the door they actually named.
+    /// </summary>
+    [Test]
+    public async Task EnterDoor_FromTheLobby_AnsweringTheQuestion_WalksThroughThatDoor()
+    {
+        var target = GetTarget();
+        StartHere<ElevatorLobby>();
+        GetItem<UpperElevatorDoor>().IsOpen = true;
+        GetLocation<UpperElevator>().InLobby = true;
+
+        await target.GetResponse("enter door");
+        var response = await target.GetResponse("blue door");
+
+        response.Should().Contain("Upper Elevator");
+        Context.CurrentLocation.Should().BeOfType<UpperElevator>();
+    }
+
+    /// <summary>
     ///     The far ends of the two shafts both name a door in their own description ("A sliding door
     ///     leads north", "to the south is a metal door") and never seeded one, so nothing there could
     ///     resolve "door" at all.

--- a/Planetfall.Tests/ElevatorTests.cs
+++ b/Planetfall.Tests/ElevatorTests.cs
@@ -6,6 +6,7 @@ using Model.AIParsing;
 using Model.Intent;
 using Model.Item;
 using Moq;
+using Newtonsoft.Json;
 using Planetfall.Item;
 using Planetfall.Item.Kalamontee.Admin;
 using Planetfall.Location.Kalamontee;
@@ -1607,6 +1608,27 @@ public class ElevatorTests : EngineTestsBase
     }
 
     /// <summary>
+    ///     Each far-end door answers to the noun its own room's description uses - "a sliding door leads
+    ///     north" at the Tower Core, "to the south is a metal door" at the Waiting Area - not just the
+    ///     bare "door" the other tests here reach for.
+    /// </summary>
+    [Test]
+    public async Task ExamineDoor_AtTheFarEnd_AnswersToTheNounTheRoomDescriptionUses()
+    {
+        var target = GetTarget();
+
+        StartHere<TowerCore>();
+        GetLocation<UpperElevator>().InLobby = false;
+        GetItem<UpperElevatorDoor>().IsOpen = true;
+        (await target.GetResponse("examine sliding door")).Should().Contain("The door is open");
+
+        StartHere<WaitingArea>();
+        GetLocation<LowerElevator>().InLobby = true;
+        GetItem<LowerElevatorDoor>().IsOpen = true;
+        (await target.GetResponse("examine metal door")).Should().Contain("The door is closed");
+    }
+
+    /// <summary>
     ///     A door in the car, a door in the lobby and a door at the far end are three objects, but one
     ///     shaft and therefore one open/closed state. Whichever object the player reaches, the state they
     ///     read is the shaft's.
@@ -1628,5 +1650,138 @@ public class ElevatorTests : EngineTestsBase
 
         StartHere<UpperElevator>();
         (await target.GetResponse("examine door")).Should().Contain("The door is closed");
+    }
+
+    // =============================================================================================
+    // Save-game compatibility. A location's Init() never runs again on restore - the saved Items list
+    // IS the room's contents - so splitting the shaft doors changed what every in-flight session is
+    // carrying. The stateless Lambda rehydrates from the session blob every turn, which makes a stale
+    // blob permanent rather than merely first-turn.
+    // =============================================================================================
+
+    /// <summary>
+    ///     Reproduces what a blob written before the split deserializes to: the shared shaft doors sit in
+    ///     the Elevator Lobby's Items, and the landing doors were never placed anywhere. Left alone, the
+    ///     lobby's verbs find the shared door - LocationBase routes over Items with no scope check - and
+    ///     it reports the raw shaft flag, which is #505 again.
+    /// </summary>
+    private void ArrangeLobbyAsAPreSplitBlob()
+    {
+        var lobby = GetLocation<ElevatorLobby>();
+        lobby.Items.Clear();
+        lobby.ItemPlacedHere(GetItem<LowerElevatorDoor>());
+        lobby.ItemPlacedHere(GetItem<UpperElevatorDoor>());
+        GetLocation<TowerCore>().Items.Clear();
+        GetLocation<WaitingArea>().Items.Clear();
+    }
+
+    [Test]
+    public async Task AfterRestore_BlobSavedBeforeTheDoorSplit_LobbyStopsContradictingItself()
+    {
+        var target = GetTarget();
+        StartHere<ElevatorLobby>();
+        ArrangeLobbyAsAPreSplitBlob();
+        // The state a completed ride to the far end leaves behind: flag open, car away.
+        GetItem<UpperElevatorDoor>().IsOpen = true;
+        GetLocation<UpperElevator>().InLobby = false;
+
+        new PlanetfallGame().AfterRestore(Context);
+
+        (await target.GetResponse("examine blue door")).Should().Contain("The door is closed");
+        (await target.GetResponse("open blue door")).Should().Contain("It won\'t budge");
+        (await target.GetResponse("north")).Should().Contain("The door is closed");
+        Context.CurrentLocation.Should().BeOfType<ElevatorLobby>();
+    }
+
+    [Test]
+    public void AfterRestore_BlobSavedBeforeTheDoorSplit_ReseatsTheLobbyDoors()
+    {
+        GetTarget();
+        var lobby = StartHere<ElevatorLobby>();
+        ArrangeLobbyAsAPreSplitBlob();
+
+        new PlanetfallGame().AfterRestore(Context);
+
+        lobby.Items.Should().Contain(GetItem<UpperElevatorLobbyDoor>());
+        lobby.Items.Should().Contain(GetItem<LowerElevatorLobbyDoor>());
+        // The shared door belongs to the car now; it must not be left answering for the lobby as well.
+        lobby.Items.Should().NotContain(GetItem<UpperElevatorDoor>());
+        lobby.Items.Should().NotContain(GetItem<LowerElevatorDoor>());
+    }
+
+    [Test]
+    public async Task AfterRestore_BlobSavedBeforeTheDoorSplit_SeedsTheFarEndDoors()
+    {
+        var target = GetTarget();
+        StartHere<ElevatorLobby>();
+        ArrangeLobbyAsAPreSplitBlob();
+
+        new PlanetfallGame().AfterRestore(Context);
+
+        GetLocation<TowerCore>().Items.Should().Contain(GetItem<UpperElevatorTowerDoor>());
+        GetLocation<WaitingArea>().Items.Should().Contain(GetItem<LowerElevatorWaitingAreaDoor>());
+
+        StartHere<TowerCore>();
+        GetLocation<UpperElevator>().InLobby = false;
+        GetItem<UpperElevatorDoor>().IsOpen = true;
+        (await target.GetResponse("examine door")).Should().Contain("The door is open");
+    }
+
+    /// <summary>
+    ///     It also runs on blobs that are already current, so it must not duplicate what is already there.
+    /// </summary>
+    [Test]
+    public void AfterRestore_OnAnAlreadyCurrentBlob_LeavesExactlyOneDoorPerRoom()
+    {
+        GetTarget();
+        var lobby = StartHere<ElevatorLobby>();
+
+        new PlanetfallGame().AfterRestore(Context);
+        new PlanetfallGame().AfterRestore(Context);
+
+        lobby.Items.OfType<ElevatorDoorBase>().Should().HaveCount(2);
+        GetLocation<TowerCore>().Items.OfType<ElevatorDoorBase>().Should().HaveCount(1);
+        GetLocation<WaitingArea>().Items.OfType<ElevatorDoorBase>().Should().HaveCount(1);
+    }
+
+    /// <summary>
+    ///     A landing door holds no state of its own, so it must not write any into the blob. The
+    ///     attribute that guarantees that has to be Newtonsoft's - saves go through JsonConvert, which
+    ///     ignores System.Text.Json's attribute of the same name and would round-trip the derived value
+    ///     back through the write-through setter.
+    /// </summary>
+    [Test]
+    public void LandingDoor_SerializesNoStateOfItsOwn()
+    {
+        GetTarget();
+
+        var json = JsonConvert.SerializeObject(GetItem<UpperElevatorLobbyDoor>());
+
+        json.Should().NotContain("IsOpen");
+        json.Should().NotContain("HasEverBeenOpened");
+    }
+
+    /// <summary>
+    ///     End to end through the real save/restore path: the shaft's state is the car door's, and it has
+    ///     to survive a round trip untouched by the three landing doors that report it.
+    /// </summary>
+    [Test]
+    public async Task SaveAndRestore_RoundTrip_PreservesTheShaftStateAndItsVantagePoints()
+    {
+        var target = GetTarget();
+        StartHere<ElevatorLobby>();
+        GetItem<UpperElevatorDoor>().IsOpen = true;
+        GetLocation<UpperElevator>().InLobby = false;
+        await target.GetResponse("look");
+
+        target.RestoreGame(target.SaveGame());
+
+        GetItem<UpperElevatorDoor>().IsOpen.Should().BeTrue();
+        GetLocation<UpperElevator>().InLobby.Should().BeFalse();
+        // ...and each vantage point still reads it correctly: closed at the lobby, open at the tower.
+        StartHere<ElevatorLobby>();
+        (await target.GetResponse("examine blue door")).Should().Contain("The door is closed");
+        StartHere<TowerCore>();
+        (await target.GetResponse("examine door")).Should().Contain("The door is open");
     }
 }

--- a/Planetfall.Tests/ElevatorTests.cs
+++ b/Planetfall.Tests/ElevatorTests.cs
@@ -1,7 +1,12 @@
 using FluentAssertions;
+using GameEngine;
+using GameEngine.Item;
 using Model.AIGeneration;
+using Model.AIParsing;
 using Model.Intent;
+using Model.Item;
 using Moq;
+using Planetfall.Item;
 using Planetfall.Item.Kalamontee.Admin;
 using Planetfall.Location.Kalamontee;
 using Planetfall.Location.Kalamontee.Tower;
@@ -1212,9 +1217,11 @@ public class ElevatorTests : EngineTestsBase
 
     /// <summary>
     ///     ExamineInteractionProcessor answers a wider set of verbs than Verbs.ExamineVerbs lists -
-    ///     "check", "look in" and "peek at" appear only in its own switch. Any of them reaching the door
-    ///     item reports the shared flag, so "check blue door" would still answer "open" on the same turn
-    ///     the room, "examine" and the exit all say closed.
+    ///     "check", "look in" and "peek at" appear only in its own switch. Every one of them now goes
+    ///     straight to the door item, which is the point of #532: the lobby's door object answers for the
+    ///     lobby, so no phrasing can slip past a room-level guard and read the shaft flag raw. This used
+    ///     to be the room intercepting each verb by hand, and a verb it forgot answered "open" on the same
+    ///     turn the room, "examine" and the exit all said closed.
     /// </summary>
     [Test]
     [TestCase("examine")]
@@ -1231,7 +1238,8 @@ public class ElevatorTests : EngineTestsBase
         GetLocation<UpperElevator>().InLobby = false;
 
         var result = await lobby.RespondToSimpleInteraction(
-            new SimpleIntent { Verb = verb, Noun = "blue door" }, Context, Mock.Of<IGenerationClient>(), null!);
+            new SimpleIntent { Verb = verb, Noun = "blue door" }, Context, Mock.Of<IGenerationClient>(),
+            new ItemProcessorFactory(Mock.Of<IAITakeAndAndDropParser>()));
 
         result.InteractionMessage.Should().Contain("The door is closed");
     }
@@ -1368,5 +1376,257 @@ public class ElevatorTests : EngineTestsBase
 
         response = await target.GetResponse("close red door");
         response.Should().Contain("It is closed");
+    }
+
+    // =============================================================================================
+    // Issue #532: each shaft door was ONE Repository singleton seeded into two rooms, so the two
+    // Init()s fought over its CurrentLocation and the loser could not resolve it as an object at all.
+    //
+    // ElevatorLobby.Map calls GetLocation<UpperElevator>() / GetLocation<LowerElevator>() to name its
+    // destinations, and Repository.GetLocation lazily Inits - so merely looking at the lobby builds
+    // both cars, whose Init runs last and takes ownership of both doors. From then on
+    // Repository.GetItemInScope rejects the door in the lobby (IsItemAccessible tests
+    // item.CurrentLocation == context.CurrentLocation), and the far-end rooms never seeded it at all.
+    //
+    // The verbs #505 taught the lobby to intercept - examine / open / close - masked this, because
+    // they never reach scope resolution. The force verbs and the far-end rooms were left exposed.
+    // =============================================================================================
+
+    /// <summary>
+    ///     Both lobby doors have to resolve as objects standing in the lobby. Asserting on the resolved
+    ///     door's own state rather than its type is what catches the load-order variant of this bug,
+    ///     where "blue door" silently resolved to the RED door because the bare noun "door" is contained
+    ///     in "blue door" and the wrong object was the only accessible one.
+    /// </summary>
+    [Test]
+    public async Task DoorNouns_FromTheLobby_ResolveToADoorStandingInTheLobby()
+    {
+        var target = GetTarget();
+        var lobby = StartHere<ElevatorLobby>();
+        // One look is the whole setup. ElevatorLobby.Map names both cars, Repository.GetLocation Inits
+        // on first request, and each car's Init used to seize the lobby's door - so simply standing here
+        // and looking around was enough to take both doors out of scope.
+        await target.GetResponse("look");
+        // Distinct states, so a transposition cannot hide behind two matching answers.
+        GetItem<UpperElevatorDoor>().IsOpen = true;
+        GetItem<LowerElevatorDoor>().IsOpen = false;
+        GetLocation<UpperElevator>().InLobby = true;
+        GetLocation<LowerElevator>().InLobby = true;
+
+        var blue = Repository.GetItemInScope("blue door", Context);
+        var red = Repository.GetItemInScope("red door", Context);
+
+        blue.Should().NotBeNull("the blue door is described by this room, so it must resolve here (#532)");
+        red.Should().NotBeNull("the red door is described by this room, so it must resolve here (#532)");
+        blue!.CurrentLocation.Should().BeSameAs(lobby);
+        red!.CurrentLocation.Should().BeSameAs(lobby);
+        blue.Should().NotBeSameAs(red);
+        ((IDoor)blue).IsOpen.Should().BeTrue("\"blue door\" must resolve to the upper shaft's door");
+        ((IDoor)red).IsOpen.Should().BeFalse("\"red door\" must resolve to the lower shaft's door");
+    }
+
+    /// <summary>
+    ///     What the lobby's player actually loses when the door falls out of scope: "enter blue door" is
+    ///     the phrasing the room's own description invites, and DoorReroute (#262) turns it into the walk
+    ///     north - but only if the noun resolves to the item the map declares as that exit's GatingItem.
+    /// </summary>
+    [Test]
+    public async Task EnterDoor_FromTheLobby_CarIsHere_WalksIntoTheCar()
+    {
+        var target = GetTarget();
+        StartHere<ElevatorLobby>();
+        await target.GetResponse("look");
+        GetItem<UpperElevatorDoor>().IsOpen = true;
+        GetLocation<UpperElevator>().InLobby = true;
+
+        var response = await target.GetResponse("enter blue door");
+
+        response.Should().Contain("Upper Elevator");
+        Context.CurrentLocation.Should().BeOfType<UpperElevator>();
+    }
+
+    [Test]
+    public async Task EnterDoor_FromTheLobby_CarIsAway_RefusesAndStaysPut()
+    {
+        var target = GetTarget();
+        StartHere<ElevatorLobby>();
+        await target.GetResponse("look");
+        // The shared flag left open by an arrival at the FAR end - the lobby's door is really closed.
+        GetItem<UpperElevatorDoor>().IsOpen = true;
+        GetLocation<UpperElevator>().InLobby = false;
+
+        var response = await target.GetResponse("enter blue door");
+
+        response.Should().Contain("The door is closed");
+        Context.CurrentLocation.Should().BeOfType<ElevatorLobby>();
+    }
+
+    [Test]
+    public async Task EnterDoor_AtTheTowerCore_CarIsHere_WalksIntoTheCar()
+    {
+        var target = GetTarget();
+        StartHere<TowerCore>();
+        GetLocation<UpperElevator>().InLobby = false;
+        GetItem<UpperElevatorDoor>().IsOpen = true;
+
+        var response = await target.GetResponse("enter door");
+
+        response.Should().Contain("Upper Elevator");
+        Context.CurrentLocation.Should().BeOfType<UpperElevator>();
+    }
+
+    [Test]
+    public async Task EnterDoor_AtTheWaitingArea_CarIsHere_WalksIntoTheCar()
+    {
+        var target = GetTarget();
+        StartHere<WaitingArea>();
+        GetLocation<LowerElevator>().InLobby = false;
+        GetItem<LowerElevatorDoor>().IsOpen = true;
+
+        var response = await target.GetResponse("enter door");
+
+        response.Should().Contain("Lower Elevator");
+        Context.CurrentLocation.Should().BeOfType<LowerElevator>();
+    }
+
+    /// <summary>
+    ///     The far ends of the two shafts both name a door in their own description ("A sliding door
+    ///     leads north", "to the south is a metal door") and never seeded one, so nothing there could
+    ///     resolve "door" at all.
+    /// </summary>
+    [Test]
+    public void DoorNoun_AtTheTowerCore_ResolvesToADoorStandingThere()
+    {
+        GetTarget();
+        var towerCore = StartHere<TowerCore>();
+
+        var door = Repository.GetItemInScope("door", Context);
+
+        door.Should().NotBeNull("the Tower Core's description names a sliding door (#532)");
+        door!.CurrentLocation.Should().BeSameAs(towerCore);
+    }
+
+    [Test]
+    public void DoorNoun_AtTheWaitingArea_ResolvesToADoorStandingThere()
+    {
+        GetTarget();
+        var waitingArea = StartHere<WaitingArea>();
+
+        var door = Repository.GetItemInScope("door", Context);
+
+        door.Should().NotBeNull("the Waiting Area's description names a metal door (#532)");
+        door!.CurrentLocation.Should().BeSameAs(waitingArea);
+    }
+
+    /// <summary>
+    ///     And having resolved, the far-end door must answer from the far end's vantage point - open only
+    ///     when the car is standing at THIS end - exactly as the entrance in the same room already does.
+    /// </summary>
+    [Test]
+    public async Task ExamineDoor_AtTheTowerCore_CarIsHere_ReportsOpen()
+    {
+        var target = GetTarget();
+        StartHere<TowerCore>();
+        GetLocation<UpperElevator>().InLobby = false;
+        GetItem<UpperElevatorDoor>().IsOpen = true;
+
+        var response = await target.GetResponse("examine door");
+
+        response.Should().Contain("The door is open");
+    }
+
+    [Test]
+    public async Task ExamineDoor_AtTheTowerCore_CarIsDownAtTheLobby_ReportsClosed()
+    {
+        var target = GetTarget();
+        StartHere<TowerCore>();
+        // The shared flag is left open by the car's arrival at the LOBBY end - the exact state that
+        // makes a raw-flag reading contradict the exit standing right beside it.
+        GetLocation<UpperElevator>().InLobby = true;
+        GetItem<UpperElevatorDoor>().IsOpen = true;
+
+        var response = await target.GetResponse("examine door");
+
+        response.Should().Contain("The door is closed");
+        response.Should().NotContain("The door is open");
+    }
+
+    [Test]
+    public async Task ExamineDoor_AtTheWaitingArea_CarIsHere_ReportsOpen()
+    {
+        var target = GetTarget();
+        StartHere<WaitingArea>();
+        GetLocation<LowerElevator>().InLobby = false;
+        GetItem<LowerElevatorDoor>().IsOpen = true;
+
+        var response = await target.GetResponse("examine door");
+
+        response.Should().Contain("The door is open");
+    }
+
+    [Test]
+    public async Task ExamineDoor_AtTheWaitingArea_CarIsUpAtTheLobby_ReportsClosed()
+    {
+        var target = GetTarget();
+        StartHere<WaitingArea>();
+        GetLocation<LowerElevator>().InLobby = true;
+        GetItem<LowerElevatorDoor>().IsOpen = true;
+
+        var response = await target.GetResponse("examine door");
+
+        response.Should().Contain("The door is closed");
+        response.Should().NotContain("The door is open");
+    }
+
+    [Test]
+    public async Task OpenDoor_AtTheTowerCore_CarIsDownAtTheLobby_WontBudge()
+    {
+        var target = GetTarget();
+        StartHere<TowerCore>();
+        GetLocation<UpperElevator>().InLobby = true;
+        GetItem<UpperElevatorDoor>().IsOpen = true;
+
+        var response = await target.GetResponse("open door");
+
+        response.Should().Contain("It won\'t budge");
+        response.Should().NotContain("It is open");
+    }
+
+    [Test]
+    public async Task OpenDoor_AtTheWaitingArea_CarIsUpAtTheLobby_WontBudge()
+    {
+        var target = GetTarget();
+        StartHere<WaitingArea>();
+        GetLocation<LowerElevator>().InLobby = true;
+        GetItem<LowerElevatorDoor>().IsOpen = true;
+
+        var response = await target.GetResponse("open door");
+
+        response.Should().Contain("It won\'t budge");
+        response.Should().NotContain("It is open");
+    }
+
+    /// <summary>
+    ///     A door in the car, a door in the lobby and a door at the far end are three objects, but one
+    ///     shaft and therefore one open/closed state. Whichever object the player reaches, the state they
+    ///     read is the shaft's.
+    /// </summary>
+    [Test]
+    public async Task ShaftDoorState_IsSharedByEveryRoomThatSeesIt_Upper()
+    {
+        var target = GetTarget();
+        StartHere<TowerCore>();
+        GetLocation<UpperElevator>().InLobby = false;
+        GetItem<UpperElevatorDoor>().IsOpen = true;
+
+        (await target.GetResponse("examine door")).Should().Contain("The door is open");
+
+        // Ride nothing - just shut the shaft and ask again from inside the car.
+        GetItem<UpperElevatorDoor>().IsOpen = false;
+
+        (await target.GetResponse("examine door")).Should().Contain("The door is closed");
+
+        StartHere<UpperElevator>();
+        (await target.GetResponse("examine door")).Should().Contain("The door is closed");
     }
 }

--- a/Planetfall/Item/Doorway.cs
+++ b/Planetfall/Item/Doorway.cs
@@ -1,22 +1,28 @@
 namespace Planetfall.Item;
 
 /// <summary>
-///     A door <i>as seen from one particular room</i>: the door object paired with the predicate that
-///     says whether it counts as open from where the asking room stands.
+///     A door <i>as seen from one particular room</i>.
 ///     <para>
-///         Every elevator-door bug this game has had — #450, #454, #456, #505, #512, #518, #523 — is the
-///         same defect. A door's state is answered by up to four surfaces of a room: the exit in its
+///         Every elevator-door bug this game has had — #450, #454, #456, #505, #512, #518, #523, #532 —
+///         is the same defect. A door's state is answered by several surfaces of a room: the exit in its
 ///         <c>Map</c>, the sentence in its description, <c>examine door</c>, and <c>open/close door</c>.
 ///         Each surface used to re-derive that state independently, one of them would be written as a
-///         plain literal or read the raw flag, and the room would then contradict itself — describing a
-///         door as open while walking that way answered "The door is closed."
+///         plain literal or read a flag that meant something else, and the room would then contradict
+///         itself — describing a door as open while walking that way answered "The door is closed."
 ///     </para>
 ///     <para>
 ///         So a room states its door exactly once, as a Doorway, and asks this object for each surface:
-///         <see cref="StateWord" /> for the description, <see cref="Passage" /> for the map, and
-///         <see cref="Answer" /> for the verbs. They cannot disagree, because there is only one
-///         predicate. A new room gets the invariant for free; drifting from it now takes deliberate
-///         effort rather than a copied string.
+///         <see cref="StateWord" /> for the description and <see cref="Passage" /> for the map. They
+///         cannot disagree, because there is only one fact. A new room gets the invariant for free;
+///         drifting from it now takes deliberate effort rather than a copied string.
+///     </para>
+///     <para>
+///         The verbs are deliberately <i>not</i> here. A Doorway used to be able to answer
+///         examine/open/close itself, for a room whose vantage point differed from the door's raw flag —
+///         which was really a symptom of one door object standing in two rooms at once, the bug behind
+///         #532. Once each room has its own door, that door's own state is the room's answer and the
+///         ordinary processors are correct; a room that intercepts its own door's verbs is stating it
+///         twice again.
 ///     </para>
 /// </summary>
 public sealed class Doorway
@@ -27,23 +33,17 @@ public sealed class Doorway
     /// </summary>
     public const string ClosedMessage = "The door is closed. ";
 
-    // ExamineInteractionProcessor answers a wider set than Verbs.ExamineVerbs lists - "check", "look in"
-    // and "peek at" appear only in its own switch. Matching just the array would let "check blue door"
-    // reach the door item and report the raw flag, reopening the contradiction for that one phrasing.
-    private static readonly string[] ExamineDoorVerbs = [..Verbs.ExamineVerbs, "check", "look in", "peek at"];
-
-    private readonly Func<bool> _isOpenHere;
-
-    /// <param name="door">The door, which owns all of the wording.</param>
-    /// <param name="isOpenHere">
-    ///     Whether the door counts as open from the room holding this Doorway. Omit it when the door's own
-    ///     flag is the whole truth, which is the usual case; supply it when the flag is shared between two
-    ///     vantage points and therefore cannot answer "open <i>here</i>" on its own.
+    /// <param name="door">
+    ///     The door, which owns all of the wording <i>and</i> the state. A Doorway deliberately takes no
+    ///     "but from here it's really closed" override: the elevator shafts used to need one because a
+    ///     single door object stood in two rooms at once, and the room that lost the coin toss then also
+    ///     lost the object from scope entirely (issue #532). The fix was to give each room its own door
+    ///     whose <see cref="IOpenAndClose.IsOpen" /> already means "open from here" — so if a room seems
+    ///     to need an override, what it actually needs is its own door.
     /// </param>
-    public Doorway(IDoor door, Func<bool>? isOpenHere = null)
+    public Doorway(IDoor door)
     {
         Door = door;
-        _isOpenHere = isOpenHere ?? (() => door.IsOpen);
     }
 
     public IDoor Door { get; }
@@ -51,7 +51,7 @@ public sealed class Doorway
     /// <summary>
     ///     The single fact every surface below is derived from.
     /// </summary>
-    public bool IsOpen => _isOpenHere();
+    public bool IsOpen => Door.IsOpen;
 
     /// <summary>
     ///     The word a room description must use for this door: "open" or "closed".
@@ -72,46 +72,5 @@ public sealed class Doorway
             Location = destination,
             CustomFailureMessage = closedMessage
         };
-    }
-
-    /// <summary>
-    ///     Answers "examine/open/close &lt;door&gt;" from <see cref="IsOpen" /> instead of the raw flag,
-    ///     re-stating exactly what the examine and open/close processors would say. Returns null for any
-    ///     other verb, any other noun, or any case where the door would really open or close — those must
-    ///     reach the normal processors so the state change actually happens.
-    ///     <para>
-    ///         Only a room whose vantage point differs from the flag needs to call this; elsewhere the
-    ///         processors already read the one true state. Nothing is lost by intercepting for such a room:
-    ///         a door with a shared flag is one the player cannot work by hand anyway, so these paths never
-    ///         mutate state for it.
-    ///     </para>
-    /// </summary>
-    public InteractionResult? Answer(SimpleIntent action, IContext context)
-    {
-        if (!action.MatchNounAndAdjective(Door.NounsForMatching))
-            return null;
-
-        if (action.MatchVerb(ExamineDoorVerbs))
-            return new PositiveInteractionResult(Door.DescribeAs(IsOpen));
-
-        if (action.MatchVerb(Verbs.OpenVerbs))
-        {
-            if (IsOpen)
-                return new PositiveInteractionResult(Door.AlreadyOpen);
-
-            var refusal = Door.CannotBeOpenedDescription(context);
-            return refusal is null ? null : new PositiveInteractionResult(refusal);
-        }
-
-        if (action.MatchVerb(Verbs.CloseVerbs))
-        {
-            if (!IsOpen)
-                return new PositiveInteractionResult(Door.AlreadyClosed);
-
-            var refusal = Door.CannotBeClosedDescription(context);
-            return refusal is null ? null : new PositiveInteractionResult(refusal);
-        }
-
-        return null;
     }
 }

--- a/Planetfall/Item/Kalamontee/Admin/ElevatorDoorBase.cs
+++ b/Planetfall/Item/Kalamontee/Admin/ElevatorDoorBase.cs
@@ -12,7 +12,9 @@ public abstract class ElevatorDoorBase : ItemBase, IDoor
         return $"The door is {(isOpen ? "open" : "closed")}. ";
     }
 
-    public bool IsOpen { get; set; }
+    // Virtual so a landing door can answer for its own room rather than hold a flag of its own; the
+    // shaft's one open/closed state stays here, on the door inside the car. See ElevatorLandingDoor.
+    public virtual bool IsOpen { get; set; }
 
     public string NowOpen(ILocation currentLocation)
     {
@@ -38,6 +40,6 @@ public abstract class ElevatorDoorBase : ItemBase, IDoor
 
     public string AlreadyClosed => "It is closed. ";
 
-    public bool HasEverBeenOpened { get; set; }
+    public virtual bool HasEverBeenOpened { get; set; }
 
 }

--- a/Planetfall/Item/Kalamontee/Admin/ElevatorLandingDoor.cs
+++ b/Planetfall/Item/Kalamontee/Admin/ElevatorLandingDoor.cs
@@ -1,0 +1,57 @@
+using System.Text.Json.Serialization;
+
+namespace Planetfall.Item.Kalamontee.Admin;
+
+/// <summary>
+///     One shaft's door <i>as it stands in one particular room</i> — the panel in the Elevator Lobby,
+///     or the one at the far end of the shaft. A landing door is a real, distinct object that lives in
+///     exactly one room, but it owns no state of its own: what it reports is the shaft's.
+///     <para>
+///         Before this existed, each shaft had a single door object seeded into two rooms, and the two
+///         <c>Init()</c>s fought over its <see cref="ItemBase.CurrentLocation" /> — the loser could not
+///         resolve the door as an object at all, so <c>enter blue door</c> in the lobby and
+///         <c>examine door</c> at the Tower Core found nothing to act on (issue #532). One object cannot
+///         honestly be in two places; giving each room its own object is what makes
+///         <c>CurrentLocation</c> true again, and with it every scope check built on it.
+///     </para>
+///     <para>
+///         Splitting identity is only safe because state is <i>not</i> split with it:
+///         <see cref="IsOpen" /> reads <see cref="IsOpenHere" /> — this room's vantage point on the one
+///         shaft-wide flag — and writes through to <see cref="ShaftDoor" />. That is what retires the
+///         workaround #505 needed: the lobby used to intercept examine/open/close because the door
+///         object it had reported the raw flag, which is only true from inside the car. A landing door
+///         reports the effective state directly, so the ordinary processors are right again and no room
+///         has to answer for its door by hand.
+///     </para>
+/// </summary>
+public abstract class ElevatorLandingDoor : ElevatorDoorBase
+{
+    /// <summary>
+    ///     The object holding the shaft's one open/closed flag — the door inside the car, which is where
+    ///     the flag lived before the split, so saved games keep pointing at it.
+    /// </summary>
+    protected abstract ElevatorDoorBase ShaftDoor { get; }
+
+    /// <summary>
+    ///     Whether the shaft counts as open <i>from this room</i>: the flag alone cannot say, because it
+    ///     is shared by both ends and the arrival path leaves it open at whichever end the car parked at.
+    ///     Implementations delegate to the car's own <c>IsOpenAtTheLobby</c> / <c>IsOpenAtTheFarEnd</c>.
+    /// </summary>
+    protected abstract bool IsOpenHere { get; }
+
+    // No backing field, and nothing to serialize: the flag belongs to ShaftDoor, which is serialized in
+    // its own right. Writing through means a landing door can never drift from the shaft it shows.
+    [JsonIgnore]
+    public override bool IsOpen
+    {
+        get => IsOpenHere;
+        set => ShaftDoor.IsOpen = value;
+    }
+
+    [JsonIgnore]
+    public override bool HasEverBeenOpened
+    {
+        get => ShaftDoor.HasEverBeenOpened;
+        set => ShaftDoor.HasEverBeenOpened = value;
+    }
+}

--- a/Planetfall/Item/Kalamontee/Admin/ElevatorLandingDoor.cs
+++ b/Planetfall/Item/Kalamontee/Admin/ElevatorLandingDoor.cs
@@ -1,4 +1,4 @@
-using System.Text.Json.Serialization;
+using Newtonsoft.Json;
 
 namespace Planetfall.Item.Kalamontee.Admin;
 
@@ -40,7 +40,15 @@ public abstract class ElevatorLandingDoor : ElevatorDoorBase
     protected abstract bool IsOpenHere { get; }
 
     // No backing field, and nothing to serialize: the flag belongs to ShaftDoor, which is serialized in
-    // its own right. Writing through means a landing door can never drift from the shaft it shows.
+    // its own right. These MUST be Newtonsoft's JsonIgnore, not System.Text.Json's - saves go through
+    // JsonConvert (GameEngine.SaveGame), which ignores the STJ attribute entirely and would happily
+    // write a landing door's derived IsOpen into the blob and then push it back through the setter on
+    // restore, overwriting the shaft flag with this room's view of it.
+    //
+    // Note that get and set are deliberately not inverses: a landing door shows whether the shaft is
+    // open *at this end*, but opening one opens the shaft. Nothing in the game exercises the setter -
+    // ElevatorDoorBase refuses open and close unconditionally - and it exists only to satisfy
+    // IOpenAndClose.
     [JsonIgnore]
     public override bool IsOpen
     {

--- a/Planetfall/Item/Kalamontee/Admin/LowerElevatorLobbyDoor.cs
+++ b/Planetfall/Item/Kalamontee/Admin/LowerElevatorLobbyDoor.cs
@@ -1,0 +1,16 @@
+using GameEngine;
+using Planetfall.Location.Kalamontee;
+
+namespace Planetfall.Item.Kalamontee.Admin;
+
+/// <summary>
+///     The red door as it stands in the Elevator Lobby.
+/// </summary>
+public class LowerElevatorLobbyDoor : ElevatorLandingDoor
+{
+    public override string[] NounsForMatching => ["red door", "door", "elevator door", "lower elevator door"];
+
+    protected override ElevatorDoorBase ShaftDoor => Repository.GetItem<LowerElevatorDoor>();
+
+    protected override bool IsOpenHere => Repository.GetLocation<LowerElevator>().IsOpenAtTheLobby;
+}

--- a/Planetfall/Item/Kalamontee/Admin/LowerElevatorWaitingAreaDoor.cs
+++ b/Planetfall/Item/Kalamontee/Admin/LowerElevatorWaitingAreaDoor.cs
@@ -1,0 +1,17 @@
+using GameEngine;
+using Planetfall.Location.Kalamontee;
+
+namespace Planetfall.Item.Kalamontee.Admin;
+
+/// <summary>
+///     The lower shaft's door at its far end — "to the south is a metal door" in the Waiting Area,
+///     which named a door the player could not touch until this object existed (issue #532).
+/// </summary>
+public class LowerElevatorWaitingAreaDoor : ElevatorLandingDoor
+{
+    public override string[] NounsForMatching => ["metal door", "door", "elevator door", "red door"];
+
+    protected override ElevatorDoorBase ShaftDoor => Repository.GetItem<LowerElevatorDoor>();
+
+    protected override bool IsOpenHere => Repository.GetLocation<LowerElevator>().IsOpenAtTheFarEnd;
+}

--- a/Planetfall/Item/Kalamontee/Admin/UpperElevatorLobbyDoor.cs
+++ b/Planetfall/Item/Kalamontee/Admin/UpperElevatorLobbyDoor.cs
@@ -1,0 +1,16 @@
+using GameEngine;
+using Planetfall.Location.Kalamontee;
+
+namespace Planetfall.Item.Kalamontee.Admin;
+
+/// <summary>
+///     The blue door as it stands in the Elevator Lobby.
+/// </summary>
+public class UpperElevatorLobbyDoor : ElevatorLandingDoor
+{
+    public override string[] NounsForMatching => ["blue door", "door", "elevator door", "upper elevator door"];
+
+    protected override ElevatorDoorBase ShaftDoor => Repository.GetItem<UpperElevatorDoor>();
+
+    protected override bool IsOpenHere => Repository.GetLocation<UpperElevator>().IsOpenAtTheLobby;
+}

--- a/Planetfall/Item/Kalamontee/Admin/UpperElevatorTowerDoor.cs
+++ b/Planetfall/Item/Kalamontee/Admin/UpperElevatorTowerDoor.cs
@@ -1,0 +1,17 @@
+using GameEngine;
+using Planetfall.Location.Kalamontee;
+
+namespace Planetfall.Item.Kalamontee.Admin;
+
+/// <summary>
+///     The upper shaft's door at its far end — "a sliding door leads north" in the Tower Core, which
+///     named a door the player could not touch until this object existed (issue #532).
+/// </summary>
+public class UpperElevatorTowerDoor : ElevatorLandingDoor
+{
+    public override string[] NounsForMatching => ["sliding door", "door", "elevator door", "blue door"];
+
+    protected override ElevatorDoorBase ShaftDoor => Repository.GetItem<UpperElevatorDoor>();
+
+    protected override bool IsOpenHere => Repository.GetLocation<UpperElevator>().IsOpenAtTheFarEnd;
+}

--- a/Planetfall/Location/Kalamontee/ElevatorLobby.cs
+++ b/Planetfall/Location/Kalamontee/ElevatorLobby.cs
@@ -12,16 +12,19 @@ internal class ElevatorLobby : LocationBase
     // must answer from the effective state, never from the shared OPENBIT flag on its own. See
     // ElevatorBase.IsOpenAtTheLobby for why, and issue #505 for what happens when they disagree. Stating
     // each door once as a Doorway is what makes "must" enforceable rather than a convention.
-    private Doorway BlueDoor =>
-        new(GetItem<UpperElevatorDoor>(), () => GetLocation<UpperElevator>().IsOpenAtTheLobby);
+    //
+    // These are the lobby's OWN door objects. The rooms at the two ends of each shaft used to share one,
+    // which meant its CurrentLocation could only ever be true for one of them - so the lobby's doors
+    // fell out of scope and "enter blue door" found nothing to enter (issue #532). A landing door also
+    // reports the effective state as its own IsOpen, which is why nothing here needs a predicate.
+    private Doorway BlueDoor => new(GetItem<UpperElevatorLobbyDoor>());
 
-    private Doorway RedDoor =>
-        new(GetItem<LowerElevatorDoor>(), () => GetLocation<LowerElevator>().IsOpenAtTheLobby);
+    private Doorway RedDoor => new(GetItem<LowerElevatorLobbyDoor>());
 
     public override void Init()
     {
-        StartWithItem<LowerElevatorDoor>();
-        StartWithItem<UpperElevatorDoor>();
+        StartWithItem<LowerElevatorLobbyDoor>();
+        StartWithItem<UpperElevatorLobbyDoor>();
     }
 
     protected override Dictionary<Direction, MovementParameters> Map(IContext context)
@@ -33,7 +36,7 @@ internal class ElevatorLobby : LocationBase
             // Both entrances need the car to be standing at the lobby as well as the door being open
             // (compone.zil, ELEVATOR-ENTER-F tests *-ELEVATOR-UP alongside OPENBIT). The door flag is
             // shared by both ends of the shaft, so on its own it cannot say which floor the car is on.
-            // That two-part test lives in the Doorway, so the exit and the description share it.
+            // That two-part test is the lobby door's own IsOpen, so every surface here shares it.
             { Direction.S, RedDoor.Passage(GetLocation<LowerElevator>(), "The door is closed.") },
             { Direction.N, BlueDoor.Passage(GetLocation<UpperElevator>(), "The door is closed.") }
         };
@@ -42,14 +45,11 @@ internal class ElevatorLobby : LocationBase
     public override async Task<InteractionResult> RespondToSimpleInteraction(SimpleIntent action, IContext context,
         IGenerationClient client, IItemProcessorFactory itemProcessorFactory)
     {
-        // The door object reports the shaft-wide flag, which is only correct from inside the car, so
-        // every verb that reads a door's state has to be answered here instead - otherwise "examine red
-        // door" and "open red door" corroborate a state the room text and the exit both deny (#505).
-        // The bare nouns ("door", "elevator door") never reach this: both doors match them, so
-        // SimpleInteractionEngine disambiguates first.
-        var doorAnswer = BlueDoor.Answer(action, context) ?? RedDoor.Answer(action, context);
-        if (doorAnswer is not null)
-            return doorAnswer;
+        // No door interception here any more. It existed because the door object this room reached
+        // reported the shaft-wide flag, which is only correct from inside the car - so "examine red door"
+        // and "open red door" corroborated a state the room text and the exit both denied (#505). The
+        // lobby now has its own door objects whose IsOpen *is* the lobby's answer, so the ordinary
+        // examine / open / close processors are correct again and the room says nothing twice (#532).
 
         if (action.Match(Verbs.PushVerbs, ["button", "elevator button"]))
             return new DisambiguationInteractionResult("Which button do you mean, the red button or the blue button",

--- a/Planetfall/Location/Kalamontee/Tower/TowerCore.cs
+++ b/Planetfall/Location/Kalamontee/Tower/TowerCore.cs
@@ -1,18 +1,26 @@
 using GameEngine.Location;
+using Model.AIGeneration;
 using Planetfall.Item.Kalamontee.Admin;
 
 namespace Planetfall.Location.Kalamontee.Tower;
 
-internal class TowerCore : LocationWithNoStartingItems
+internal class TowerCore : LocationBase
 {
     public override string Name => "Tower Core";
 
     // This is the far end of the upper shaft, so the entrance needs the same two-part test the Waiting
     // Area uses on the lower one: the door open *and* the car standing at this end. A bare
     // Go<UpperElevator>() let you walk into a car parked down at the lobby, because the door flag is
-    // shared by both ends of the shaft (issue #505).
-    private Doorway Door =>
-        new(Repository.GetItem<UpperElevatorDoor>(), () => GetLocation<UpperElevator>().IsOpenAtTheFarEnd);
+    // shared by both ends of the shaft (issue #505). That test is the tower door's own IsOpen.
+    private Doorway Door => new(GetItem<UpperElevatorTowerDoor>());
+
+    // The room's description names this door ("a sliding door leads north"), so the room has to have
+    // one. It never did - the shaft's single door object was owned by the car and the lobby - so
+    // "examine door" and "enter door" up here resolved to nothing at all (issue #532).
+    public override void Init()
+    {
+        StartWithItem<UpperElevatorTowerDoor>();
+    }
 
     protected override Dictionary<Direction, MovementParameters> Map(IContext context)
     {
@@ -33,7 +41,7 @@ internal class TowerCore : LocationWithNoStartingItems
             "This is a small, circular room. A sliding door leads north, and a spiral staircase heads " +
             "upwards. Other exits lie to the northeast and southwest.";
     }
-    
+
     protected override void OnFirstTimeEnterLocation(IContext context)
     {
         context.AddPoints(4);

--- a/Planetfall/Location/Shuttle/WaitingArea.cs
+++ b/Planetfall/Location/Shuttle/WaitingArea.cs
@@ -4,7 +4,7 @@ using Planetfall.Location.Kalamontee;
 
 namespace Planetfall.Location.Shuttle;
 
-public class WaitingArea : LocationWithNoStartingItems
+public class WaitingArea : LocationBase
 {
     public override string Name => "Waiting Area";
 
@@ -13,9 +13,17 @@ public class WaitingArea : LocationWithNoStartingItems
     // The original gates this entrance on the door being open *and* the car actually being at this end
     // of the shaft (compone.zil, OTHER-ELEVATOR-ENTER-F, which also makes the door the implicit "it" -
     // hence the Doorway's GatingItem). A bare Go<LowerElevator>() let you walk into a car parked up at
-    // the lobby, and then be sealed in, since the car's own exits gate on the door.
-    private Doorway Door =>
-        new(Repository.GetItem<LowerElevatorDoor>(), () => GetLocation<LowerElevator>().IsOpenAtTheFarEnd);
+    // the lobby, and then be sealed in, since the car's own exits gate on the door. That two-part test
+    // is the waiting area door's own IsOpen.
+    private Doorway Door => new(GetItem<LowerElevatorWaitingAreaDoor>());
+
+    // The room's description names this door ("to the south is a metal door"), so the room has to have
+    // one. It never did - the shaft's single door object was owned by the car and the lobby - so
+    // "examine door" and "enter door" here resolved to nothing at all (issue #532).
+    public override void Init()
+    {
+        StartWithItem<LowerElevatorWaitingAreaDoor>();
+    }
 
     protected override Dictionary<Direction, MovementParameters> Map(IContext context)
     {

--- a/Planetfall/PlanetfallGame.cs
+++ b/Planetfall/PlanetfallGame.cs
@@ -1,6 +1,11 @@
+using GameEngine.Location;
 using Planetfall.GlobalCommand;
 using Planetfall.Item.Feinstein;
+using Planetfall.Item.Kalamontee.Admin;
 using Planetfall.Item.Kalamontee.Mech.FloydPart;
+using Planetfall.Location.Kalamontee;
+using Planetfall.Location.Kalamontee.Tower;
+using Planetfall.Location.Shuttle;
 
 namespace Planetfall;
 
@@ -117,4 +122,47 @@ public class PlanetfallGame : IInfocomGame
     }
 
     public string SystemPromptSecretKey => "PlanetfallPrompt";
+
+    /// <summary>
+    ///     Re-seats the elevator shaft doors, for sessions saved before each room got its own (#532).
+    /// </summary>
+    /// <remarks>
+    ///     Until #532 a shaft had one door object seeded into two rooms, so a blob written by an older
+    ///     build has the shared <c>UpperElevatorDoor</c> / <c>LowerElevatorDoor</c> sitting in the
+    ///     Elevator Lobby's <c>Items</c>, and nothing at all in the Tower Core or the Waiting Area.
+    ///     Restored as-is, the lobby's verbs would find that shared door — <c>LocationBase</c> routes over
+    ///     <c>Items</c> without a scope check — and it reports the raw shaft flag, which is only true from
+    ///     inside the car. That is #505 all over again, and permanently: the stateless deployment
+    ///     rehydrates from the blob every turn, so an in-flight game would never heal itself. Verified by
+    ///     restoring a pre-split blob: <c>examine blue door</c> answered "The door is open." on the same
+    ///     turn <c>north</c> answered "The door is closed."
+    ///     <para>
+    ///         Only the three landing rooms are touched. The car keeps the shaft door, which is still
+    ///         where the one open/closed flag lives, so no state is migrated — only which object stands in
+    ///         which room. Idempotent, so it is harmless on an already-current blob.
+    ///     </para>
+    /// </remarks>
+    public void AfterRestore(IContext context)
+    {
+        ReseatDoors(Repository.GetLocation<ElevatorLobby>(),
+            Repository.GetItem<UpperElevatorLobbyDoor>(), Repository.GetItem<LowerElevatorLobbyDoor>());
+        ReseatDoors(Repository.GetLocation<TowerCore>(), Repository.GetItem<UpperElevatorTowerDoor>());
+        ReseatDoors(Repository.GetLocation<WaitingArea>(), Repository.GetItem<LowerElevatorWaitingAreaDoor>());
+    }
+
+    /// <summary>
+    ///     Makes <paramref name="doors" /> exactly the elevator doors standing in <paramref name="room" />,
+    ///     evicting any other the restored blob left there.
+    /// </summary>
+    private static void ReseatDoors(LocationBase room, params ElevatorDoorBase[] doors)
+    {
+        // An older blob left the shared shaft door here. It belongs to the car now, and its
+        // CurrentLocation is owned by whichever room legitimately holds it, so only drop it from this
+        // room's contents - never touch the door object itself, and never touch the shaft's flag.
+        foreach (var stale in room.Items.OfType<ElevatorDoorBase>().Except(doors).ToList())
+            room.RemoveItem(stale);
+
+        foreach (var door in doors.Where(door => !room.Items.Contains(door)))
+            room.ItemPlacedHere(door);
+    }
 }

--- a/UnitTests/IntentEngine/SimpleInteractionEngineTests.cs
+++ b/UnitTests/IntentEngine/SimpleInteractionEngineTests.cs
@@ -236,57 +236,70 @@ public class SimpleInteractionEngineTests
     }
 
 
+    /// <summary>
+    ///     The ambiguity check itself now lives in <see cref="NounDisambiguator" />, shared with the
+    ///     multi-noun and enter/exit engines (issue #532) - so these call it directly rather than
+    ///     reaching into SimpleInteractionEngine by reflection.
+    /// </summary>
     [TestFixture]
     public class CheckDisambiguationMethod : SimpleInteractionEngineTests
     {
         [Test]
         public void Should_ReturnNull_When_NoAmbiguousItems()
         {
-            // Arrange
             var intent = new SimpleIntent { Verb = "take", Noun = "sword" };
-            
+
             var sword = new Mock<IItem>();
-            sword.Setup(i => i.NounsForMatching).Returns(new[] { "sword", "blade" });
-            sword.Setup(i => i.NounsForPreciseMatching).Returns(new[] { "sword", "blade" });
+            sword.Setup(i => i.NounsForMatching).Returns(["sword", "blade"]);
+            sword.Setup(i => i.NounsForPreciseMatching).Returns(["sword", "blade"]);
 
-            var items = new List<IItem> { sword.Object };
-            _mockContext.Setup(c => c.GetAllItemsRecursively).Returns(items);
+            _mockContext.Setup(c => c.GetAllItemsRecursively).Returns([sword.Object]);
 
-            // Use reflection to call the private method
-            var method = typeof(SimpleInteractionEngine).GetMethod("CheckDisambiguation",
-                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            var result = NounDisambiguator.Check(intent.MatchNounAndAdjective, _mockContext.Object, "take {0}");
 
-            // Act
-            var result = method!.Invoke(_engine, new object[] { intent, _mockContext.Object });
-
-            // Assert
             result.Should().BeNull();
         }
 
         [Test]
         public void Should_ReturnNull_When_OnlyOneItemMatches()
         {
-            // Arrange
             var intent = new SimpleIntent { Verb = "take", Noun = "sword" };
-            
+
             var sword = new Mock<IItem>();
-            sword.Setup(i => i.NounsForMatching).Returns(new[] { "sword", "blade" });
+            sword.Setup(i => i.NounsForMatching).Returns(["sword", "blade"]);
 
             var dagger = new Mock<IItem>();
-            dagger.Setup(i => i.NounsForMatching).Returns(new[] { "dagger", "knife" });
+            dagger.Setup(i => i.NounsForMatching).Returns(["dagger", "knife"]);
 
-            var items = new List<IItem> { sword.Object, dagger.Object };
-            _mockContext.Setup(c => c.GetAllItemsRecursively).Returns(items);
+            _mockContext.Setup(c => c.GetAllItemsRecursively).Returns([sword.Object, dagger.Object]);
 
-            // Use reflection to call the private method
-            var method = typeof(SimpleInteractionEngine).GetMethod("CheckDisambiguation",
-                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            var result = NounDisambiguator.Check(intent.MatchNounAndAdjective, _mockContext.Object, "take {0}");
 
-            // Act
-            var result = method!.Invoke(_engine, new object[] { intent, _mockContext.Object });
-
-            // Assert
             result.Should().BeNull();
+        }
+
+        [Test]
+        public void Should_AskWhichOne_When_TwoItemsAnswerToTheSameNoun()
+        {
+            var intent = new SimpleIntent { Verb = "take", Noun = "door" };
+
+            var red = new Mock<IItem>();
+            red.Setup(i => i.NounsForMatching).Returns(["door", "red door"]);
+            red.Setup(i => i.NounsForPreciseMatching).Returns(["door", "red door"]);
+
+            var blue = new Mock<IItem>();
+            blue.Setup(i => i.NounsForMatching).Returns(["door", "blue door"]);
+            blue.Setup(i => i.NounsForPreciseMatching).Returns(["door", "blue door"]);
+
+            _mockContext.Setup(c => c.GetAllItemsRecursively).Returns([red.Object, blue.Object]);
+
+            var result = NounDisambiguator.Check(intent.MatchNounAndAdjective, _mockContext.Object, "take {0}");
+
+            result.Should().NotBeNull();
+            result!.InteractionMessage.Should().Contain("red door");
+            result.InteractionMessage.Should().Contain("blue door");
+            // The reply has to name one item unambiguously, or we would loop forever asking.
+            result.PossibleResponses["door"].Should().BeOneOf("red door", "blue door");
         }
     }
 

--- a/UnitTests/IntentMappings/base-mappings.json
+++ b/UnitTests/IntentMappings/base-mappings.json
@@ -57,6 +57,8 @@
     { "inputs": ["close red door"], "verb": "close", "noun": "red door" },
     { "inputs": ["examine red door"], "verb": "examine", "noun": "red door" },
     { "inputs": ["examine blue door"], "verb": "examine", "noun": "blue door" },
+    { "inputs": ["examine sliding door"], "verb": "examine", "noun": "sliding door" },
+    { "inputs": ["examine metal door"], "verb": "examine", "noun": "metal door" },
     { "inputs": ["open elevator door"], "verb": "open", "noun": "elevator door" },
     { "inputs": ["open blue door"], "verb": "open", "noun": "blue door" },
     { "inputs": ["close blue door"], "verb": "close", "noun": "blue door" },

--- a/UnitTests/IntentMappings/base-mappings.json
+++ b/UnitTests/IntentMappings/base-mappings.json
@@ -359,6 +359,8 @@
     { "inputs": ["enter pod", "board pod", "enter the pod", "board the pod"], "noun": "pod" },
     { "inputs": ["enter bulkhead", "board bulkhead"], "noun": "bulkhead" },
     { "inputs": ["enter door", "board door"], "noun": "door" },
+    { "inputs": ["enter blue door", "board blue door"], "noun": "blue door" },
+    { "inputs": ["enter red door", "board red door"], "noun": "red door" },
 
     { "inputs": ["enter helicopter", "board helicopter", "enter the helicopter"], "noun": "helicopter" },
     { "inputs": ["enter vehicle", "board vehicle", "enter the vehicle"], "noun": "vehicle" },

--- a/UnitTests/IntentMappings/base-mappings.json
+++ b/UnitTests/IntentMappings/base-mappings.json
@@ -363,6 +363,8 @@
     { "inputs": ["enter door", "board door"], "noun": "door" },
     { "inputs": ["enter blue door", "board blue door"], "noun": "blue door" },
     { "inputs": ["enter red door", "board red door"], "noun": "red door" },
+    { "inputs": ["enter upper elevator door"], "noun": "upper elevator door" },
+    { "inputs": ["enter lower elevator door"], "noun": "lower elevator door" },
 
     { "inputs": ["enter helicopter", "board helicopter", "enter the helicopter"], "noun": "helicopter" },
     { "inputs": ["enter vehicle", "board vehicle", "enter the vehicle"], "noun": "vehicle" },


### PR DESCRIPTION
Fixes #532.

## The bug

Each elevator shaft had a single door object seeded into two rooms, so `ElevatorLobby.Init` and `ElevatorBase.Init` fought over its `CurrentLocation` and the loser could not resolve it as an object at all.

Merely **looking at the lobby** is enough to trigger it: `ElevatorLobby.Map` names both cars, `Repository.GetLocation` `Init`s on first request, and each car's `Init` then takes ownership of the lobby's door. From there `Repository.GetItemInScope` rejects it, because `IsItemAccessible` tests `item.CurrentLocation == context.CurrentLocation` (`GameEngine/Repository.cs:214`). Verified white-box — after one `look` in the lobby, `GetItemInScope("blue door", ctx)` returns `null` and the door's `CurrentLocation` reads *Upper Elevator*.

The far ends of the two shafts were a stronger version of the same thing: `TowerCore` and `WaitingArea` both name a door in their own description ("A sliding door leads north", "to the south is a metal door") and never seeded one, so nothing there could resolve `door` at all.

## The fix

One object cannot honestly be in two places, so **split identity and share state** — option (1) in the issue.

Each room gets its own landing door (`UpperElevatorLobbyDoor`, `UpperElevatorTowerDoor`, `LowerElevatorLobbyDoor`, `LowerElevatorWaitingAreaDoor`). A landing door holds no state: its `IsOpen` reads that room's vantage point on the shaft — the `IsOpenAtTheLobby` / `IsOpenAtTheFarEnd` predicates from #505 — and writes through to the car's door, which keeps holding the shaft's one flag.

## Relationship to the 2.0.6 elevator refactor

#510 (issue #505) established that every lobby surface must answer from the car's effective position; #530 (issue #523) made each room state its door exactly once, as a `Doorway`. #530 deliberately did not change object identity, which is what left #532 open.

Both of those carry a workaround for the same root cause — one door object standing in two rooms, so its raw flag means the wrong thing in one of them:

- `Doorway`'s `isOpenHere` override
- the lobby's `RespondToSimpleInteraction` intercepting `examine` / `open` / `close`

Once each room has its own door, that door's raw state **is** its room's answer, the ordinary examine/open/close processors are correct again, and both workarounds are unreachable. This PR removes them, along with `Doorway.Answer`. A room that intercepts its own door's verbs is stating it twice, which is the thing the `Doorway` refactor set out to stop — so `Doorway` now takes a door and nothing else, and its doc records why there is no override.

## What changes for the player

| Command | Where | Before | After |
|---|---|---|---|
| `enter blue door` | lobby, car standing here | narrator refusal, stays put | walks into the car |
| `enter door` | lobby (two doors) | silently picked the red one | "Do you mean...?" |
| `examine door` | Tower Core / Waiting Area | nothing resolved | reports the shaft state **from this end** |
| `open door` | Tower Core / Waiting Area | nothing resolved | "It won't budge." |

## Review round: three further defects, all fixed

**1. Pre-split saves reintroduced #505 — the serious one.** A location's `Init()` never runs again on restore; the saved `Items` list *is* the room's contents. So a blob written before the split still has the shared `UpperElevatorDoor` sitting in the lobby, and nothing at all in the far-end rooms. `LocationBase` routes verbs over `Items` with no scope check, so the lobby found that shared door and it reported the raw shaft flag: `examine blue door` → "The door is open." on the same turn `north` → "The door is closed." Permanently, too — the stateless deployment rehydrates from the blob every turn, so an in-flight session would never heal itself.

Added `IInfocomGame.AfterRestore(IContext)` — a no-op by default, called from `RestoreGame` once the saved Repository state is installed — and implemented it in `PlanetfallGame` to re-seat the elevator doors. Only *which object stands in which room* is migrated; the shaft's flag still lives on the car's door, so no state is touched. Idempotent, since it also runs on current blobs.

**2. Wrong `JsonIgnore`.** It was `System.Text.Json`'s, but saves go through Newtonsoft (`JsonConvert`). Newtonsoft ignored it, so the blob really did carry a landing door's derived `IsOpen` and pushed it back through the write-through setter on restore — benign only because `Repository.Restore` discards the instance it lands on. Now Newtonsoft's attribute, pinned by a test that serializes a landing door and asserts it emits no state.

**3. `enter door` didn't disambiguate.** `GetItemInScope` returns the first match, and the enter/exit engines resolved straight through it — so the lobby asked "Do you mean...?" for `examine door` but silently picked one for `enter door`, refusing while citing the red door on a turn the room described an open blue one. The check was private and duplicated in `SimpleInteractionEngine` and `MultiNounEngine`, which is exactly why the engines without a copy never asked; extracted to `NounDisambiguator` and called from all four. Guarded both sides of the `Union` while extracting — the enter/exit unit tests mock `IContext` without `GetAllItemsRecursively`, and `Union` throws on a null argument as well as a null receiver.

## Tests

23 new tests. Every reproduction was confirmed red before its fix and green after — verified by stashing the production files (for the original bug) and by disabling each fix in place (for the review round).

The scope tests assert on the **resolved door's own state** rather than its type — that is what catches the load-order variant the issue describes, where `"blue door"` silently resolves to the *red* door because the bare noun `"door"` is contained in `"blue door"`. No wording-level test can see that.

Two pre-existing tests changed:
- `ExamineDoor_EveryVerbTheExamineProcessorAnswers_...` passed `null!` as the item-processor factory, which worked only because the lobby intercepted before reaching the item. It now passes a real factory and exercises the same guarantee through the processors — and passes against both old and new production code.
- The two reflection-based tests of `SimpleInteractionEngine`'s private `CheckDisambiguation` now call `NounDisambiguator` directly, plus a new test for the ambiguous case they never covered (they only asserted the null paths).

Added to the deterministic test parser's mappings: `enter blue door` / `enter red door` (the phrasing the lobby's description invites), the two far-end doors' primary nouns `sliding door` / `metal door` — which nothing exercised — and the disambiguation follow-ups.

**Full run: 6,853 tests pass** (Planetfall.Tests 3914, ZorkOne.Tests 1782, UnitTests 1131, Console.Tests 16, EscapeRoom.Tests 9), solution builds clean.

## The issue's "also noticed" item — investigated, not a production bug

`push red door` summoning the car is a **test-harness artifact**. `TestParser` truncates the noun to the second word (`words[1]`), so `"push red door"` parses as `Noun="red"`, which then matches the bare `"red"` in the red call button's list. `SimpleIntent.MatchNoun` is exact equality, so a real parse of that input — `Noun="red door"`, or `Adjective="red"` / `Noun="door"` — never equals `"red"`.

Narrowing the noun list would cost the bare `press red` phrasing to fix nothing, so the call button's nouns are left alone. Worth knowing that the harness can manufacture symptoms this way.

## Docs

`CLAUDE.md`'s anti-pattern #4 (shared-instance scope corruption) previously recorded only the narrator fallback from #282, which stops the blank line but leaves the object out of scope for every other verb. Added the actual resolution pattern — split identity, share state — with this change as the worked example.