### PR TITLE
Answer to "escape pod" and "pod bulkhead", the names Deck Nine's prose teaches

### DIFF
--- a/Planetfall.Tests/DoorTests.cs
+++ b/Planetfall.Tests/DoorTests.cs
@@ -264,7 +264,10 @@ public class DoorTests : EngineTestsBase
 
         var examine = await target.GetResponse("examine bulkhead");
 
-        examine.Should().Contain("nothing special about the narrow emergency bulkhead");
+        // The door's display name is its longest noun, which is POD-DOOR's own DESC
+        // (planetfall-source/globals.zil:1094). It used to be "narrow emergency bulkhead" — the name of
+        // the gangway bulkhead (globals.zil:1139), a different door entirely.
+        examine.Should().Contain("nothing special about the escape pod bulkhead");
     }
 
     [Test]

--- a/Planetfall.Tests/EnterPodTests.cs
+++ b/Planetfall.Tests/EnterPodTests.cs
@@ -144,6 +144,49 @@ public class EnterPodTests : EngineTestsBase
     }
 
     /// <summary>
+    /// The pod door has to answer to every name the room description gives it. Deck Nine says "the
+    /// entrance to one of the ship's primary escape pods. The pod bulkhead is closed." — so "escape
+    /// pod" and "pod bulkhead" are the two phrases the prose actively teaches, and both used to miss
+    /// the BulkheadDoor entirely: the narrator then mocked the player for naming an object that
+    /// wasn't there ("the elusive escape pod ... seems to have taken a day off").
+    ///
+    /// The original states the same object under both names. planetfall-source/globals.zil:1094 gives
+    /// POD-DOOR the synonyms DOOR/BULKHEAD with adjectives EMERGENCY/ESCAPE/POD, and globals.zil:904
+    /// gives GLOBAL-POD the synonym POD with adjectives EMERGENCY/ESCAPE/PRIMARY — and GLOBAL-POD-F
+    /// (globals.zil:925) sends OPEN straight to POD-DOOR, so naming the pod and naming its bulkhead
+    /// are the same command. This port merges the two into BulkheadDoor, so it must carry the union
+    /// of those names.
+    ///
+    /// Both phrasings are covered in both shapes the AI parser produces — the whole phrase as one
+    /// noun, and split into adjective + noun — because SimpleIntent.MatchNounAndAdjective compares
+    /// "adjective noun" against that very same list, with no containment fallback.
+    /// </summary>
+    [TestFixture]
+    public class PodDoorNames : EngineTestsBase
+    {
+        private const string NoEmergencyYet =
+            "Why open the door to the emergency escape pod if there's no emergency?";
+
+        [TestCase("open escape pod")]
+        [TestCase("open the escape pod")]
+        [TestCase("open pod bulkhead")]
+        [TestCase("open the pod bulkhead")]
+        [TestCase("open emergency bulkhead")]
+        [TestCase("open escape pod bulkhead")]
+        [TestCase("open pod")]
+        [TestCase("open bulkhead")]
+        public async Task OpenPodDoor_ByAnyOfItsNames_GetsTheDoorsOwnAnswer(string command)
+        {
+            var target = GetTarget();
+            target.Context.CurrentLocation = Repository.GetLocation<DeckNine>();
+
+            var response = await target.GetResponse(command);
+
+            response.Should().Contain(NoEmergencyYet);
+        }
+    }
+
+    /// <summary>
     /// "exit pod" from inside the pod after it has landed in the ocean. The pod's door now leads to
     /// the Underwater location (WhereDoesTheDoorLead), so "exit pod" -> Move(Out) must carry the
     /// player out into the water when the bulkhead is open, and report the closed door otherwise -

--- a/Planetfall.Tests/EnterPodTests.cs
+++ b/Planetfall.Tests/EnterPodTests.cs
@@ -171,7 +171,6 @@ public class EnterPodTests : EngineTestsBase
         [TestCase("open the escape pod")]
         [TestCase("open pod bulkhead")]
         [TestCase("open the pod bulkhead")]
-        [TestCase("open emergency bulkhead")]
         [TestCase("open escape pod bulkhead")]
         [TestCase("open pod")]
         [TestCase("open bulkhead")]
@@ -183,6 +182,43 @@ public class EnterPodTests : EngineTestsBase
             var response = await target.GetResponse(command);
 
             response.Should().Contain(NoEmergencyYet);
+        }
+
+        /// <summary>
+        /// Naming the pod must not answer under some other door's name. The door's display name is its
+        /// longest noun (ExamineInteractionProcessor), and that has to be POD-DOOR's own DESC, "escape
+        /// pod bulkhead" (globals.zil:1094) — not "narrow emergency bulkhead", which names the bulkhead
+        /// at the base of the gangway (GANGWAY-DOOR, globals.zil:1139).
+        /// </summary>
+        [Test]
+        public async Task ExaminePod_AnswersUnderThePodsOwnBulkheadName()
+        {
+            var target = GetTarget();
+            target.Context.CurrentLocation = Repository.GetLocation<DeckNine>();
+
+            var response = await target.GetResponse("examine escape pod");
+
+            response.Should().Contain("escape pod bulkhead");
+            response.Should().NotContain("narrow emergency bulkhead");
+        }
+
+        /// <summary>
+        /// The bare EMERGENCY qualifier is shared: in the original, POD-DOOR, GANGWAY-DOOR
+        /// (globals.zil:1139) and CORRIDOR-DOOR (globals.zil:1133) all carry ADJECTIVE EMERGENCY with
+        /// SYNONYM DOOR/BULKHEAD, and all three are in Deck Nine's scope once the latter two slam shut
+        /// (globals.zil:1216). So "emergency bulkhead" is ambiguous there, not a name the pod door owns —
+        /// and the turn the game narrates "A narrow emergency bulkhead at the base of the gangway ...
+        /// crash shut!", the pod door must not answer for it.
+        /// </summary>
+        [Test]
+        public async Task AmbiguousEmergencyName_IsNotClaimedByThePodDoor()
+        {
+            var target = GetTarget();
+            target.Context.CurrentLocation = Repository.GetLocation<DeckNine>();
+
+            var response = await target.GetResponse("open emergency bulkhead");
+
+            response.Should().NotContain(NoEmergencyYet);
         }
     }
 

--- a/Planetfall/Item/Feinstein/BulkheadDoor.cs
+++ b/Planetfall/Item/Feinstein/BulkheadDoor.cs
@@ -21,16 +21,27 @@ public class BulkheadDoor : ItemBase, IOpenAndClose
     ///     <para>
     ///         Trap when adding to this list: the LONGEST entry doubles as the item's display name
     ///         (ExamineInteractionProcessor prints "nothing special about the {longest noun}"), so a new
-    ///         long synonym silently renames the door. "narrow emergency bulkhead" must stay the longest.
+    ///         long synonym silently renames the door. "escape pod bulkhead" — POD-DOOR's own DESC — must
+    ///         stay the longest. It previously was not: "narrow emergency bulkhead" held that spot, which
+    ///         is GANGWAY-DOOR's name (globals.zil:1139), so "examine escape pod" answered about the
+    ///         bulkhead at the base of the gangway.
+    ///     </para>
+    ///     <para>
+    ///         Deliberately absent: the bare EMERGENCY qualifier on a door/bulkhead. The original shares
+    ///         that adjective across three objects in Deck Nine's scope — POD-DOOR, GANGWAY-DOOR
+    ///         (globals.zil:1139) and CORRIDOR-DOOR (globals.zil:1133), the latter two becoming
+    ///         referenceable when they slam shut (globals.zil:1216) — so "emergency bulkhead" and
+    ///         "emergency door" are ambiguous there, not names POD-DOOR owns. Claiming them here would
+    ///         make the pod door answer for the gangway bulkhead the turn the game narrates it closing.
+    ///         "emergency pod" IS kept: POD is GLOBAL-POD's synonym alone, so it is unambiguous.
     ///     </para>
     /// </remarks>
     public override string[] NounsForMatching =>
     [
         // POD-DOOR
         "bulkhead", "door", "bulkhead door",
-        "emergency bulkhead", "escape bulkhead", "pod bulkhead",
-        "emergency door", "escape door", "pod door",
-        "escape pod bulkhead", "escape pod door", "narrow emergency bulkhead",
+        "escape bulkhead", "pod bulkhead", "escape pod bulkhead",
+        "escape door", "pod door", "escape pod door",
         // GLOBAL-POD
         "pod", "emergency pod", "escape pod", "primary pod"
     ];

--- a/Planetfall/Item/Feinstein/BulkheadDoor.cs
+++ b/Planetfall/Item/Feinstein/BulkheadDoor.cs
@@ -4,8 +4,36 @@ namespace Planetfall.Item.Feinstein;
 
 public class BulkheadDoor : ItemBase, IOpenAndClose
 {
+    /// <summary>
+    ///     The original states this as two objects that share one command: POD-DOOR
+    ///     (planetfall-source/globals.zil:1094 — synonyms DOOR/BULKHEAD, adjectives EMERGENCY/ESCAPE/POD)
+    ///     and GLOBAL-POD (globals.zil:904 — synonym POD, adjectives EMERGENCY/ESCAPE/PRIMARY), whose
+    ///     action routine sends OPEN straight to POD-DOOR (globals.zil:925). This port merges them into
+    ///     one item, so it has to carry the union of both name sets.
+    /// </summary>
+    /// <remarks>
+    ///     Every adjective+noun pair must be spelled out. The AI parser hands back either the whole
+    ///     phrase as one noun or an adjective/noun split, and SimpleIntent.MatchNounAndAdjective simply
+    ///     compares "adjective noun" against this list — there is no containment fallback on this path.
+    ///     Leaving "escape pod" and "pod bulkhead" out, the exact two phrases Deck Nine's own description
+    ///     teaches, meant "open escape pod" resolved to nothing and the narrator mocked the player for
+    ///     naming an object that wasn't there.
+    ///     <para>
+    ///         Trap when adding to this list: the LONGEST entry doubles as the item's display name
+    ///         (ExamineInteractionProcessor prints "nothing special about the {longest noun}"), so a new
+    ///         long synonym silently renames the door. "narrow emergency bulkhead" must stay the longest.
+    ///     </para>
+    /// </remarks>
     public override string[] NounsForMatching =>
-        ["bulkhead", "bulkhead door", "door", "pod", "pod door", "escape pod door", "narrow emergency bulkhead"];
+    [
+        // POD-DOOR
+        "bulkhead", "door", "bulkhead door",
+        "emergency bulkhead", "escape bulkhead", "pod bulkhead",
+        "emergency door", "escape door", "pod door",
+        "escape pod bulkhead", "escape pod door", "narrow emergency bulkhead",
+        // GLOBAL-POD
+        "pod", "emergency pod", "escape pod", "primary pod"
+    ];
 
     public bool IsOpen { get; set; }
 

--- a/UnitTests/IntentMappings/base-mappings.json
+++ b/UnitTests/IntentMappings/base-mappings.json
@@ -53,6 +53,16 @@
     { "inputs": ["press message playback button"], "verb": "press", "noun": "message playback button" },
     { "inputs": ["press glowing button"], "verb": "press", "noun": "glowing button" },
 
+    // The escape-pod bulkhead, named the way Deck Nine's own description names it. The live AI parser
+    // returns both shapes for these - the whole phrase as one noun, or split into adjective + noun -
+    // so both are stubbed here (issue: "open escape pod" was answered as if no pod existed).
+    { "inputs": ["open escape pod"], "verb": "open", "noun": "escape pod" },
+    { "inputs": ["open the escape pod"], "verb": "open", "noun": "pod", "adjective": "escape" },
+    { "inputs": ["open pod bulkhead"], "verb": "open", "noun": "pod bulkhead" },
+    { "inputs": ["open the pod bulkhead"], "verb": "open", "noun": "bulkhead", "adjective": "pod" },
+    { "inputs": ["open emergency bulkhead"], "verb": "open", "noun": "bulkhead", "adjective": "emergency" },
+    { "inputs": ["open escape pod bulkhead"], "verb": "open", "noun": "escape pod bulkhead" },
+
     { "inputs": ["open red door"], "verb": "open", "noun": "red door" },
     { "inputs": ["close red door"], "verb": "close", "noun": "red door" },
     { "inputs": ["examine red door"], "verb": "examine", "noun": "red door" },

--- a/UnitTests/IntentMappings/base-mappings.json
+++ b/UnitTests/IntentMappings/base-mappings.json
@@ -60,8 +60,12 @@
     { "inputs": ["open the escape pod"], "verb": "open", "noun": "pod", "adjective": "escape" },
     { "inputs": ["open pod bulkhead"], "verb": "open", "noun": "pod bulkhead" },
     { "inputs": ["open the pod bulkhead"], "verb": "open", "noun": "bulkhead", "adjective": "pod" },
-    { "inputs": ["open emergency bulkhead"], "verb": "open", "noun": "bulkhead", "adjective": "emergency" },
     { "inputs": ["open escape pod bulkhead"], "verb": "open", "noun": "escape pod bulkhead" },
+    { "inputs": ["examine escape pod"], "verb": "examine", "noun": "escape pod" },
+    // Deliberately NOT a pod-door name: the original shares the EMERGENCY adjective across three doors
+    // in Deck Nine's scope, so this phrase is ambiguous rather than POD-DOOR's. Stubbed so the test can
+    // prove the pod door does not claim it.
+    { "inputs": ["open emergency bulkhead"], "verb": "open", "noun": "bulkhead", "adjective": "emergency" },
 
     { "inputs": ["open red door"], "verb": "open", "noun": "red door" },
     { "inputs": ["close red door"], "verb": "close", "noun": "red door" },


### PR DESCRIPTION
## The bug

```
> open escape pod
Ah, the elusive escape pod—a mythical creature of the corridor, perhaps? It seems
to have taken a day off.
```

On Deck Nine, `open escape pod` was answered as if no pod existed. So was `open pod
bulkhead` — which is the exact phrase the room's own description uses:

> "…To port is the entrance to one of the ship's primary escape pods. **The pod bulkhead** is closed."

## Root cause

`BulkheadDoor.NounsForMatching` held `"pod"` and `"pod door"` but neither `"escape pod"`
nor `"pod bulkhead"`.

Item routing on this path is exact-match only — `SimpleIntent.MatchNounAndAdjective`
concatenates `"{Adjective} {Noun}"` and compares it against that list, with no
containment fallback. So **both** shapes the AI parser returns missed the door:

| parser output | matched? |
|---|---|
| `Noun: "escape pod"` | no |
| `Noun: "pod", Adjective: "escape"` | no |
| `Noun: "pod"` | yes |

The engine then fell through to `Repository.ItemExistsInTheStory`, which *does* match by
containment (`"pod"` inside `"escape pod"`), so the player got the "that noun exists but
isn't here" narration instead of the door's own refusal.

**Not a code regression.** `git log -S` shows the noun list unchanged since Dec 2024, and
`open pod` / `open bulkhead` have always worked. What changed is the AI parser drifting
from returning `"pod"` to returning the fuller phrase the player typed — the gap was
always there.

## Verification against the original

`planetfall-source/globals.zil` states this as two objects sharing one command:

- **`POD-DOOR`** (globals.zil:1094) — `DESC` "escape pod bulkhead", synonyms `DOOR`/`BULKHEAD`, adjectives `EMERGENCY`/`ESCAPE`/`POD`
- **`GLOBAL-POD`** (globals.zil:904) — `DESC` "escape pod", synonym `POD`, adjectives `EMERGENCY`/`ESCAPE`/`PRIMARY`
- **`GLOBAL-POD-F`** (globals.zil:925) — sends `OPEN` straight to `POD-DOOR`, so naming the
  pod and naming its bulkhead are the same command

This port merges the two into `BulkheadDoor`, so it now carries the union of both name sets.

### One name deliberately *not* claimed

`ADJECTIVE EMERGENCY` is shared across **three** objects in Deck Nine's scope — `POD-DOOR`,
`GANGWAY-DOOR` (globals.zil:1139) and `CORRIDOR-DOOR` (globals.zil:1133) — the latter two
becoming referenceable the turn they slam shut (globals.zil:1216, `FCLEAR ... INVISIBLE`;
both are in Deck Nine's `GLOBAL` list at globals.zil:505). So `"emergency bulkhead"` and
`"emergency door"` are ambiguous there, not names `POD-DOOR` owns. Claiming them would mean
that on the very turn the game narrates

> "More distant explosions! A narrow emergency bulkhead at the base of the gangway and a wider one along the corridor to starboard both crash shut!"

…`open emergency bulkhead` answers for the *escape pod*. The adjective-qualified names the
pod door owns uniquely (`escape`/`pod` × `bulkhead`/`door`) carry the fix on their own.
`"emergency pod"` **is** kept — `POD` is `GLOBAL-POD`'s synonym alone, so it's unambiguous.

## Also fixed: the door was displayed under another door's name

The **longest** noun doubles as the item's display name — `ExamineInteractionProcessor`
prints `"nothing special about the {longest noun}"`. That longest entry was
`"narrow emergency bulkhead"`, which is `GANGWAY-DOOR`'s name (globals.zil:1139), not this
door's. Latent while only `"pod"`/`"pod door"` reached it; once `"escape pod"` was added,
`examine escape pod` answered:

> There is nothing special about the narrow emergency bulkhead.

— a different door entirely. Dropped, so `POD-DOOR`'s own `DESC` `"escape pod bulkhead"` is
now the longest and the name the game prints. `DoorTests.ExamineBulkhead_StillWorks` asserts
the corrected name.

## TDD

`PodDoorNames` fixture in `Planetfall.Tests/EnterPodTests.cs`:

- 7 `[TestCase]`s over every name the door should answer to. Before the fix the 5 new
  phrasings failed on the assertion diff and the 2 already-working ones passed; after, all 7 pass.
- `ExaminePod_AnswersUnderThePodsOwnBulkheadName` — naming the pod answers under the pod's
  bulkhead name, not the gangway's.
- `AmbiguousEmergencyName_IsNotClaimedByThePodDoor` — the shared `EMERGENCY` phrase stays unclaimed.

Both of the latter two were verified to **fail** when the offending nouns are put back, so
they're real guards rather than vacuous passes.

Both parser shapes are stubbed in `base-mappings.json`, since the live parser genuinely
returns both — confirmed by probing the resolved intents (`open escape pod` →
`noun:"escape pod"`, `open the escape pod` → `noun:"pod", adj:"escape"`).

## Noticed, deliberately not changed

Overloading "longest noun" as the display name is fragile by design — any noun addition
anywhere can silently rename an object, as it did here. Worth a dedicated `DisplayName`
some day; out of scope for a bug fix.

## Tests

| suite | result |
|---|---|
| Planetfall.Tests | 3923 passed |
| UnitTests | 1131 passed, 1 skipped |
| ZorkOne.Tests | 1782 passed |
| EscapeRoom.Tests | 9 passed |
| Stationfall.Tests | 4 passed |

`dotnet build` — succeeded, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
