### PR TITLE
Recover omitted multi-noun parser prepositions

### DIFF
--- a/Model/ParsingHelper.cs
+++ b/Model/ParsingHelper.cs
@@ -7,6 +7,16 @@ namespace Model;
 
 public static class ParsingHelper
 {
+    // These are the connectors accepted by multi-noun handlers across the games. They give us a
+    // deterministic fallback when the AI identifies both nouns but intermittently omits the
+    // <preposition> tag (#538).
+    private static readonly string[] MultiNounPrepositions =
+    [
+        "down into", "next to", "underneath", "through", "towards", "against", "across", "using", "beside",
+        "toward", "with", "onto", "into", "under", "over", "near", "from", "off", "down", "at", "by", "in",
+        "on", "to"
+    ];
+
     // Issue #423: whole-scene nouns that mean "the room itself", not a specific object. When gpt-4o tags a
     // non-exact room-look ("look at the room", "look around the area") as intent=look with one of these as
     // the noun, it is still a bare room-look and must render the room — NOT be redirected to a targeted
@@ -223,8 +233,7 @@ public static class ParsingHelper
             if (string.IsNullOrEmpty(prepositionTag))
             {
                 logger?.LogDebug("No preposition was found trying to make a MultiNoun intent");
-                // TODO: Claude is inconsistent giving us the preposition. For now, hardcode the most common one if we don't get it. 
-                prepositionTag = "with";
+                prepositionTag = RecoverPrepositionFromInput(originalInput, nouns[0], nouns[1]) ?? "with";
             }
 
             return new MultiNounIntent
@@ -239,6 +248,35 @@ public static class ParsingHelper
         }
 
         return null;
+    }
+
+    private static string? RecoverPrepositionFromInput(string input, string nounOne, string nounTwo)
+    {
+        var nounOneIndex = input.IndexOf(nounOne, StringComparison.OrdinalIgnoreCase);
+        if (nounOneIndex < 0)
+            return null;
+
+        var textAfterNounOne = nounOneIndex + nounOne.Length;
+        var nounTwoIndex = input.IndexOf(nounTwo, textAfterNounOne, StringComparison.OrdinalIgnoreCase);
+        if (nounTwoIndex < 0)
+            return null;
+
+        var betweenNouns = input[textAfterNounOne..nounTwoIndex];
+        var normalized = string.Concat(betweenNouns.Select(character =>
+            char.IsLetter(character) || char.IsWhiteSpace(character) ? char.ToLowerInvariant(character) : ' '));
+        var padded = $" {string.Join(' ', normalized.Split(' ', StringSplitOptions.RemoveEmptyEntries))} ";
+
+        // The connector nearest noun two expresses the relationship between the parsed nouns. If a
+        // phrase and its suffix end together ("down into" / "into"), keep the longer phrase.
+        return MultiNounPrepositions
+            .Select(preposition =>
+                (Preposition: preposition,
+                    Index: padded.LastIndexOf($" {preposition} ", StringComparison.Ordinal)))
+            .Where(match => match.Index >= 0)
+            .OrderByDescending(match => match.Index + match.Preposition.Length)
+            .ThenByDescending(match => match.Preposition.Length)
+            .Select(match => match.Preposition)
+            .FirstOrDefault();
     }
 
     private static GoToDestinationIntent? DetermineGoToIntent(string? response)

--- a/UnitTests/Models/ParsingHelperTests.cs
+++ b/UnitTests/Models/ParsingHelperTests.cs
@@ -236,6 +236,45 @@ public class ParsingHelperTests
         multiNounIntent?.Message.Should().Be(MultiNounResponse);
     }
 
+    [TestCase("set dial to 419", "set", "dial", "419", "to")]
+    [TestCase("set laser to 1", "set", "laser", "1", "to")]
+    [TestCase("put the shiny in the panel", "put", "shiny", "panel", "in")]
+    [TestCase("put good in cube", "put", "good", "cube", "in")]
+    [TestCase("slide teleportation card through slot", "slide", "teleportation card", "slot", "through")]
+    [TestCase("drop magnet down into the crack", "drop", "magnet", "crack", "down into")]
+    [TestCase("put magnet down on panel", "put", "magnet", "panel", "on")]
+    public void GetIntent_WhenModelOmitsMultiNounPreposition_RecoversItFromOriginalInput(
+        string input, string verb, string nounOne, string nounTwo, string expectedPreposition)
+    {
+        // Production repro for #538. gpt-4o intermittently omitted the preposition tag for this
+        // command family. ParsingHelper replaced every missing preposition with "with", producing
+        // `set dial with 419`; ConferenceRoomDoor only accepts "to", so no handler ran.
+        var response = $@"<intent>act</intent>
+<verb>{verb}</verb>
+<noun>{nounOne}</noun>
+<noun>{nounTwo}</noun>";
+
+        var result = ParsingHelper.GetIntent(input, response, _loggerMock?.Object);
+
+        result.Should().BeOfType<MultiNounIntent>()
+            .Which.Preposition.Should().Be(expectedPreposition);
+    }
+
+    [Test]
+    public void GetIntent_WhenMissingPrepositionCannotBeRecovered_PreservesWithFallback()
+    {
+        const string input = "with the wrench, turn the bolt";
+        const string response = @"<intent>act</intent>
+<verb>turn</verb>
+<noun>bolt</noun>
+<noun>wrench</noun>";
+
+        var result = ParsingHelper.GetIntent(input, response, _loggerMock?.Object);
+
+        result.Should().BeOfType<MultiNounIntent>()
+            .Which.Preposition.Should().Be("with");
+    }
+
     [Test]
     public void GetIntent_WithMultipleVerbs_ReturnsMultipleCommandsIntent()
     {


### PR DESCRIPTION
## Summary

- recover a missing multi-noun preposition from the player's original command instead of always substituting `with`
- select the connector nearest the second noun, preserving multi-word connectors such as `down into`
- retain the historical `with` fallback when noun order prevents safe recovery
- add deterministic regression coverage for the affected `set`, `put`, and `slide` command shapes

## Root cause

Production parsing logs for #538 showed that GPT-4o intermittently omitted `<preposition>to</preposition>` while still returning both nouns. `ParsingHelper` converted every omitted preposition to `with`, producing intents such as `set dial with 419`. The Planetfall handlers require `to`, so those turns reached no handler.

The logged outcomes line up with that transformation: malformed `set dial to 419` and `set dial to 42` parses became `with` and failed, while adjacent parses containing `to` succeeded.

## Impact

Commands whose parser response omits the preposition can now retain the relationship the player actually typed, allowing deterministic game handlers to match. This addresses the identified root cause for the critical `set` failures and several `put` failures in #538.

Production logs for some reported `slide`, `take`, and `press` failures contained correctly shaped intents; those may represent a separate state or dispatch issue and are not claimed fixed here.

## Validation

- red: focused regression produced expected `on`, actual `down` before the connector-selection correction
- `dotnet test UnitTests/UnitTests.csproj --no-restore --filter 'FullyQualifiedName~ParsingHelperTests.GetIntent_WhenModelOmitsMultiNounPreposition_RecoversItFromOriginalInput'` — 7 passed
- `dotnet test UnitTests/UnitTests.csproj --no-restore` — 1,139 passed, 1 skipped
- `git diff --check`

Addresses #538.