### PR TITLE
Fix #484: stop the shared hint solver prompt hardcoding Planetfall

### DIFF
--- a/Model/Hints/HintLlm.cs
+++ b/Model/Hints/HintLlm.cs
@@ -4,8 +4,26 @@ namespace Model.Hints;
 // Model.AIGeneration) so both the engine (GameEngine.Hints) and the OpenAI implementation
 // (ZorkAI.OpenAI) can see it without a project-reference cycle.
 
-/// <summary>The voice both LLM calls speak in. v1: one snarky-narrator persona for all games.</summary>
-public sealed record HintPersona(string SystemPrompt);
+/// <summary>
+///     The voice both LLM calls speak in (v1: one snarky-narrator persona per game), plus the small amount
+///     of game identity the shared solver prompt needs. <see cref="IHintLanguageModel" /> implementations
+///     live in a shared library, so anything game-specific — which game this is, and which flags of the
+///     player's situation actually change an answer — must arrive here rather than be hardcoded there.
+/// </summary>
+/// <param name="SystemPrompt">The persona's voice, used verbatim by the revealer (LLM 2).</param>
+/// <param name="GameName">
+///     The game being solved, as the player would name it (e.g. "Planetfall"). Defaults to a neutral phrase
+///     so an un-customized persona asserts no game identity at all.
+/// </param>
+/// <param name="StateGrounding">
+///     A short, game-specific list of what the player's situation contains and what actually matters in it
+///     (e.g. "what's done, Floyd alive/dead, their health") — grounding for the solver, never an excuse to
+///     dodge the question.
+/// </param>
+public sealed record HintPersona(
+    string SystemPrompt,
+    string GameName = "this text adventure",
+    string StateGrounding = "what they have done so far, and their current condition");
 
 /// <summary>One turn of the hint conversation — what the player asked and what was revealed back.</summary>
 public sealed record HintExchange(string Question, string Revealed);

--- a/Model/Hints/HintLlm.cs
+++ b/Model/Hints/HintLlm.cs
@@ -12,8 +12,9 @@ namespace Model.Hints;
 /// </summary>
 /// <param name="SystemPrompt">The persona's voice, used verbatim by the revealer (LLM 2).</param>
 /// <param name="GameName">
-///     The game being solved, as the player would name it (e.g. "Planetfall"). Defaults to a neutral phrase
-///     so an un-customized persona asserts no game identity at all.
+///     The game being solved, as the player would name it (e.g. "Planetfall"). Empty by default: an
+///     un-customized persona asserts no game identity at all, and the prompt drops the naming clause
+///     rather than substituting a placeholder.
 /// </param>
 /// <param name="StateGrounding">
 ///     A short, game-specific list of what the player's situation contains and what actually matters in it
@@ -22,7 +23,7 @@ namespace Model.Hints;
 /// </param>
 public sealed record HintPersona(
     string SystemPrompt,
-    string GameName = "this text adventure",
+    string GameName = "",
     string StateGrounding = "what they have done so far, and their current condition");
 
 /// <summary>One turn of the hint conversation — what the player asked and what was revealed back.</summary>

--- a/Planetfall.Tests/Hints/PlanetfallHintProviderTests.cs
+++ b/Planetfall.Tests/Hints/PlanetfallHintProviderTests.cs
@@ -37,6 +37,17 @@ public class PlanetfallHintProviderTests : EngineTestsBase
     }
 
     [Test]
+    public void Persona_CarriesTheGameIdentityAndStateGrounding()
+    {
+        // The shared solver prompt is game-agnostic; Planetfall's identity and the flags that matter to it
+        // (Floyd alive/dead, health) travel on the persona, not baked into ZorkAI.OpenAI (issue #484).
+        var persona = Provider().Persona;
+        persona.GameName.Should().Be(new PlanetfallGame().GameName);
+        persona.StateGrounding.Should().Contain("Floyd");
+        persona.SystemPrompt.Should().Contain("narrator");
+    }
+
+    [Test]
     public void DescribePlayerContext_LeadsWithKeyState_ThenFullSaveGame()
     {
         var context = Provider().DescribePlayerContext(Context);

--- a/Planetfall/Hints/PlanetfallHintProvider.cs
+++ b/Planetfall/Hints/PlanetfallHintProvider.cs
@@ -23,9 +23,16 @@ public sealed class PlanetfallHintProvider : IHintProvider
 
     public string Docs => Knowledge.Value;
 
+    // The game's identity and its decision-critical flags ride on the persona: the hint LLM implementation
+    // is shared by every game, so it can't know either of them (#484). GameName comes off the game itself
+    // rather than a second copy of the string here.
     public HintPersona Persona => new(
         "You are the invisible, incorporeal narrator of the Infocom game Planetfall — dry, lightly " +
-        "sarcastic, in character. Never mention being an AI; never break the fourth wall about 'hints'.");
+        "sarcastic, in character. Never mention being an AI; never break the fourth wall about 'hints'.",
+        Game.GameName,
+        "what's done, Floyd alive/dead, their health");
+
+    private static readonly PlanetfallGame Game = new();
 
     public IReadOnlyList<IProactiveRule> ProactiveRules { get; } = new IProactiveRule[]
     {

--- a/UnitTests/OpenAIClientBehaviorTests.cs
+++ b/UnitTests/OpenAIClientBehaviorTests.cs
@@ -306,6 +306,9 @@ public class OpenAiHintLanguageModelBehaviorTests
         var system = messages![0].Content[0].Text;
         system.Should().NotContain("Planetfall");
         system.Should().NotContain("Floyd");
+        // ...and the sentence must still read as English: no game identity means the naming clause is
+        // dropped entirely, not filled with a placeholder ("the text-adventure game this text adventure").
+        system.Should().StartWith("You are the SOLVER stage of a hint system for a text adventure.");
     }
 
     [Test]

--- a/UnitTests/OpenAIClientBehaviorTests.cs
+++ b/UnitTests/OpenAIClientBehaviorTests.cs
@@ -267,6 +267,48 @@ public class OpenAiHintLanguageModelBehaviorTests
     }
 
     [Test]
+    public async Task Solve_SystemPrompt_NamesThePersonasGame_NotAHardcodedOne()
+    {
+        // ZorkAI.OpenAI is shared by every game. The solver prompt must take the game's identity and its
+        // state-grounding language from the persona, or every non-Planetfall game gets a system prompt
+        // asserting it IS Planetfall and talking about Floyd (issue #484).
+        IReadOnlyList<ChatMessage>? messages = null;
+        var completion = new Mock<IChatCompletionClient>();
+        completion.Setup(c => c.CompleteChatAsync(It.IsAny<IReadOnlyList<ChatMessage>>(),
+                It.IsAny<ChatCompletionOptions>()))
+            .Callback<IReadOnlyList<ChatMessage>, ChatCompletionOptions>((m, _) => messages = m)
+            .ReturnsAsync("Open it with the key.");
+        var target = new OpenAiHintLanguageModel(null, completion.Object);
+
+        await target.Solve("zork docs", "west of house", [], "How do I open the door?",
+            new HintPersona("Be dry.", "Zork I", "which treasures are in the trophy case, whether the thief lives"));
+
+        var system = messages![0].Content[0].Text;
+        system.Should().Contain("Zork I");
+        system.Should().Contain("trophy case");
+        system.Should().NotContain("Planetfall");
+        system.Should().NotContain("Floyd");
+    }
+
+    [Test]
+    public async Task Solve_SystemPrompt_WithDefaultPersona_NamesNoGameAtAll()
+    {
+        IReadOnlyList<ChatMessage>? messages = null;
+        var completion = new Mock<IChatCompletionClient>();
+        completion.Setup(c => c.CompleteChatAsync(It.IsAny<IReadOnlyList<ChatMessage>>(),
+                It.IsAny<ChatCompletionOptions>()))
+            .Callback<IReadOnlyList<ChatMessage>, ChatCompletionOptions>((m, _) => messages = m)
+            .ReturnsAsync("Something.");
+        var target = new OpenAiHintLanguageModel(null, completion.Object);
+
+        await target.Solve("docs", "somewhere", [], "What now?", new HintPersona("Be dry."));
+
+        var system = messages![0].Content[0].Text;
+        system.Should().NotContain("Planetfall");
+        system.Should().NotContain("Floyd");
+    }
+
+    [Test]
     public async Task Reveal_WhenProviderFails_ReturnsCompleteSolution()
     {
         var completion = new Mock<IChatCompletionClient>();

--- a/ZorkAI.OpenAI/OpenAiHintLanguageModel.cs
+++ b/ZorkAI.OpenAI/OpenAiHintLanguageModel.cs
@@ -35,8 +35,15 @@ public sealed class OpenAiHintLanguageModel : OpenAIClientBase, IHintLanguageMod
         // This class is shared by every game, so the solver scaffolding below must stay generic: the game's
         // identity and the flags that matter in its state come from the persona. Hardcoding them here told
         // Zork/EscapeRoom they were playing Planetfall, and grounded them on Floyd (#484).
+        // Name the game only when the persona actually supplies one — an unnamed game drops the clause
+        // rather than filling it with a placeholder, which would read "...the text-adventure game this
+        // text adventure."
+        var game = string.IsNullOrWhiteSpace(persona.GameName)
+            ? "a text adventure"
+            : $"the text-adventure game {persona.GameName}";
+
         var system =
-            $"You are the SOLVER stage of a hint system for the text-adventure game {persona.GameName}. Work out the " +
+            $"You are the SOLVER stage of a hint system for {game}. Work out the " +
             "COMPLETE, correct answer to the player's question, using ONLY the knowledge base and their situation.\n" +
             "RESOLVE FOLLOW-UPS: the player may be continuing a thread. If their new question is elliptical " +
             "('how do I open it?', 'more', 'is it serious?'), use the conversation so far to figure out what " +

--- a/ZorkAI.OpenAI/OpenAiHintLanguageModel.cs
+++ b/ZorkAI.OpenAI/OpenAiHintLanguageModel.cs
@@ -32,8 +32,11 @@ public sealed class OpenAiHintLanguageModel : OpenAIClientBase, IHintLanguageMod
     {
         if (!HasApiKey) return string.Empty;
 
-        const string system =
-            "You are the SOLVER stage of a hint system for the text-adventure game Planetfall. Work out the " +
+        // This class is shared by every game, so the solver scaffolding below must stay generic: the game's
+        // identity and the flags that matter in its state come from the persona. Hardcoding them here told
+        // Zork/EscapeRoom they were playing Planetfall, and grounded them on Floyd (#484).
+        var system =
+            $"You are the SOLVER stage of a hint system for the text-adventure game {persona.GameName}. Work out the " +
             "COMPLETE, correct answer to the player's question, using ONLY the knowledge base and their situation.\n" +
             "RESOLVE FOLLOW-UPS: the player may be continuing a thread. If their new question is elliptical " +
             "('how do I open it?', 'more', 'is it serious?'), use the conversation so far to figure out what " +
@@ -45,7 +48,7 @@ public sealed class OpenAiHintLanguageModel : OpenAIClientBase, IHintLanguageMod
             "redirect them to a different task or item.\n" +
             "- Only if they ask an open-ended question ('what do I do?', 'I'm stuck', 'where next?') should you use " +
             "their current next step from the situation.\n" +
-            "Use the player's situation (what's done, Floyd alive/dead, their health) as grounding/background — to " +
+            $"Use the player's situation ({persona.StateGrounding}) as grounding/background — to " +
             "make the answer accurate, NEVER as an excuse to dodge the question. This output is internal reasoning " +
             "for a second stage (not shown to the player) — be specific and complete. Never invent facts beyond the " +
             "knowledge base; if it isn't covered, say so.";


### PR DESCRIPTION
Fixes #484.

## The leak

`ZorkAI.OpenAI` is a shared library, but `OpenAiHintLanguageModel.Solve` built a SOLVER system prompt that asserted the game **is Planetfall** and grounded on Planetfall state:

- `ZorkAI.OpenAI/OpenAiHintLanguageModel.cs:36` — `"...hint system for the text-adventure game Planetfall."`
- `ZorkAI.OpenAI/OpenAiHintLanguageModel.cs:48` — `"...(what's done, Floyd alive/dead, their health)..."`

Any other game routed through the `IHintLanguageModel` seam — Zork I/II, EscapeRoom — got the wrong game identity and grounding on an NPC that doesn't exist in it.

## The fix

Parameterize the two game-specific bits via `HintPersona`, which already travels into both tiers; the generic solver/reveal scaffolding stays in the shared class.

- `HintPersona` gains `GameName` and `StateGrounding`, both optional so existing single-argument call sites keep compiling and simply stop claiming to be Planetfall.
  - `GameName` defaults to empty, and the solver **drops the naming clause entirely** when no game is supplied (`"...a hint system for a text adventure."`) rather than substituting a placeholder.
  - `StateGrounding` defaults to neutral phrasing — what the player has done, and their current condition.
- `PlanetfallHintProvider` supplies both, taking `GameName` off `PlanetfallGame` rather than repeating the literal, so Planetfall's own prompt is byte-for-byte what it was.

## Tests (TDD)

Each test was written first and confirmed red on its assertion diff, then green after the fix.

- `UnitTests/OpenAIClientBehaviorTests.cs`
  - `Solve_SystemPrompt_NamesThePersonasGame_NotAHardcodedOne` — with a Zork-flavored persona, the captured system message names *that* game and grounding, and contains neither `Planetfall` nor `Floyd`.
  - `Solve_SystemPrompt_WithDefaultPersona_NamesNoGameAtAll` — the default persona leaks nothing game-specific, and the sentence still reads as English.
- `Planetfall.Tests/Hints/PlanetfallHintProviderTests.cs`
  - `Persona_CarriesTheGameIdentityAndStateGrounding` — Planetfall still carries its own name and the Floyd/health grounding, now from the provider.

## Verification

`main` merged in; `dotnet build Zork.sln` clean (0 errors), and every suite exercising the changed code passes against the updated base:

| Suite | Result |
| --- | --- |
| `UnitTests` | 1133 passed, 0 failed |
| `Planetfall.Tests` | 3924 passed, 0 failed |
| `ZorkOne.Tests` | 1782 passed, 0 failed |
| `EscapeRoom.Tests` | 9 passed, 0 failed |