### PR TITLE
Fix #529: seal Deck Nine's Up/East exits when the emergency bulkheads crash shut

### DIFF
--- a/Planetfall.Tests/ExplosionTests.cs
+++ b/Planetfall.Tests/ExplosionTests.cs
@@ -926,6 +926,58 @@ public class ExplosionTests : EngineTestsBase
 
             target.Context.CurrentLocation.Should().BeOfType<ReactorLobby>();
         }
+
+        // The two exits back onto Deck Nine are gated on the same bulkheads (globals.zil:646 gates the
+        // Gangway's DOWN on GANGWAY-DOOR; globals.zil:629 gates the Reactor Lobby's WEST on
+        // CORRIDOR-DOOR). The DeckNine-side tests above already prove ExplosionCoordinator closes both
+        // doors at the seal, so these characterize the return-exit gates themselves: open before the
+        // seal, refused after. Driven by the door state directly rather than the 11-wait sequence
+        // because once the bulkheads shut, both rooms are one turn from the unconditional move-12
+        // explosion death - a player can't stand in either and try the door without being killed first.
+        // A fresh target per state keeps the two halves independent (GetTarget resets the Repository).
+        [Test]
+        public async Task GangwayDownToDeckNine_IsGatedOnTheNarrowBulkhead()
+        {
+            // Open (the door's start state): Down is a real exit back to Deck Nine.
+            var openTarget = GetTarget();
+            openTarget.Context.CurrentLocation = Repository.GetLocation<Gangway>();
+            Repository.GetItem<GangwayDoor>().IsOpen = true;
+
+            (await openTarget.GetResponse("down")).Should().NotContain("The emergency bulkhead is closed.");
+            openTarget.Context.CurrentLocation.Should().BeOfType<DeckNine>();
+
+            // Closed (as ExplosionCoordinator leaves it after the seal): Down is refused, no escape back.
+            var sealedTarget = GetTarget();
+            sealedTarget.Context.CurrentLocation = Repository.GetLocation<Gangway>();
+            Repository.GetItem<GangwayDoor>().IsOpen = false;
+
+            var response = await sealedTarget.GetResponse("down");
+
+            response.Should().Contain("The emergency bulkhead is closed.");
+            sealedTarget.Context.CurrentLocation.Should().BeOfType<Gangway>();
+        }
+
+        [Test]
+        public async Task ReactorLobbyWestToDeckNine_IsGatedOnTheWideBulkhead()
+        {
+            // Open (the door's start state): West is a real exit back to Deck Nine.
+            var openTarget = GetTarget();
+            openTarget.Context.CurrentLocation = Repository.GetLocation<ReactorLobby>();
+            Repository.GetItem<CorridorDoor>().IsOpen = true;
+
+            (await openTarget.GetResponse("west")).Should().NotContain("The emergency bulkhead is closed.");
+            openTarget.Context.CurrentLocation.Should().BeOfType<DeckNine>();
+
+            // Closed (as ExplosionCoordinator leaves it after the seal): West is refused, no escape back.
+            var sealedTarget = GetTarget();
+            sealedTarget.Context.CurrentLocation = Repository.GetLocation<ReactorLobby>();
+            Repository.GetItem<CorridorDoor>().IsOpen = false;
+
+            var response = await sealedTarget.GetResponse("west");
+
+            response.Should().Contain("The emergency bulkhead is closed.");
+            sealedTarget.Context.CurrentLocation.Should().BeOfType<ReactorLobby>();
+        }
     }
 
     [TestFixture]

--- a/Planetfall.Tests/ExplosionTests.cs
+++ b/Planetfall.Tests/ExplosionTests.cs
@@ -833,6 +833,101 @@ public class ExplosionTests : EngineTestsBase
         }
     }
 
+    // Issue #529: during the Feinstein explosion, one turn after the pod door opens, the game narrates
+    // that "a narrow emergency bulkhead at the base of the gangway and a wider one along the corridor to
+    // starboard both crash shut". In the original those two doors (CORRIDOR-DOOR / GANGWAY-DOOR) have
+    // their OPENBIT cleared, sealing Deck Nine's East and Up exits so the escape pod is the only way out
+    // (planetfall-source/globals.zil:1211-1216 closes both doors before printing the same message;
+    // globals.zil:493-507 gate DECK-NINE's EAST/UP on them). The port kept the prose but never modelled
+    // the doors: Up and E stayed freely traversable, and walking through a "shut" bulkhead dropped the
+    // player into Reactor Lobby / Gangway and killed them one turn later - a death the original makes
+    // impossible by simply refusing the move.
+    [TestFixture]
+    public class BulkheadSealTests : EngineTestsBase
+    {
+        // Drop the player on Deck Nine with the random ambassador/Blather encounter (DeckNine.Act rolls
+        // 1-6 on moves 2-6) pinned off, so the escape sequence advances deterministically.
+        private GameEngine<PlanetfallGame, PlanetfallContext> DeckNineTarget()
+        {
+            var target = GetTarget();
+            var noSpawn = new Mock<IRandomChooser>();
+            noSpawn.Setup(r => r.RollDice(6)).Returns(3); // neither 1 (ambassador) nor 2 (Blather)
+            Repository.GetLocation<DeckNine>().Chooser = noSpawn.Object;
+            target.Context.CurrentLocation = Repository.GetLocation<DeckNine>();
+            return target;
+        }
+
+        // Advance the explosion until the "both crash shut" beat has fired, staying on Deck Nine.
+        // Nine idle waits (moves 1-9), the tenth command is the explosion (pod door opens), the
+        // eleventh is the seal.
+        private static async Task WaitUntilBulkheadsCrashShut(
+            GameEngine<PlanetfallGame, PlanetfallContext> target)
+        {
+            var response = "";
+            for (var i = 0; i < 11; i++)
+                response = await target.GetResponse("wait");
+
+            response.Should().Contain("both crash shut");
+        }
+
+        [Test]
+        public async Task AfterBulkheadsCrashShut_EastIsBlocked()
+        {
+            var target = DeckNineTarget();
+            await WaitUntilBulkheadsCrashShut(target);
+
+            var response = await target.GetResponse("east");
+
+            response.Should().Contain("The emergency bulkhead is closed.");
+            target.Context.CurrentLocation.Should().BeOfType<DeckNine>();
+        }
+
+        [Test]
+        public async Task AfterBulkheadsCrashShut_UpIsBlocked()
+        {
+            var target = DeckNineTarget();
+            await WaitUntilBulkheadsCrashShut(target);
+
+            var response = await target.GetResponse("up");
+
+            response.Should().Contain("The emergency bulkhead is closed.");
+            target.Context.CurrentLocation.Should().BeOfType<DeckNine>();
+        }
+
+        // The original refuses the move outright; the port let you walk out and be killed the very next
+        // beat. Once sealed, leaving through the corridor must not end the run.
+        [Test]
+        public async Task AfterBulkheadsCrashShut_PlayerDoesNotDieFromLeaving()
+        {
+            var target = DeckNineTarget();
+            await WaitUntilBulkheadsCrashShut(target);
+
+            var afterEast = await target.GetResponse("east");
+            var afterOneMoreTurn = await target.GetResponse("wait");
+
+            afterEast.Should().NotContain("You have died");
+            afterOneMoreTurn.Should().NotContain("You have died");
+            target.Context.DeathCounter.Should().Be(0);
+        }
+
+        // Regression guard: before the seal (at the explosion turn itself), East is still a real exit to
+        // the Reactor Lobby - the fix gates the exit on the bulkhead, it does not amputate it. Green
+        // before and after the fix.
+        [Test]
+        public async Task BeforeBulkheadsCrashShut_EastStillReachesReactorLobby()
+        {
+            var target = DeckNineTarget();
+
+            // Nine waits (moves 1-9); the tenth command is the explosion turn, doors still open.
+            for (var i = 0; i < 9; i++)
+                await target.GetResponse("wait");
+
+            await target.GetResponse("east");
+
+            target.Context.CurrentLocation.Should().BeOfType<ReactorLobby>();
+        }
+    }
+
     [TestFixture]
     public class EscapePodTimelineTests : EngineTestsBase
     {

--- a/Planetfall/Item/Feinstein/CorridorDoor.cs
+++ b/Planetfall/Item/Feinstein/CorridorDoor.cs
@@ -1,0 +1,33 @@
+using GameEngine.Item;
+
+namespace Planetfall.Item.Feinstein;
+
+/// <summary>
+///     The wide emergency bulkhead that seals Deck Nine's starboard corridor to the Reactor Lobby
+///     when the Feinstein starts coming apart. Ported to restore the original's seal mechanic
+///     (issue #529): the game narrates it crashing shut during the explosion
+///     (planetfall-source/globals.zil:1214-1217), and both Deck Nine's EAST exit
+///     (globals.zil:500) and the Reactor Lobby's WEST exit back (globals.zil:629) are gated on its
+///     OPENBIT. It starts open; <see cref="Feinstein.ExplosionCoordinator" /> clears it the turn the
+///     bulkheads crash shut.
+/// </summary>
+/// <remarks>
+///     Deliberately NOT seeded into any room's scope, unlike the pod <see cref="BulkheadDoor" />.
+///     In the original this and <see cref="GangwayDoor" /> both start INVISIBLE and only become
+///     referenceable once they slam shut, and they SHARE the synonyms DOOR/BULKHEAD with the pod
+///     door (globals.zil:1131-1143). Placing them in Deck Nine's scope would make "bulkhead"/"door"
+///     ambiguous with the pod door the player actually needs to reach — the exact ambiguity
+///     <see cref="BulkheadDoor" />'s noun list is written to avoid. Their only job here is to hold
+///     the one bit that gates the exits, so they live purely as state; the exit
+///     <c>MovementParameters</c> read <see cref="IsOpen" /> off the singleton via <c>CanGo</c>.
+/// </remarks>
+internal class CorridorDoor : ItemBase
+{
+    // The wide bulkhead's DESC in the original (globals.zil:1133). Never surfaced in scope, so these
+    // never collide with the pod door: containment matching is directional, and a query for
+    // "bulkhead"/"door" is shorter than "wide bulkhead" and so never resolves to this item.
+    public override string[] NounsForMatching => ["wide bulkhead", "wide emergency bulkhead"];
+
+    // Starts open: Deck Nine's East exit is freely traversable until the explosion seals it.
+    public bool IsOpen { get; set; } = true;
+}

--- a/Planetfall/Item/Feinstein/GangwayDoor.cs
+++ b/Planetfall/Item/Feinstein/GangwayDoor.cs
@@ -1,0 +1,24 @@
+using GameEngine.Item;
+
+namespace Planetfall.Item.Feinstein;
+
+/// <summary>
+///     The narrow emergency bulkhead at the base of the gangway that seals Deck Nine off from the
+///     Gangway when the Feinstein starts coming apart. Ported to restore the original's seal
+///     mechanic (issue #529): the game narrates it crashing shut during the explosion
+///     (planetfall-source/globals.zil:1214-1217), and both Deck Nine's UP exit (globals.zil:503)
+///     and the Gangway's DOWN exit back (globals.zil:646) are gated on its OPENBIT. It starts open;
+///     <see cref="Feinstein.ExplosionCoordinator" /> clears it the turn the bulkheads crash shut.
+/// </summary>
+/// <remarks>
+///     Deliberately NOT seeded into any room's scope — see <see cref="CorridorDoor" /> for why this
+///     and the corridor bulkhead live purely as state rather than as scoped, nameable objects.
+/// </remarks>
+internal class GangwayDoor : ItemBase
+{
+    // The narrow bulkhead's DESC in the original (globals.zil:1141).
+    public override string[] NounsForMatching => ["narrow bulkhead", "narrow emergency bulkhead"];
+
+    // Starts open: Deck Nine's Up exit is freely traversable until the explosion seals it.
+    public bool IsOpen { get; set; } = true;
+}

--- a/Planetfall/Location/Feinstein/DeckNine.cs
+++ b/Planetfall/Location/Feinstein/DeckNine.cs
@@ -59,8 +59,29 @@ internal class DeckNine : LocationBase, ITurnBasedActor
     {
         return new Dictionary<Direction, MovementParameters>
         {
-            { Direction.Up, Go<Gangway>() },
-            { Direction.E, Go<ReactorLobby>() },
+            // Up and East are gated exactly as West/In are: once the emergency bulkheads crash shut
+            // during the explosion (ExplosionCoordinator closes them one turn after the pod door
+            // opens), these two exits seal and the escape pod is the only way out - matching the
+            // original, which refuses the move rather than letting the player walk out to their death
+            // (issue #529; globals.zil:500,503 gate EAST/UP on CORRIDOR-DOOR/GANGWAY-DOOR).
+            {
+                Direction.Up,
+                new MovementParameters
+                {
+                    Location = Repository.GetLocation<Gangway>(),
+                    CanGo = _ => Repository.GetItem<GangwayDoor>().IsOpen,
+                    CustomFailureMessage = "The emergency bulkhead is closed. "
+                }
+            },
+            {
+                Direction.E,
+                new MovementParameters
+                {
+                    Location = Repository.GetLocation<ReactorLobby>(),
+                    CanGo = _ => Repository.GetItem<CorridorDoor>().IsOpen,
+                    CustomFailureMessage = "The emergency bulkhead is closed. "
+                }
+            },
             {
                 Direction.W,
                 new MovementParameters

--- a/Planetfall/Location/Feinstein/ExplosionCoordinator.cs
+++ b/Planetfall/Location/Feinstein/ExplosionCoordinator.cs
@@ -58,6 +58,15 @@ internal class ExplosionCoordinator : ITurnBasedActor
 
             case TurnWhenFeinsteinBlowsUp + 1:
             {
+                // Seal Deck Nine off from the gangway and the starboard corridor, matching the
+                // original, which clears OPENBIT on both bulkheads here (globals.zil:1214-1217)
+                // *before* printing the "crash shut" prose below. Without this the narration was
+                // cosmetic: Deck Nine's Up/East exits stayed open and walking through a "shut"
+                // bulkhead killed the player one turn later (issue #529). Closed no matter where the
+                // player is standing when this beat fires, exactly as the ZIL does it unconditionally.
+                Repository.GetItem<CorridorDoor>().IsOpen = false;
+                Repository.GetItem<GangwayDoor>().IsOpen = false;
+
                 action = context.CurrentLocation switch
                 {
                     _ when context.CurrentLocation is BlatherLocation =>

--- a/Planetfall/Location/Feinstein/Gangway.cs
+++ b/Planetfall/Location/Feinstein/Gangway.cs
@@ -12,7 +12,17 @@ public class Gangway : LocationWithNoStartingItems
     {
         return new Dictionary<Direction, MovementParameters>
         {
-            { Direction.Down, Go<DeckNine>() },
+            // The down exit back to Deck Nine is sealed by the same narrow bulkhead once it crashes
+            // shut in the explosion (issue #529; globals.zil:646 gates DOWN on GANGWAY-DOOR).
+            {
+                Direction.Down,
+                new MovementParameters
+                {
+                    Location = Repository.GetLocation<DeckNine>(),
+                    CanGo = _ => Repository.GetItem<GangwayDoor>().IsOpen,
+                    CustomFailureMessage = "The emergency bulkhead is closed. "
+                }
+            },
             { Direction.Up, Go<DeckEight>() }
         };
     }

--- a/Planetfall/Location/Feinstein/ReactorLobby.cs
+++ b/Planetfall/Location/Feinstein/ReactorLobby.cs
@@ -8,7 +8,17 @@ internal class ReactorLobby : BlatherLocation
     {
         return new Dictionary<Direction, MovementParameters>
         {
-            { Direction.W, Go<DeckNine>() },
+            // The west exit back to Deck Nine is sealed by the same wide corridor bulkhead once it
+            // crashes shut in the explosion (issue #529; globals.zil:629 gates WEST on CORRIDOR-DOOR).
+            {
+                Direction.W,
+                new MovementParameters
+                {
+                    Location = Repository.GetLocation<DeckNine>(),
+                    CanGo = _ => Repository.GetItem<CorridorDoor>().IsOpen,
+                    CustomFailureMessage = "The emergency bulkhead is closed. "
+                }
+            },
             { Direction.E, BlatherBlocksYou() },
             { Direction.S, BlatherBlocksYou() }
         };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1463,9 +1463,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3457,9 +3457,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3982,9 +3982,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6919,9 +6919,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -7369,9 +7369,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
Fixes #529.

## Problem

During the Feinstein explosion, one turn after the escape-pod door opens, the game narrates that Deck Nine has been sealed:

> More distant explosions! A narrow emergency bulkhead at the base of the gangway and a wider one along the corridor to starboard both crash shut!

That message was **purely cosmetic**. Both "sealed" exits (`Up` to the Gangway, `E` to the Reactor Lobby) stayed freely traversable, and walking through either one dropped the player into a room the original seals off and killed them one turn later — a death the original makes impossible, because it simply refuses the move.

Root cause: the two door objects the original uses to gate those exits — `CORRIDOR-DOOR` and `GANGWAY-DOOR` — were never ported. `DeckNine.Map`'s `Up`/`E` were unconditional `Go<T>()`, and `ExplosionCoordinator`'s crash-shut case emitted the prose but mutated no state.

## Original behavior (ZIL — ground truth)

- `globals.zil:500,503` — Deck Nine's `EAST`/`UP` are conditional: `IF CORRIDOR-DOOR IS OPEN` / `IF GANGWAY-DOOR IS OPEN`.
- `globals.zil:629,646` — the return exits (Reactor Lobby `WEST`, Gangway `DOWN`) are gated on the same doors.
- `globals.zil:1214-1217` — at the crash-shut beat the original clears `OPENBIT` on **both** doors *before* printing the same message.

## Fix

Model the two doors the way the pod door is already modelled:

- Add `CorridorDoor` and `GangwayDoor` — state-only bulkhead items that start open.
- Gate `DeckNine.Up`/`E` (and the return exits `Gangway.Down`, `ReactorLobby.W`) on their `IsOpen`, mirroring the existing `W`/`In` pod-door pattern, with a `"The emergency bulkhead is closed."` refusal.
- Close both doors in `ExplosionCoordinator`'s crash-shut case, **before** the narration, so the state change and the message stay in sync.

### Design note

The two doors are **deliberately not seeded into any room's scope**. In the original they start `INVISIBLE` and share the synonyms `DOOR`/`BULKHEAD` with the pod door, so placing them in Deck Nine's scope would reintroduce the exact "bulkhead"/"door" ambiguity `BulkheadDoor`'s noun list is carefully written to avoid. They exist purely as the bit that gates the exits; the exit `CanGo` lambdas read `IsOpen` off the singleton.

## Testing (TDD)

Added `BulkheadSealTests` to `ExplosionTests`:

1. `AfterBulkheadsCrashShut_EastIsBlocked` — east is refused, player still on Deck Nine.
2. `AfterBulkheadsCrashShut_UpIsBlocked` — up is refused, player still on Deck Nine.
3. `AfterBulkheadsCrashShut_PlayerDoesNotDieFromLeaving` — leaving no longer ends the run.
4. `BeforeBulkheadsCrashShut_EastStillReachesReactorLobby` — regression guard: before the seal, east still reaches the Reactor Lobby (green before and after).

Tests 1–3 were **red first for the right reason** (the response was `"Reactor Lobby…"` / `"Gangway…"` and the player died); green after the fix. The random ambassador/Blather encounter is pinned off via a mocked `IRandomChooser` so the sequence is deterministic.

Full solution builds with 0 errors; **Planetfall.Tests 3933/3933** and **UnitTests 1147/1148** (1 pre-existing skip) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)