### PR TITLE
Fix #538: stop dropping prepositional multi-noun commands at the parser

### DIFF
--- a/IntegrationTests/OpenAIParserTests.cs
+++ b/IntegrationTests/OpenAIParserTests.cs
@@ -537,4 +537,48 @@ public class OpenAIParserTests
         var simpleIntent = intent as SimpleIntent;
         simpleIntent!.Noun.Should().Be("rug");
     }
+
+    /// <summary>
+    ///     Issue #538. The prepositional walkthrough commands ("set dial to 419", "slide card through
+    ///     slot", "put bedistor in panel") intermittently reached no handler in production — roughly
+    ///     20-40% of the time — because gpt-4o omits the &lt;preposition&gt; tag on some runs of the
+    ///     SAME input, and the parser then substituted "with". The deterministic repair lives in
+    ///     <c>ParsingHelper</c> and is proved by <c>ParsingHelperTests</c> and
+    ///     <c>Planetfall.Tests.LiveParserShapeTests</c>; this test is the live counterpart, run against
+    ///     the real model several times over so a future prompt or model change that reintroduces the
+    ///     instability is visible here rather than in a player's session.
+    /// </summary>
+    [Test]
+    [TestCase("set dial to 419", "set", "dial", "419", "to")]
+    [TestCase("set laser to 1", "set", "laser", "1", "to")]
+    [TestCase("slide teleportation card through slot", "slide", "card", "slot", "through")]
+    public async Task MultiNounShapeIsStableAcrossRepeatedRuns(string input, string verb, string nounOne,
+        string nounTwo, string preposition)
+    {
+        const int runs = 5;
+
+        string locationObjectDescription;
+        lock (_lockObject)
+        {
+            Repository.Reset();
+            var locationObject = (ILocation)Activator.CreateInstance(typeof(RecArea))!;
+            locationObjectDescription = locationObject.GetDescription(Mock.Of<IContext>());
+        }
+
+        var target = new OpenAIParser(null);
+
+        for (var run = 1; run <= runs; run++)
+        {
+            var intent = await target.AskTheAIParser(input, locationObjectDescription, string.Empty);
+            Console.WriteLine($"Run {run}: {intent.Message}");
+
+            intent.Should().BeOfType<MultiNounIntent>($"run {run} of '{input}' must produce a two-noun intent");
+            var multiNoun = (MultiNounIntent)intent;
+
+            multiNoun.Verb.Should().Be(verb, $"run {run}");
+            multiNoun.NounOne.Should().Contain(nounOne, $"run {run}");
+            multiNoun.NounTwo.Should().Be(nounTwo, $"run {run}");
+            multiNoun.Preposition.Should().Be(preposition, $"run {run}");
+        }
+    }
 }

--- a/IntegrationTests/OpenAIParserTests.cs
+++ b/IntegrationTests/OpenAIParserTests.cs
@@ -581,4 +581,35 @@ public class OpenAIParserTests
             multiNoun.Preposition.Should().Be(preposition, $"run {run}");
         }
     }
+
+    /// <summary>
+    ///     Issue #538. "press 3" was the only single-noun phrasing that reached no handler, because a
+    ///     bare numeral is not the noun phrase rule 3 asks for and the model sometimes leaves it
+    ///     untagged. The deterministic repair (recovering the noun from the player's own input) is
+    ///     proved by <c>ParsingHelperTests</c> and
+    ///     <c>Planetfall.Tests.LiveParserShapeTests</c>; this is the live counterpart. The teleport
+    ///     booth's description is passed literally rather than built from the location, which is
+    ///     internal to the Planetfall assembly.
+    /// </summary>
+    [Test]
+    [TestCase("press 3")]
+    [TestCase("press 1")]
+    public async Task DigitButtonShapeIsStableAcrossRepeatedRuns(string input)
+    {
+        const int runs = 5;
+        const string boothDescription =
+            "Booth 2. This is a tiny room with a large \"2\" painted on the wall. A panel contains a " +
+            "slot about ten centimeters wide, a brown button labelled \"1\" and a tan button labelled \"3.\"";
+
+        var target = new OpenAIParser(null);
+
+        for (var run = 1; run <= runs; run++)
+        {
+            var intent = await target.AskTheAIParser(input, boothDescription, string.Empty);
+            Console.WriteLine($"Run {run}: {intent.Message}");
+
+            intent.Should().BeOfType<SimpleIntent>($"run {run} of '{input}' must produce a single-noun intent");
+            ((SimpleIntent)intent).Noun.Should().NotBeNullOrWhiteSpace($"run {run}");
+        }
+    }
 }

--- a/Model/ParsingHelper.cs
+++ b/Model/ParsingHelper.cs
@@ -220,7 +220,23 @@ public static class ParsingHelper
 
         var nouns = ExtractElementsByTag(response, "noun");
         if (!nouns.Any())
-            return null;
+        {
+            // Issue #538: the model tagged the intent and the verb but no object at all, and the whole
+            // command then collapses to a NullIntent and goes straight to the narrator. This is what
+            // dropped "press 3" — the only single-noun phrasing in the report — because rule 3 asks the
+            // model to tag noun PHRASES and a bare numeral is not one, so it sometimes leaves the digit
+            // out. The player named the object, so recover it from their own words.
+            var recovered = RecoverNounFromInput(originalInput, verbTag);
+            if (recovered is null)
+            {
+                logger?.LogDebug("No noun was found, and none could be recovered from the player's input");
+                return null;
+            }
+
+            nouns = [recovered.Value.Noun];
+            if (string.IsNullOrEmpty(prepositionTag))
+                prepositionTag = recovered.Value.Preposition;
+        }
 
         if (nouns.Count == 1)
         {
@@ -376,6 +392,80 @@ public static class ParsingHelper
                 return words[i];
 
         return null;
+    }
+
+    // Issue #538. Words that lead a noun phrase without being part of it; dropped when reading a noun
+    // back out of the player's own sentence.
+    private static readonly string[] Determiners =
+        ["the", "a", "an", "my", "your", "his", "her", "their", "its", "some", "this", "that", "these", "those"];
+
+    /// <summary>
+    ///     Issue #538. Reads the object of the command out of the player's original input, for the
+    ///     turns where the AI parser tagged an intent and a verb but no &lt;noun&gt; at all. Returns
+    ///     null — leaving the historical <see cref="NullIntent" /> in place — when there is nothing
+    ///     trustworthy to recover.
+    /// </summary>
+    /// <remarks>
+    ///     Deliberately conservative on two counts, so this can only ever turn a dropped turn into a
+    ///     working one and never change a turn that already worked:
+    ///     <list type="bullet">
+    ///         <item>
+    ///             The tagged verb must actually appear in the input. The prompt asks the model to
+    ///             normalize verbs ("turn on" -&gt; "activate", "put on" -&gt; "don"), and when it has
+    ///             done so we cannot tell where the verb ends and the object begins — "turn on lamp"
+    ///             would yield the nonsense noun "on lamp".
+    ///         </item>
+    ///         <item>
+    ///             A genuinely object-less command ("jump") recovers nothing and stays a NullIntent.
+    ///         </item>
+    ///     </list>
+    ///     A preposition is peeled off either end of the phrase and returned separately, so
+    ///     "look under the rug" recovers the noun "rug" with the adverb "under", and "set dial to 42"
+    ///     recovers "dial" with "to" — the shapes the handlers are actually written against.
+    /// </remarks>
+    private static (string Noun, string? Preposition)? RecoverNounFromInput(string? originalInput, string verb)
+    {
+        if (string.IsNullOrWhiteSpace(originalInput) || string.IsNullOrWhiteSpace(verb))
+            return null;
+
+        var words = originalInput
+            .Split(WordSeparators, StringSplitOptions.RemoveEmptyEntries)
+            .Select(word => word.ToLowerInvariant())
+            .ToList();
+
+        var verbIndex = words.IndexOf(verb.Trim().ToLowerInvariant());
+        if (verbIndex < 0)
+            return null;
+
+        var remainder = words.Skip(verbIndex + 1).ToList();
+
+        string? preposition = null;
+
+        // A phrase that OPENS with a preposition is modifying the verb ("look under the rug"), so the
+        // preposition is the adverb and the noun is whatever follows it.
+        remainder = DropLeadingDeterminers(remainder);
+        if (remainder.Count > 1 && KnownPrepositions.Contains(remainder[0]))
+        {
+            preposition = remainder[0];
+            remainder = DropLeadingDeterminers(remainder.Skip(1).ToList());
+        }
+
+        // A preposition LATER in the phrase begins a second argument ("set dial to 42"). The noun ends
+        // there; the tail is still reachable through OriginalInput, which is what the handlers for
+        // those commands read.
+        var tailPreposition = remainder.FindIndex(KnownPrepositions.Contains);
+        if (tailPreposition > 0)
+        {
+            preposition ??= remainder[tailPreposition];
+            remainder = remainder.Take(tailPreposition).ToList();
+        }
+
+        return remainder.Count == 0 ? null : (string.Join(' ', remainder), preposition);
+    }
+
+    private static List<string> DropLeadingDeterminers(List<string> words)
+    {
+        return words.SkipWhile(Determiners.Contains).ToList();
     }
 
     /// <summary>

--- a/Model/ParsingHelper.cs
+++ b/Model/ParsingHelper.cs
@@ -126,7 +126,21 @@ public static class ParsingHelper
             return null;
 
         var nouns = ExtractElementsByTag(response, "noun");
-        
+
+        // Issue #538: the system prompt's own rule 1e carves out "take <thing> with <tool>" as an
+        // "act", not a "take" — precisely because the model tends to bucket it as a take anyway. When
+        // it does slip (intermittently, for the same input), the two-noun command collapsed into a
+        // TakeIntent that keeps only the FIRST noun, so the tool is silently dropped, the multi-noun
+        // handler (e.g. FusedBedistor's "take fused with pliers") never runs, and the turn falls
+        // through to the AI narrator with no engine response. A two-noun take joined by a TOOL
+        // preposition is always the action form, so let it fall through to DetermineActionIntent.
+        // Scoped to the tool prepositions on purpose: "take the sword and the shield" is a genuine
+        // multi-item take and must keep reaching TakeProcessor. Scoped to exactly two nouns because
+        // that is the only count DetermineActionIntent can turn into a MultiNounIntent — any other
+        // count must stay a take rather than degrade into a NullIntent.
+        if (nouns.Count == 2 && UsesAToolPreposition(response, input))
+            return null;
+
         return new TakeIntent
         {
             Message = response,
@@ -185,7 +199,11 @@ public static class ParsingHelper
         // intent once it has confirmed a noun is present (an object-less look already returned a
         // LookIntent), so treat that noun-bearing look as an action too, rather than a bare room-look
         // that silently swallows the noun.
-        if (intentTag != "act" && intentTag != "look")
+        // Issue #538: a "take" only reaches here when DetermineTakeIntent has already declined it as a
+        // tool-assisted two-noun command ("take the bedistor with the pliers") — the shape the system
+        // prompt's rule 1e defines as an action. Accept it here so it becomes the MultiNounIntent its
+        // handler is waiting for instead of collapsing to a NullIntent and the narrator.
+        if (intentTag != "act" && intentTag != "look" && intentTag != "take")
         {
             logger?.LogDebug("The intent tag was not 'act' trying to make an act intent");
             return null;
@@ -223,8 +241,19 @@ public static class ParsingHelper
             if (string.IsNullOrEmpty(prepositionTag))
             {
                 logger?.LogDebug("No preposition was found trying to make a MultiNoun intent");
-                // TODO: Claude is inconsistent giving us the preposition. For now, hardcode the most common one if we don't get it. 
-                prepositionTag = "with";
+
+                // Issue #538: the model is inconsistent about emitting <preposition> — the SAME
+                // two-noun command produces the tag on one turn and omits it on the next. The old
+                // fallback hardcoded "with", which is correct only for the "with" family; every other
+                // prepositional command ("set dial to 419", "slide card through slot", "put bedistor
+                // in panel") then reached its handler carrying a preposition the player never typed,
+                // so every MatchPreposition guard missed and the turn fell through to the AI narrator
+                // with no engine response at all. That is why two identical consecutive commands could
+                // have opposite outcomes, and why "unlock padlock with key" never showed the bug.
+                // The player's own words are ground truth for which preposition joins the two nouns,
+                // so recover it from them; "with" stays the fallback only when the input genuinely has
+                // no preposition to recover ("unlock door key").
+                prepositionTag = RecoverPrepositionFromInput(originalInput, nouns[1]) ?? "with";
             }
 
             return new MultiNounIntent
@@ -291,6 +320,86 @@ public static class ParsingHelper
             return null;
 
         return intentTag != tag ? null : new T();
+    }
+
+    // Issue #538. The prepositions a player can realistically use to join two nouns in a command.
+    // Matched whole-word, so this is only ever used to read the preposition back out of the player's
+    // own sentence when the AI parser failed to tag it — never to decide whether a command is valid.
+    private static readonly string[] KnownPrepositions =
+    [
+        "underneath", "throughout", "through", "between", "beneath", "against", "towards", "outside",
+        "inside", "beside", "behind", "across", "around", "toward", "under", "using", "above", "along",
+        "about", "after", "onto", "into", "over", "with", "from", "down", "upon", "past", "off", "out",
+        "for", "at", "by", "in", "on", "to", "up"
+    ];
+
+    private static readonly char[] WordSeparators = [' ', '\t', '\r', '\n', ',', '.', ';', ':', '!', '?', '"', '\''];
+
+    /// <summary>
+    ///     Issue #538. Reads the preposition that joins the two nouns out of the player's original
+    ///     input, for the turns where the AI parser omitted the &lt;preposition&gt; tag. Returns null
+    ///     when the player used no preposition at all ("unlock door key"), leaving the caller's
+    ///     historical "with" default in place.
+    /// </summary>
+    /// <remarks>
+    ///     The search runs BACKWARDS from the second noun so it finds the preposition that actually
+    ///     binds the pair rather than any earlier one in the sentence ("with the pliers, slide the card
+    ///     through the slot" is "through", not "with"). Index 0 is excluded because that position is
+    ///     the verb, not a connector.
+    /// </remarks>
+    private static string? RecoverPrepositionFromInput(string? originalInput, string secondNoun)
+    {
+        if (string.IsNullOrWhiteSpace(originalInput))
+            return null;
+
+        var words = originalInput
+            .Split(WordSeparators, StringSplitOptions.RemoveEmptyEntries)
+            .Select(word => word.ToLowerInvariant())
+            .ToList();
+
+        // Start just before the second noun where we can find it. The model sometimes normalizes or
+        // re-words a noun, in which case we fall back to scanning from the end of the sentence.
+        var startIndex = words.Count - 1;
+        var headOfSecondNoun = secondNoun
+            .Split(WordSeparators, StringSplitOptions.RemoveEmptyEntries)
+            .FirstOrDefault()?.ToLowerInvariant();
+
+        if (!string.IsNullOrEmpty(headOfSecondNoun))
+        {
+            var nounIndex = words.LastIndexOf(headOfSecondNoun);
+            if (nounIndex > 0)
+                startIndex = nounIndex - 1;
+        }
+
+        for (var i = startIndex; i >= 1; i--)
+            if (KnownPrepositions.Contains(words[i]))
+                return words[i];
+
+        return null;
+    }
+
+    /// <summary>
+    ///     Issue #538. True when a two-noun command joins its nouns with a TOOL preposition — the
+    ///     "take the bedistor with/using the pliers" shape that the system prompt's rule 1e says must
+    ///     be an action, not a take. Checks the parser's own tag first, then the player's words, since
+    ///     the mis-bucketed turns are exactly the ones where a tag goes missing.
+    /// </summary>
+    private static bool UsesAToolPreposition(string? response, string? originalInput)
+    {
+        string[] toolPrepositions = ["with", "using"];
+
+        var prepositionTag = ExtractElementsByTag(response, "preposition").FirstOrDefault();
+        if (!string.IsNullOrEmpty(prepositionTag) &&
+            toolPrepositions.Contains(prepositionTag, StringComparer.OrdinalIgnoreCase))
+            return true;
+
+        if (string.IsNullOrWhiteSpace(originalInput))
+            return false;
+
+        return originalInput
+            .Split(WordSeparators, StringSplitOptions.RemoveEmptyEntries)
+            .Skip(1)
+            .Any(word => toolPrepositions.Contains(word, StringComparer.OrdinalIgnoreCase));
     }
 
     private static List<string> ExtractElementsByTag(string? response, string tag)

--- a/Planetfall.Tests/LiveParserShapeTests.cs
+++ b/Planetfall.Tests/LiveParserShapeTests.cs
@@ -1,0 +1,122 @@
+using FluentAssertions;
+using GameEngine;
+using Model.Interface;
+using Moq;
+using OpenAI.Chat;
+using Planetfall.GlobalCommand;
+using Planetfall.Item.Kalamontee;
+using Planetfall.Item.Kalamontee.Admin;
+using Planetfall.Item.Kalamontee.Mech;
+using Planetfall.Item.Lawanda;
+using Planetfall.Location.Computer;
+using Planetfall.Location.Kalamontee;
+using Planetfall.Location.Lawanda;
+using ZorkAI.OpenAI;
+
+namespace Planetfall.Tests;
+
+/// <summary>
+///     Issue #538. Every walkthrough suite in this repo drives the engine through
+///     <c>UnitTests.TestParser</c>, which resolves an intent straight out of
+///     <c>UnitTests/IntentMappings/base-mappings.json</c>. That proves the HANDLERS work but says
+///     nothing about whether the real parser ever reaches them — which is exactly where the bug
+///     lived: in production these commands intermittently produced no engine response at all, and
+///     the player got invented narrator prose instead of the action they asked for.
+///     <para>
+///         These tests close that blind spot for the specific shapes involved. They run the genuine
+///         <see cref="ParsingHelper" /> (via <see cref="OpenAIParser" />) over the raw tagged
+///         completions gpt-4o actually emits — including the degraded shapes that caused the
+///         dropped turns — and assert the command still reaches its handler.
+///     </para>
+/// </summary>
+public class LiveParserShapeTests : EngineTestsBase
+{
+    /// <summary>
+    ///     Builds a real <see cref="IntentParser" /> whose AI layer is stubbed to return a fixed
+    ///     tagged completion. Everything downstream of the model — tag extraction, intent-shape
+    ///     classification, engine dispatch — is the production code path.
+    /// </summary>
+    private static IIntentParser ParserReturning(string taggedCompletion)
+    {
+        var completion = new Mock<IChatCompletionClient>();
+        completion
+            .Setup(c => c.CompleteChatAsync(It.IsAny<IReadOnlyList<ChatMessage>>(),
+                It.IsAny<ChatCompletionOptions>()))
+            .ReturnsAsync(taggedCompletion);
+
+        return new IntentParser(new OpenAIParser(null, completion.Object), new PlanetfallGlobalCommandFactory());
+    }
+
+    [Test]
+    public async Task SetDialToTheCode_WhenTheParserOmitsThePreposition_StillOpensTheConferenceRoomDoor()
+    {
+        var target = GetTarget(ParserReturning("""
+                                               <intent>act</intent>
+                                               <verb>set</verb>
+                                               <noun>dial</noun>
+                                               <noun>419</noun>
+                                               """));
+        StartHere<RecArea>();
+        GetItem<ConferenceRoomDoor>().UnlockCode = "419";
+
+        var response = await target.GetResponse("set dial to 419");
+
+        response.Should().Contain("The door swings open");
+        GetItem<ConferenceRoomDoor>().IsOpen.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task SetLaserDial_WhenTheParserOmitsThePreposition_StillMovesTheSetting()
+    {
+        var target = GetTarget(ParserReturning("""
+                                               <intent>act</intent>
+                                               <verb>set</verb>
+                                               <noun>laser</noun>
+                                               <noun>1</noun>
+                                               """));
+        StartHere<StripNearRelay>();
+        Take<Laser>();
+
+        var response = await target.GetResponse("set laser to 1");
+
+        response.Should().Contain("The dial is now set to 1");
+        GetItem<Laser>().Setting.Should().Be(1);
+    }
+
+    [Test]
+    public async Task SlideCardThroughSlot_WhenTheParserOmitsThePreposition_StillActivatesTheBooth()
+    {
+        var target = GetTarget(ParserReturning("""
+                                               <intent>act</intent>
+                                               <verb>slide</verb>
+                                               <noun>teleportation card</noun>
+                                               <noun>slot</noun>
+                                               """));
+        StartHere<BoothTwo>();
+        Take<TeleportationAccessCard>();
+
+        var response = await target.GetResponse("slide teleportation card through slot");
+
+        response.Should().Contain("Redee");
+    }
+
+    [Test]
+    public async Task TakeWithATool_WhenTheParserBucketsItAsATake_StillRemovesTheFusedBedistor()
+    {
+        var target = GetTarget(ParserReturning("""
+                                               <intent>take</intent>
+                                               <verb>take</verb>
+                                               <noun>fused bedistor</noun>
+                                               <noun>pliers</noun>
+                                               <preposition>with</preposition>
+                                               """));
+        StartHere<CourseControl>();
+        Take<Pliers>();
+        GetItem<LargeMetalCube>().IsOpen = true;
+
+        var response = await target.GetResponse("take fused bedistor with pliers");
+
+        response.Should().Contain("you manage to remove the fused bedistor");
+        Context.HasItem<FusedBedistor>().Should().BeTrue();
+    }
+}

--- a/Planetfall.Tests/LiveParserShapeTests.cs
+++ b/Planetfall.Tests/LiveParserShapeTests.cs
@@ -100,6 +100,51 @@ public class LiveParserShapeTests : EngineTestsBase
         response.Should().Contain("Redee");
     }
 
+    /// <summary>
+    ///     Issue #538. "press 3" is the only single-noun phrasing in the report that reached no
+    ///     handler, and its object is a bare numeral — which rule 3 of the system prompt does not
+    ///     describe as a noun phrase, so gpt-4o sometimes leaves it untagged entirely. That collapses
+    ///     the turn to a NullIntent and the booth never teleports.
+    /// </summary>
+    [Test]
+    public async Task PressADigitButton_WhenTheParserOmitsTheNoun_StillTeleports()
+    {
+        var target = GetTarget(ParserReturning("""
+                                               <intent>act</intent>
+                                               <verb>press</verb>
+                                               """));
+        var booth = StartHere<BoothTwo>();
+        booth.IsEnabled = true;
+
+        var response = await target.GetResponse("press 3");
+
+        response.Should().Contain("strange feeling in the pit of your stomach");
+        Context.CurrentLocation.Name.Should().Be("Booth 3");
+    }
+
+    /// <summary>
+    ///     Issue #538, the other shape a bare numeral provokes: rather than dropping the digit, the
+    ///     model expands it against the room description into "button 3". The booths listed
+    ///     "3 button" but never that word order, so the command missed every match and fell through to
+    ///     the narrator.
+    /// </summary>
+    [Test]
+    public async Task PressADigitButton_WhenTheParserExpandsItToButtonN_StillTeleports()
+    {
+        var target = GetTarget(ParserReturning("""
+                                               <intent>act</intent>
+                                               <verb>press</verb>
+                                               <noun>button 3</noun>
+                                               """));
+        var booth = StartHere<BoothTwo>();
+        booth.IsEnabled = true;
+
+        var response = await target.GetResponse("press 3");
+
+        response.Should().Contain("strange feeling in the pit of your stomach");
+        Context.CurrentLocation.Name.Should().Be("Booth 3");
+    }
+
     [Test]
     public async Task TakeWithATool_WhenTheParserBucketsItAsATake_StillRemovesTheFusedBedistor()
     {

--- a/Planetfall/Location/Kalamontee/BoothOne.cs
+++ b/Planetfall/Location/Kalamontee/BoothOne.cs
@@ -43,13 +43,20 @@ internal class BoothOne : BoothBase
                     { "tan button", "tan button" }
                 }, "press the {0}");
 
-        if (action.Match(Verbs.PushVerbs, ["tan button", "tan", "beige button", "beige", "3", 
-                "2", "two", "three", "3 button", "2 button", "three button", "two button"]))
+        // "button 2" as well as "2 button" (issue #538): asked to name the object of a bare "press 2",
+        // the AI parser resolves the digit against the room description and can return either word
+        // order. Only one was listed, so the other missed every match and the turn fell through to the
+        // narrator without teleporting.
+        if (action.Match(Verbs.PushVerbs, ["tan button", "tan", "beige button", "beige", "3",
+                "2", "two", "three", "3 button", "2 button", "three button", "two button",
+                "button 2", "button 3", "button two", "button three"]))
         {
-            if (action.MatchNoun(["beige button", "beige", "2", "two", "2 button", "two button"]))
+            if (action.MatchNoun(["beige button", "beige", "2", "two", "2 button", "two button",
+                    "button 2", "button two"]))
                 return GoTwo(context);
 
-            if (action.MatchNoun(["tan button", "tan", "3", "three", "3 button", "three button"]))
+            if (action.MatchNoun(["tan button", "tan", "3", "three", "3 button", "three button",
+                    "button 3", "button three"]))
                 return GoThree(context);
         }
 

--- a/Planetfall/Location/Kalamontee/BoothTwo.cs
+++ b/Planetfall/Location/Kalamontee/BoothTwo.cs
@@ -37,16 +37,23 @@ internal class BoothTwo : BoothBase
                     { "brown button", "brown button" }
                 }, "press the {0}");
 
-        if (action.Match(Verbs.PushVerbs, ["brown button", "brown", "tan button", "tan", "1", 
-                "3", "one", "three", "1 button", "3 button", "one button", "three button"]))
+        // "button 3" as well as "3 button" (issue #538): asked to name the object of a bare "press 3",
+        // the AI parser resolves the digit against the room description and can return either word
+        // order. Only one was listed, so the other missed every match and the turn fell through to the
+        // narrator without teleporting.
+        if (action.Match(Verbs.PushVerbs, ["brown button", "brown", "tan button", "tan", "1",
+                "3", "one", "three", "1 button", "3 button", "one button", "three button",
+                "button 1", "button 3", "button one", "button three"]))
         {
             // "three", not "two": this booth's tan button is labelled "3". Booth 2 has no "2" button
             // at all, so matching "two" here both answered a noun that does not exist and left the
             // spelled-out "three" falling through to the narrator without teleporting.
-            if (action.MatchNoun(["tan button", "tan", "3", "three", "3 button", "three button"]))
+            if (action.MatchNoun(["tan button", "tan", "3", "three", "3 button", "three button",
+                    "button 3", "button three"]))
                 return GoThree(context);
 
-            if (action.MatchNoun(["brown button", "brown", "1", "one", "1 button", "one button"]))
+            if (action.MatchNoun(["brown button", "brown", "1", "one", "1 button", "one button",
+                    "button 1", "button one"]))
                 return GoOne(context);
         }
 

--- a/Planetfall/Location/Lawanda/BoothThree.cs
+++ b/Planetfall/Location/Lawanda/BoothThree.cs
@@ -39,13 +39,20 @@ internal class BoothThree : BoothBase
                     { "brown button", "brown button" }
                 }, "press the {0}");
 
-        if (action.Match(Verbs.PushVerbs, ["brown button", "brown", "beige button", "beige", "1", 
-                "2", "one", "two", "1 button", "2 button", "one button", "two button"]))
+        // "button 2" as well as "2 button" (issue #538): asked to name the object of a bare "press 2",
+        // the AI parser resolves the digit against the room description and can return either word
+        // order. Only one was listed, so the other missed every match and the turn fell through to the
+        // narrator without teleporting.
+        if (action.Match(Verbs.PushVerbs, ["brown button", "brown", "beige button", "beige", "1",
+                "2", "one", "two", "1 button", "2 button", "one button", "two button",
+                "button 1", "button 2", "button one", "button two"]))
         {
-            if (action.MatchNoun(["beige button", "beige", "2", "two", "2 button", "two button"]))
+            if (action.MatchNoun(["beige button", "beige", "2", "two", "2 button", "two button",
+                    "button 2", "button two"]))
                 return GoTwo(context);
 
-            if (action.MatchNoun(["brown button", "brown", "1", "one", "1 button", "one button"]))
+            if (action.MatchNoun(["brown button", "brown", "1", "one", "1 button", "one button",
+                    "button 1", "button one"]))
                 return GoOne(context);
         }
 

--- a/UnitTests/Models/ParsingHelperTests.cs
+++ b/UnitTests/Models/ParsingHelperTests.cs
@@ -492,7 +492,8 @@ public class ParsingHelperTests
     [Test]
     public void GetIntent_WithMultiNounNoPreposition_DefaultsToWith()
     {
-        // Arrange
+        // Arrange - the player themselves used no preposition, so there is nothing to recover from
+        // their words and the historical "with" default is still the best guess (issue #538).
         var input = "unlock door key";
         var response = @"<intent>act</intent>
 <verb>unlock</verb>
@@ -506,6 +507,103 @@ public class ParsingHelperTests
         result.Should().BeOfType<MultiNounIntent>();
         var multiNounIntent = result as MultiNounIntent;
         multiNounIntent?.Preposition.Should().Be("with");
+    }
+
+    /// <summary>
+    ///     Issue #538. gpt-4o intermittently omits the &lt;preposition&gt; tag on a perfectly
+    ///     well-formed two-noun command, and the old fallback hardcoded "with". That is right only for
+    ///     the "with" family: "set dial to 419", "slide card through slot" and "put bedistor in panel"
+    ///     all arrived at their handlers carrying "with", every <c>MatchPreposition</c> guard missed,
+    ///     and the turn fell through to the AI narrator with no engine response. Because the omission
+    ///     is a coin flip, two identical consecutive commands produced opposite outcomes. The player's
+    ///     own words are the ground truth for which preposition binds the two nouns, so recover it
+    ///     from the original input.
+    /// </summary>
+    [TestCase("set dial to 419", "set", "dial", "419", "to")]
+    [TestCase("set laser to 1", "set", "laser", "1", "to")]
+    [TestCase("slide teleportation card through slot", "slide", "teleportation card", "slot", "through")]
+    [TestCase("put the shiny bedistor in the panel", "put", "shiny bedistor", "panel", "in")]
+    [TestCase("throw the laser off the edge", "throw", "laser", "edge", "off")]
+    public void GetIntent_WhenParserOmitsThePreposition_RecoversItFromThePlayersOwnWords(
+        string input, string verb, string nounOne, string nounTwo, string expectedPreposition)
+    {
+        var response = $"""
+                        <intent>act</intent>
+                        <verb>{verb}</verb>
+                        <noun>{nounOne}</noun>
+                        <noun>{nounTwo}</noun>
+                        """;
+
+        var result = ParsingHelper.GetIntent(input, response, _loggerMock?.Object);
+
+        result.Should().BeOfType<MultiNounIntent>();
+        ((MultiNounIntent)result).Preposition.Should().Be(expectedPreposition);
+    }
+
+    [Test]
+    public void GetIntent_WhenParserOmitsThePreposition_PrefersTheOneBindingTheTwoNouns()
+    {
+        // Issue #538: recovery must pick the preposition that actually connects the two nouns, not
+        // the first one anywhere in the sentence. "with" appears earlier here, but the second noun
+        // ("slot") is bound by "through".
+        var input = "with the pliers, slide the card through the slot";
+        var response = @"<intent>act</intent>
+<verb>slide</verb>
+<noun>card</noun>
+<noun>slot</noun>";
+
+        var result = ParsingHelper.GetIntent(input, response, _loggerMock?.Object);
+
+        result.Should().BeOfType<MultiNounIntent>();
+        ((MultiNounIntent)result).Preposition.Should().Be("through");
+    }
+
+    /// <summary>
+    ///     Issue #538. The system prompt's own rule 1e carves out "take &lt;thing&gt; with
+    ///     &lt;tool&gt;" as an <c>act</c>, not a <c>take</c> — precisely because the model tends to
+    ///     bucket it as a take. When it does slip, the two-noun command collapsed into a
+    ///     <see cref="TakeIntent" /> that kept only the first noun, so
+    ///     <c>FusedBedistor.RespondToMultiNounInteraction</c> ("take fused with pliers") never ran and
+    ///     the turn fell through to the narrator. A two-noun take joined by a TOOL preposition is
+    ///     always the action form.
+    /// </summary>
+    [TestCase("with")]
+    [TestCase("using")]
+    public void GetIntent_WhenParserTagsAToolAssistedTakeAsATake_StillReturnsTheActionForm(string preposition)
+    {
+        var response = $"""
+                        <intent>take</intent>
+                        <verb>take</verb>
+                        <noun>fused bedistor</noun>
+                        <noun>pliers</noun>
+                        <preposition>{preposition}</preposition>
+                        """;
+
+        var result = ParsingHelper.GetIntent($"take the fused bedistor {preposition} the pliers", response,
+            _loggerMock?.Object);
+
+        result.Should().BeOfType<MultiNounIntent>();
+        var multiNoun = (MultiNounIntent)result;
+        multiNoun.Verb.Should().Be("take");
+        multiNoun.NounOne.Should().Be("fused bedistor");
+        multiNoun.NounTwo.Should().Be("pliers");
+        multiNoun.Preposition.Should().Be(preposition);
+    }
+
+    [Test]
+    public void GetIntent_WithATwoNounTakeThatIsNotToolAssisted_StaysATakeIntent()
+    {
+        // Guard for the #538 diversion above: "take the sword and the shield" is a genuine multi-item
+        // TAKE, not a tool-assisted one. It must keep reaching TakeProcessor (which re-reads the whole
+        // input to build the item list) rather than being rewritten into a two-noun action.
+        var response = @"<intent>take</intent>
+<verb>take</verb>
+<noun>sword</noun>
+<noun>shield</noun>";
+
+        var result = ParsingHelper.GetIntent("take the sword and the shield", response, _loggerMock?.Object);
+
+        result.Should().BeOfType<TakeIntent>();
     }
 
     [Test]

--- a/UnitTests/Models/ParsingHelperTests.cs
+++ b/UnitTests/Models/ParsingHelperTests.cs
@@ -606,6 +606,66 @@ public class ParsingHelperTests
         result.Should().BeOfType<TakeIntent>();
     }
 
+    /// <summary>
+    ///     Issue #538. "press 3" was the only SINGLE-noun phrasing in the report that intermittently
+    ///     reached no handler, and what makes it unusual is that its object is a bare numeral. Rule 3
+    ///     of the system prompt asks the model to tag noun PHRASES, and a bare digit is not one, so on
+    ///     some runs gpt-4o emits the intent and the verb and simply leaves the number out — the whole
+    ///     command then collapses to a <see cref="NullIntent" /> and goes straight to the narrator.
+    ///     The player typed the object, so recover it from their own words rather than dropping the
+    ///     turn.
+    /// </summary>
+    [TestCase("press 3", "press", "3", null)]
+    [TestCase("press the tan button", "press", "tan button", null)]
+    [TestCase("type 17", "type", "17", null)]
+    [TestCase("look under the rug", "look", "rug", "under")]
+    [TestCase("set dial to 42", "set", "dial", "to")]
+    public void GetIntent_WhenParserOmitsTheNoun_RecoversItFromThePlayersOwnWords(
+        string input, string verb, string expectedNoun, string? expectedAdverb)
+    {
+        var response = $"""
+                        <intent>act</intent>
+                        <verb>{verb}</verb>
+                        """;
+
+        var result = ParsingHelper.GetIntent(input, response, _loggerMock?.Object);
+
+        result.Should().BeOfType<SimpleIntent>();
+        var simpleIntent = (SimpleIntent)result;
+        simpleIntent.Verb.Should().Be(verb);
+        simpleIntent.Noun.Should().Be(expectedNoun);
+        simpleIntent.Adverb.Should().Be(expectedAdverb);
+        simpleIntent.OriginalInput.Should().Be(input);
+    }
+
+    [Test]
+    public void GetIntent_WhenParserOmitsTheNounAndThePlayerNamedNoObject_StaysANullIntent()
+    {
+        // Guard for the #538 noun recovery: a genuinely object-less command has nothing to recover.
+        // It must keep degrading to the narrator rather than inventing an empty noun.
+        var response = @"<intent>act</intent>
+<verb>jump</verb>";
+
+        var result = ParsingHelper.GetIntent("jump", response, _loggerMock?.Object);
+
+        result.Should().BeOfType<NullIntent>();
+    }
+
+    [Test]
+    public void GetIntent_WhenParserOmitsTheNounAndRewroteTheVerb_StaysANullIntent()
+    {
+        // Guard for the #538 noun recovery: the prompt tells the model to normalize verbs ("turn on"
+        // -> "activate"), so when the tagged verb is absent from the input we cannot tell where the
+        // verb ends and the object begins. Recovering blindly would yield "on lamp"; declining leaves
+        // behavior exactly as it was.
+        var response = @"<intent>act</intent>
+<verb>activate</verb>";
+
+        var result = ParsingHelper.GetIntent("turn on lamp", response, _loggerMock?.Object);
+
+        result.Should().BeOfType<NullIntent>();
+    }
+
     [Test]
     public void GetIntent_WithAdjectiveTag_IncludesAdjective()
     {


### PR DESCRIPTION
Fixes #538.

## The bug

`set dial to 419`, `slide card through slot`, `put bedistor in panel`, `take fused with pliers` and `press 3` intermittently reached no handler in production — roughly 20–40% of the time — and the turn fell through to the AI narrator, so the player got invented prose instead of the action they asked for. Two identical consecutive commands could produce opposite outcomes; one dropped `set laser to 1` left a game unwinnable.

Three distinct parser-shape defects, all deterministic once you know the shape.

## 1. Omitted `<preposition>` → hardcoded `"with"`

gpt-4o omits the `<preposition>` tag on some runs of the *same* input, and `ParsingHelper` substituted a hardcoded `"with"` (a long-standing `TODO` in the file). Every handler gates on `MatchPreposition(["to"])` / `(["through"])` / `(["in"])`, so a command arriving with a preposition the player never typed missed every guard and collapsed to the narrator.

This also explains the shape of the report's own data: `unlock padlock with key` — the one family the `"with"` default happens to fit — worked 100% of the time it was tried.

**Fix:** the player's own words are ground truth for which preposition joins the two nouns, so recover it from the original input, scanning *backwards* from the second noun so it finds the preposition that actually binds the pair (`with the pliers, slide the card through the slot` → `through`, not `with`). `"with"` remains the fallback only when the input genuinely has no preposition (`unlock door key`).

## 2. `take <thing> with <tool>` bucketed as `intent=take`

The system prompt's own rule 1e already declares this an `act` rather than a `take` — precisely because the model tends to bucket it as a take anyway. When it slipped, the two-noun command collapsed into a `TakeIntent` that keeps only the first noun, silently dropping the tool, so `FusedBedistor`'s `take fused with pliers` handler never ran. A two-noun take joined by a tool preposition now routes to the action path. Scoped to exactly two nouns and to `with`/`using`, so `take the sword and the shield` still reaches `TakeProcessor` unchanged.

## 3. `press 3` — the bare numeral

`press 3` was the only *single*-noun phrasing in the report, and what makes it unusual is that its object is a bare digit. Two shapes drop it, both digit-specific:

- **No `<noun>` tag at all.** Rule 3 asks the model to tag noun *phrases*, and a bare digit is not one, so gpt-4o sometimes emits the intent and the verb and nothing else — `NullIntent`, straight to the narrator. Now the noun is recovered from the player's own words. Deliberately conservative, so it can only turn a dropped turn into a working one: the tagged verb must actually appear in the input (the prompt asks the model to normalize verbs, and `turn on lamp` tagged `activate` would otherwise yield the nonsense noun `"on lamp"`), and an object-less command (`jump`) still recovers nothing and stays a `NullIntent`. A preposition is peeled off either end and returned as the adverb, so `look under the rug` recovers noun `rug` + `under`, and `set dial to 42` recovers `dial` + `to` — the shapes those handlers are written against.
- **The digit expanded to the other word order.** Asked to name the object of a bare `press 3`, the model can resolve it against the room description as `"button 3"`. All three teleport booths listed `"3 button"` but never `"button 3"`, so that order missed every match and fell through without teleporting. Both orders are now accepted, digit and spelled-out.

## Tests

Every repair is proved by deterministic unit tests over `ParsingHelper.GetIntent` in `UnitTests/Models/ParsingHelperTests.cs`, each red before the change and green after, plus guard tests that pin the cases which must *not* change.

`Planetfall.Tests/LiveParserShapeTests.cs` closes the fixture blind spot the issue calls out (also flagged in #526 and #423): every walkthrough suite drives the engine through `TestParser`/`base-mappings.json`, which resolves intents directly and never exercises the real parser, which is why CI stayed green throughout. The new tests run the engine through the genuine `ParsingHelper` (via `OpenAIParser` over a stubbed chat seam) on the degraded completions that caused the dropped turns. Before the fix all six reproduce the exact production symptom — an empty engine response:

```
Expected response "\n" to contain "The door swings open".
Expected response "\n" to contain "The dial is now set to 1".
Expected response "\n" to contain "Redee".
Expected response "\n" to contain "strange feeling in the pit of your stomach".
```

Live repeated-run counterparts (5 runs per phrasing) are added to the `[Explicit]` `IntegrationTests/OpenAIParserTests.cs`, per the issue's suggestion 2.

**Full suites, all green:** UnitTests 1146, Planetfall.Tests 3897, ZorkOne.Tests 1782, EscapeRoom.Tests 9, Console.Tests 16, Stationfall.Tests 4.

## Not addressed

The issue's suggestion 1 — a deterministic refusal instead of narrator invention when a known verb+noun resolves to no handler — is left open and now tracked as #541. It is a behavior change across all three games rather than a bug fix, and the parser repairs here stand on their own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


