### PR TITLE
Fix #536 & #537: stop take/drop from grabbing an object the player never named

### DIFF
--- a/GameEngine/Item/ItemProcessor/TakeOrDropInteractionProcessor.cs
+++ b/GameEngine/Item/ItemProcessor/TakeOrDropInteractionProcessor.cs
@@ -115,6 +115,15 @@ public class TakeOrDropInteractionProcessor : IVerbProcessor
             // (e.g. a second Fromitz board) instead of the one actually held. Only fall back to the global
             // lookup when nothing in inventory matches, purely so DropIt can still produce its "you don't
             // have that" message for a real-but-unheld item instead of a silent no-match.
+            //
+            // Issue #536: for a single-object command, resolve the player's noun strictly - a loose
+            // suffix-word match ("drop lower card" -> a top-level-held ID card via its bare "card") must
+            // not drop an item the player never named (DropIt's flat guard only shields nested items).
+            // Quantified commands keep the old loose lookup.
+            if (NounMatch.NamesASingleObject(action.Noun, action.OriginalInput))
+                return DropIt(context, StrictlyNamedItem(action,
+                    noun => Repository.GetItemInInventory(noun, context) ?? Repository.GetItem(noun)));
+
             var specificItem = Repository.GetItemInInventory(action.Noun, context) ?? Repository.GetItem(action.Noun);
             return specificItem is not null ? DropIt(context, specificItem) : new NoNounMatchInteractionResult();
         }
@@ -133,6 +142,19 @@ public class TakeOrDropInteractionProcessor : IVerbProcessor
 
             return DropIt(context, item);
         }
+
+        // Issue #537 (drop side): identical shape to the take branch - the drop list-parser sees the inventory
+        // listing and returns everything held when the player names one item the listing doesn't surface
+        // directly (e.g. a single item nested in an open held container). A multi-element result for a command
+        // that names exactly one object is a non-answer, so resolve the player's own noun and drop that. Only a
+        // genuinely quantified command should drop the batch.
+        //
+        // Issue #536, one branch over: GetItemInInventory also matches by loose containment, and DropIt's flat
+        // guard only protects nested items - a top-level-held item ("drop lower card" -> the ID card) would be
+        // dropped by its bare noun. StrictlyNamedItem requires a precise name before dropping the resolved object.
+        if (NounMatch.NamesASingleObject(action.Noun, action.OriginalInput))
+            return DropIt(context, StrictlyNamedItem(action,
+                noun => Repository.GetItemInInventory(noun, context) ?? Repository.GetItem(noun)));
 
         // When dropping multiple items, we need to provide feedback for items that don't exist.
         // Issue #362: same scoped-first fallback as the single-item branch above - an unscoped
@@ -160,6 +182,18 @@ public class TakeOrDropInteractionProcessor : IVerbProcessor
             // smart enough to match the noun to the item description. An example of this is the "magnet" which is
             // (deliberately, as a puzzle) described as "a metal bar, curved into a U-shape" which the parser does not
             // understand is a magnet. So as a final attempt, let's see if there is a direct noun match.
+            //
+            // Issue #536: GetItemInScope matches by loose word-boundary containment and reaches into worn/held
+            // containers, so a bare noun ("card" on the ID card) gets dragged out by any "<adjective> card"
+            // phrase - "take lower card" in an empty Kitchen quietly pulled the ID card from the uniform pocket
+            // and answered a bare "Taken.". This is the same silent wrong-item substitution #502 removed from the
+            // single-candidate branch, one branch over. For a single-object command resolve the player's noun
+            // strictly: only take what that noun *precisely* names, so a suffix-word coincidence falls through to
+            // the standard "that isn't here" refusal. The magnet still works ("magnet" is one of its own nouns).
+            // A quantified command never resolves one specific object here, so it keeps the old loose lookup.
+            if (NounMatch.NamesASingleObject(action.Noun, action.OriginalInput))
+                return TakeIt(context, StrictlyNamedItem(action, noun => Repository.GetItemInScope(noun, context)));
+
             var specificItem = Repository.GetItemInScope(action.Noun, context);
             return specificItem is not null ? TakeIt(context, specificItem) : new NoNounMatchInteractionResult();
         }
@@ -176,6 +210,21 @@ public class TakeOrDropInteractionProcessor : IVerbProcessor
 
             return TakeIt(context, item);
         }
+
+        // Issue #537: the take list-parser only ever sees the room description and, asked which of *those*
+        // things the player wants, returns the whole room when the player names something that isn't in it
+        // (the reported case was "take medicine" with the medicine inside a held, open bottle). A multi-element
+        // result for a command that names exactly one object is the parser failing to find the noun, not the
+        // player asking for all of them - so resolve the player's own noun and take that one thing. Only a
+        // genuinely quantified command ("take all", "take X and Y") should sweep the room, and
+        // NamesASingleObject is precisely what tells the two apart (issue #502).
+        //
+        // Issue #536, one branch over: GetItemInScope matches by loose containment and reaches into worn/held
+        // containers, so following the noun unguarded would still drag a pocketed item up by a bare noun -
+        // "take lower card" in a populated room pulling the ID card out by its "card". StrictlyNamedItem requires
+        // the resolved object to be *precisely* named; a suffix-word coincidence falls through to the refusal.
+        if (NounMatch.NamesASingleObject(action.Noun, action.OriginalInput))
+            return TakeIt(context, StrictlyNamedItem(action, noun => Repository.GetItemInScope(noun, context)));
 
         // When taking multiple items, we need to provide feedback for items that don't exist
         var itemsWithFeedback = items
@@ -194,11 +243,13 @@ public class TakeOrDropInteractionProcessor : IVerbProcessor
     /// that thing" silently pocketed (or dropped) an unnamed object and answered a bare "Taken."
     ///
     /// <para>This is the take/drop policy: the parser's candidate wins unless the noun the player
-    /// actually typed contradicts it, in which case their own noun wins - and when that resolves to
-    /// nothing, the caller's null handling produces a <see cref="NoNounMatchInteractionResult"/>
-    /// instead of a wrong-item success. The two predicates it leans on are general noun logic and
-    /// live in <see cref="NounMatch"/>; see <see cref="NounMatch.NamesASingleObject"/> in particular
-    /// for why a quantified or multi-object command must be left alone entirely.</para>
+    /// actually typed contradicts it, in which case their own noun wins - resolved through
+    /// <see cref="StrictlyNamedItem"/> so a loose suffix-word coincidence cannot substitute a different
+    /// object (issue #536), and when it resolves to nothing the caller's null handling produces a
+    /// <see cref="NoNounMatchInteractionResult"/> instead of a wrong-item success. The predicates it
+    /// leans on are general noun logic and live in <see cref="NounMatch"/>; see
+    /// <see cref="NounMatch.NamesASingleObject"/> in particular for why a quantified or multi-object
+    /// command must be left alone entirely.</para>
     /// </summary>
     private static IItem? ItemThePlayerActuallyNamed(IItem? candidate, SimpleIntent action,
         Func<string, IItem?> resolveNoun)
@@ -211,7 +262,31 @@ public class TakeOrDropInteractionProcessor : IVerbProcessor
         if (!NounMatch.NamesASingleObject(action.Noun, action.OriginalInput))
             return candidate;
 
-        return NounMatch.CouldName(candidate, action.Noun) ? candidate : resolveNoun(action.Noun);
+        return NounMatch.CouldName(candidate, action.Noun) ? candidate : StrictlyNamedItem(action, resolveNoun);
+    }
+
+    /// <summary>
+    /// The single seam through which every take/drop branch resolves the noun the player *actually
+    /// typed* as the authoritative pick (the zero-, single- re-resolution, and multi-candidate paths).
+    /// It resolves through the given lookup but accepts the result only when the noun *precisely* names
+    /// it (<see cref="NounMatch.PreciselyNames"/>).
+    ///
+    /// <para>The resolvers used here (<see cref="Repository.GetItemInScope"/>,
+    /// <see cref="Repository.GetItemInInventory"/>) match by loose word-boundary containment and reach
+    /// into worn/held containers, so resolving the player's noun unguarded lets a bare candidate noun be
+    /// dragged out by any phrase that merely ends in it - "lower card" pulling the ID card up by its
+    /// "card" (issue #536). Funnelling all three branches through here means the precise-name guard
+    /// cannot be added to one branch and forgotten in another. Returns null - which the TakeIt/DropIt
+    /// callers turn into a <see cref="NoNounMatchInteractionResult"/> - when the noun is empty, resolves
+    /// to nothing, or resolves only by a loose suffix-word coincidence.</para>
+    /// </summary>
+    private static IItem? StrictlyNamedItem(SimpleIntent action, Func<string, IItem?> resolveNoun)
+    {
+        if (string.IsNullOrWhiteSpace(action.Noun))
+            return null;
+
+        var resolved = resolveNoun(action.Noun);
+        return resolved is not null && NounMatch.PreciselyNames(resolved, action.Noun) ? resolved : null;
     }
 
     public static InteractionResult DropIt(IContext context, IItem? castItem)

--- a/GameEngine/NounMatch.cs
+++ b/GameEngine/NounMatch.cs
@@ -74,14 +74,19 @@ public static class NounMatch
     /// candidate noun can be dragged out by any phrase that merely ends in it - this refuses that:
     /// "lower card" does not name the ID card just because "card" is a trailing word of it (issue #536).
     ///
-    /// <para>This is the check the zero-candidate take fallback needs. That branch resolves the player's
-    /// noun through <see cref="Repository.GetItemInScope"/>, whose loose containment reaches into worn and
-    /// held containers; the ID card's bare noun "card" would otherwise let "take lower card" in an empty
-    /// room quietly pull the ID card out of a pocket. Requiring a precise-noun hit keeps the genuine
-    /// fallback cases - the magnet the parser cannot describe ("magnet" is one of its own nouns), an item
-    /// the player really is carrying - while rejecting a suffix-word coincidence. The port distinguishes
-    /// the two cards in exactly this vocabulary: <c>LowerElevatorAccessCard</c> registers "lower card" as
-    /// a precise noun; <c>IdCard</c> does not.</para>
+    /// <para>This is the check the take/drop <c>StrictlyNamedItem</c> guard needs. Those branches resolve
+    /// the player's noun through <see cref="Repository.GetItemInScope"/>, whose loose containment reaches
+    /// into worn and held containers; the ID card's bare noun "card" would otherwise let "take lower card"
+    /// quietly pull the ID card out of a pocket. Requiring a precise-noun hit keeps the genuine cases - the
+    /// magnet the parser cannot describe ("magnet" is one of its own nouns), an item the player really is
+    /// carrying - while rejecting a suffix-word coincidence. The port distinguishes the two cards in exactly
+    /// this vocabulary: <c>LowerElevatorAccessCard</c> registers "lower card" as a precise noun;
+    /// <c>IdCard</c> does not.</para>
+    ///
+    /// <para>Also the single predicate <see cref="Repository.GetPreciseMatchInScope"/> and its
+    /// inventory-scoped sibling resolve their adjective-aware pass with, so "is this noun exactly one of
+    /// the item's precise nouns?" is defined in exactly one place (the lookup half over in
+    /// <see cref="Repository"/> asks it; this comparison half answers it).</para>
     /// </summary>
     public static bool PreciselyNames(IItem candidate, string? noun)
     {

--- a/GameEngine/NounMatch.cs
+++ b/GameEngine/NounMatch.cs
@@ -68,6 +68,33 @@ public static class NounMatch
     }
 
     /// <summary>
+    /// A deliberately stricter sibling of <see cref="CouldName"/>: true only when the typed noun is,
+    /// verbatim, one of the item's own precise nouns (<see cref="IItem.NounsForPreciseMatching"/>).
+    /// Where <see cref="CouldName"/> allows word-boundary containment in both directions - so a bare
+    /// candidate noun can be dragged out by any phrase that merely ends in it - this refuses that:
+    /// "lower card" does not name the ID card just because "card" is a trailing word of it (issue #536).
+    ///
+    /// <para>This is the check the zero-candidate take fallback needs. That branch resolves the player's
+    /// noun through <see cref="Repository.GetItemInScope"/>, whose loose containment reaches into worn and
+    /// held containers; the ID card's bare noun "card" would otherwise let "take lower card" in an empty
+    /// room quietly pull the ID card out of a pocket. Requiring a precise-noun hit keeps the genuine
+    /// fallback cases - the magnet the parser cannot describe ("magnet" is one of its own nouns), an item
+    /// the player really is carrying - while rejecting a suffix-word coincidence. The port distinguishes
+    /// the two cards in exactly this vocabulary: <c>LowerElevatorAccessCard</c> registers "lower card" as
+    /// a precise noun; <c>IdCard</c> does not.</para>
+    /// </summary>
+    public static bool PreciselyNames(IItem candidate, string? noun)
+    {
+        if (string.IsNullOrWhiteSpace(noun))
+            return false;
+
+        var typed = noun.ToLowerInvariant().Trim();
+
+        return candidate.NounsForPreciseMatching
+            .Any(n => n.Trim().Equals(typed, StringComparison.InvariantCultureIgnoreCase));
+    }
+
+    /// <summary>
     /// True only when the command names exactly one object. Callers that verify an AI list-parser's
     /// candidate against the noun the IntentParser extracted must gate on this first (issue #502).
     ///

--- a/GameEngine/Repository.cs
+++ b/GameEngine/Repository.cs
@@ -120,8 +120,7 @@ public static class Repository
     private static IItem? GetPreciseMatchInInventory(string noun, IContext context)
     {
         return (context.GetAllItemsRecursively ?? [])
-            .FirstOrDefault(item => item.NounsForPreciseMatching
-                .Any(n => n.Equals(noun, StringComparison.InvariantCultureIgnoreCase)));
+            .FirstOrDefault(item => NounMatch.PreciselyNames(item, noun));
     }
 
     /// <summary>
@@ -200,7 +199,7 @@ public static class Repository
 
         return candidates.FirstOrDefault(item =>
             IsItemAccessible(item, context) &&
-            item.NounsForPreciseMatching.Any(n => n.Equals(noun, StringComparison.InvariantCultureIgnoreCase)));
+            NounMatch.PreciselyNames(item, noun));
     }
 
     /// <summary>

--- a/UnitTests/NounMatchTests.cs
+++ b/UnitTests/NounMatchTests.cs
@@ -1,5 +1,7 @@
 using GameEngine;
 using GameEngine.Item;
+using Planetfall.Item.Feinstein;
+using Planetfall.Item.Kalamontee.Admin;
 using ZorkOne.Item;
 
 namespace UnitTests;
@@ -142,6 +144,51 @@ public class NounMatchTests
         public void NamesASingleObject_ToleratesANullOriginalInput()
         {
             NounMatch.NamesASingleObject("lantern", null).Should().BeTrue();
+        }
+    }
+
+    [TestFixture]
+    public class PreciselyNamesTests : NounMatchTests
+    {
+        [Test]
+        public void PreciselyNames_RejectsASuffixWordCoincidence()
+        {
+            // Issue #536: the ID card's bare noun "card" is a trailing word of "lower card", so the
+            // looser CouldName says yes - which is exactly how "take lower card" in an empty room
+            // dragged the ID card out of a pocket. PreciselyNames must say no: "lower card" is not one
+            // of the ID card's own precise nouns.
+            var idCard = Repository.GetItem<IdCard>();
+
+            NounMatch.CouldName(idCard, "lower card").Should()
+                .BeTrue("this is the loose match PreciselyNames is meant to be stricter than");
+            NounMatch.PreciselyNames(idCard, "lower card").Should().BeFalse();
+        }
+
+        [Test]
+        public void PreciselyNames_AcceptsTheCardThatActuallyRegistersThatPhrase()
+        {
+            // The port distinguishes the two cards in exactly this vocabulary: the lower elevator access
+            // card registers "lower card" as one of its precise nouns, the ID card does not.
+            NounMatch.PreciselyNames(Repository.GetItem<LowerElevatorAccessCard>(), "lower card").Should().BeTrue();
+        }
+
+        [TestCase("lantern", TestName = "PreciselyNames_ExactBareNoun")]
+        [TestCase("brass lantern", TestName = "PreciselyNames_ExactAdjectivePhrase")]
+        [TestCase("LANTERN", TestName = "PreciselyNames_IsCaseInsensitive")]
+        [TestCase("  brass lantern  ", TestName = "PreciselyNames_IgnoresSurroundingWhitespace")]
+        public void PreciselyNames_AcceptsTheItemsOwnNouns(string noun)
+        {
+            NounMatch.PreciselyNames(Repository.GetItem<Lantern>(), noun).Should().BeTrue();
+        }
+
+        [TestCase("lower lantern", TestName = "PreciselyNames_RejectsAnAdjectiveTheItemDoesNotRegister")]
+        [TestCase("xyzzy", TestName = "PreciselyNames_RejectsNonsense")]
+        [TestCase("", TestName = "PreciselyNames_RejectsEmpty")]
+        [TestCase("   ", TestName = "PreciselyNames_RejectsWhitespace")]
+        [TestCase(null, TestName = "PreciselyNames_RejectsNull")]
+        public void PreciselyNames_RejectsWhatIsNotOneOfItsNouns(string? noun)
+        {
+            NounMatch.PreciselyNames(Repository.GetItem<Lantern>(), noun).Should().BeFalse();
         }
     }
 }

--- a/UnitTests/SingleNounProcessors/TakeProcessorTests.cs
+++ b/UnitTests/SingleNounProcessors/TakeProcessorTests.cs
@@ -5,6 +5,8 @@ using Model.AIGeneration;
 using Model.Intent;
 using Model.Interaction;
 using Model.Interface;
+using Planetfall.Item.Feinstein;
+using Planetfall.Item.Kalamontee.Mech;
 
 namespace UnitTests.SingleNounProcessors;
 
@@ -499,6 +501,314 @@ public class TakeProcessorTests : EngineTestsBase
 
         result.Should().Contain("Dropped");
         target.Context.HasItem<Lantern>().Should().BeFalse();
+    }
+
+    [Test]
+    public async Task Take_ZeroCandidates_NounLooselyMatchesAPocketedItem_DoesNotSilentlyTakeIt()
+    {
+        // Issue #536: the zero-candidate fallback (parser returns nothing, as it does in an empty room)
+        // resolved action.Noun through Repository.GetItemInScope, whose loose word-boundary containment
+        // reaches into worn/held containers. The ID card's bare noun "card" is a trailing word of "lower
+        // card", so "take lower card" in a room with nothing takeable quietly pulled the ID card out of a
+        // pocket and answered a bare "Taken." - the same silent wrong-item substitution #502 removed from
+        // the single-candidate branch, one branch over. The stub returning an EMPTY list is what
+        // production really does here; the pre-existing #502 tests all stub a non-empty list.
+        var target = GetTarget();
+        target.Context.CurrentLocation = Repository.GetLocation<NorthOfHouse>();
+
+        var sack = Repository.GetItem<BrownSack>();
+        target.Context.Take(sack);
+        sack.IsOpen = true;
+        var idCard = Repository.GetItem<IdCard>();
+        sack.ItemPlacedHere(idCard);
+
+        TakeAndDropParser.Setup(s => s.GetListOfItemsToTake(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync([]);
+
+        IVerbProcessor processor = new TakeOrDropInteractionProcessor(TakeAndDropParser.Object);
+        var result = await processor.Process(
+            new SimpleIntent { Verb = "take", Noun = "lower card", OriginalInput = "take lower card" },
+            target.Context, Repository.GetItem<Lantern>(), Client.Object);
+
+        result.Should().BeOfType<NoNounMatchInteractionResult>();
+        target.Context.HasItem<IdCard>().Should().BeFalse("the player never named the ID card");
+        idCard.CurrentLocation.Should().Be(sack, "the ID card must stay where it was stowed");
+    }
+
+    [Test]
+    public async Task Take_ZeroCandidates_RoomItemTheParserCannotDescribe_IsStillTaken()
+    {
+        // Issue #536 guard rail: the whole reason this fallback exists is the magnet, which is
+        // (deliberately, as a puzzle) described as "a metal bar, curved into a U-shape" so the list
+        // parser does not recognise it and returns nothing. "take magnet" with the magnet in the room
+        // must still succeed - "magnet" is one of the magnet's own nouns, so it precisely names it.
+        var target = GetTarget();
+        var location = Repository.GetLocation<NorthOfHouse>();
+        target.Context.CurrentLocation = location;
+        location.ItemPlacedHere(Repository.GetItem<Magnet>());
+
+        TakeAndDropParser.Setup(s => s.GetListOfItemsToTake(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync([]);
+
+        IVerbProcessor processor = new TakeOrDropInteractionProcessor(TakeAndDropParser.Object);
+        var result = await processor.Process(
+            new SimpleIntent { Verb = "take", Noun = "magnet", OriginalInput = "take magnet" },
+            target.Context, Repository.GetItem<Magnet>(), Client.Object);
+
+        result!.InteractionMessage.Should().Contain("Taken");
+        target.Context.HasItem<Magnet>().Should().BeTrue();
+    }
+
+    [Test]
+    public async Task Take_ZeroCandidates_ItemGenuinelyCarried_IsStillTaken()
+    {
+        // Issue #536 guard rail: naming something you really are carrying (inside an open held
+        // container) must still resolve - the fix rejects a suffix-word coincidence, not a genuine
+        // noun that precisely names a carried item.
+        var target = GetTarget();
+        target.Context.CurrentLocation = Repository.GetLocation<NorthOfHouse>();
+
+        var sack = Repository.GetItem<BrownSack>();
+        target.Context.Take(sack);
+        sack.IsOpen = true;
+        sack.ItemPlacedHere(Repository.GetItem<Lunch>());
+
+        TakeAndDropParser.Setup(s => s.GetListOfItemsToTake(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync([]);
+
+        IVerbProcessor processor = new TakeOrDropInteractionProcessor(TakeAndDropParser.Object);
+        var result = await processor.Process(
+            new SimpleIntent { Verb = "take", Noun = "lunch", OriginalInput = "take lunch" },
+            target.Context, Repository.GetItem<Lantern>(), Client.Object);
+
+        result!.InteractionMessage.Should().Contain("Taken");
+        target.Context.HasItem<Lunch>().Should().BeTrue("the player named the lunch and is carrying it");
+    }
+
+    [Test]
+    public async Task Take_MultiCandidate_SingleObjectNamed_TakesOnlyThatNoun_NotTheWholeRoom()
+    {
+        // Issue #537: the take list-parser only sees the room description, so when the player names one
+        // object that is NOT in the room (the reported case was "take medicine" with the medicine inside
+        // a held, open bottle) it returns the room's whole contents. The engine treated that multi-
+        // element list as "the player asked for all of these" and swept every portable item in the room
+        // - without picking up the thing actually named. A single-object command must follow the noun.
+        var target = GetTarget();
+        var location = Repository.GetLocation<NorthOfHouse>();
+        target.Context.CurrentLocation = location;
+        location.ItemPlacedHere(Repository.GetItem<Sword>());
+        location.ItemPlacedHere(Repository.GetItem<Lantern>());
+        location.ItemPlacedHere(Repository.GetItem<Rope>());
+
+        var sack = Repository.GetItem<BrownSack>();
+        target.Context.Take(sack);
+        sack.IsOpen = true;
+        sack.ItemPlacedHere(Repository.GetItem<Lunch>());
+
+        TakeAndDropParser.Setup(s => s.GetListOfItemsToTake(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(["sword", "lantern", "rope"]);
+
+        IVerbProcessor processor = new TakeOrDropInteractionProcessor(TakeAndDropParser.Object);
+        var result = await processor.Process(
+            new SimpleIntent { Verb = "take", Noun = "lunch", OriginalInput = "take lunch" },
+            target.Context, Repository.GetItem<Sword>(), Client.Object);
+
+        result!.InteractionMessage.Should().Contain("Taken");
+        target.Context.HasItem<Lunch>().Should().BeTrue("the player asked for the lunch");
+        target.Context.HasItem<Sword>().Should().BeFalse("the sword was never named");
+        target.Context.HasItem<Lantern>().Should().BeFalse("the lantern was never named");
+        target.Context.HasItem<Rope>().Should().BeFalse("the rope was never named");
+    }
+
+    [Test]
+    public async Task Take_MultiCandidate_QuantifiedRequest_StillTakesEverythingNamed()
+    {
+        // Issue #537 guard rail: a genuinely quantified command ("take X and Y") must keep its take-all
+        // behavior. NamesASingleObject is false here (the input carries " and "), so the multi-take path
+        // is left exactly as it was.
+        var target = GetTarget();
+        var location = Repository.GetLocation<NorthOfHouse>();
+        target.Context.CurrentLocation = location;
+        location.ItemPlacedHere(Repository.GetItem<Sword>());
+        location.ItemPlacedHere(Repository.GetItem<Lantern>());
+
+        TakeAndDropParser.Setup(s => s.GetListOfItemsToTake(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(["sword", "lantern"]);
+
+        IVerbProcessor processor = new TakeOrDropInteractionProcessor(TakeAndDropParser.Object);
+        await processor.Process(
+            new SimpleIntent { Verb = "take", Noun = "sword", OriginalInput = "take the sword and the lantern" },
+            target.Context, Repository.GetItem<Sword>(), Client.Object);
+
+        target.Context.HasItem<Sword>().Should().BeTrue();
+        target.Context.HasItem<Lantern>().Should().BeTrue();
+    }
+
+    [Test]
+    public async Task Drop_MultiCandidate_SingleObjectNamed_DropsOnlyThatNoun_NotEverythingHeld()
+    {
+        // Issue #537 (drop side): GetItemsToDrop has the identical shape - the drop list-parser sees the
+        // inventory listing and can return several held items when the player named just one. A single-
+        // object command must drop only what the noun resolves to, not the whole inventory.
+        var target = GetTarget();
+        target.Context.CurrentLocation = Repository.GetLocation<NorthOfHouse>();
+        target.Context.Take(Repository.GetItem<Sword>());
+        target.Context.Take(Repository.GetItem<Lantern>());
+        target.Context.Take(Repository.GetItem<Rope>());
+
+        TakeAndDropParser.Setup(s => s.GetListOfItemsToDrop(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(["sword", "lantern", "rope"]);
+
+        IVerbProcessor processor = new TakeOrDropInteractionProcessor(TakeAndDropParser.Object);
+        var result = await processor.Process(
+            new SimpleIntent { Verb = "drop", Noun = "sword", OriginalInput = "drop sword" },
+            target.Context, Repository.GetItem<Sword>(), Client.Object);
+
+        result!.InteractionMessage.Should().Contain("Dropped");
+        target.Context.HasItem<Sword>().Should().BeFalse("the player asked to drop the sword");
+        target.Context.HasItem<Lantern>().Should().BeTrue("the lantern was never named");
+        target.Context.HasItem<Rope>().Should().BeTrue("the rope was never named");
+    }
+
+    [Test]
+    public async Task Drop_MultiCandidate_QuantifiedRequest_StillDropsEverythingNamed()
+    {
+        // Issue #537 guard rail (drop side): "drop X and Y" must keep dropping both.
+        var target = GetTarget();
+        target.Context.CurrentLocation = Repository.GetLocation<NorthOfHouse>();
+        target.Context.Take(Repository.GetItem<Sword>());
+        target.Context.Take(Repository.GetItem<Lantern>());
+
+        TakeAndDropParser.Setup(s => s.GetListOfItemsToDrop(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(["sword", "lantern"]);
+
+        IVerbProcessor processor = new TakeOrDropInteractionProcessor(TakeAndDropParser.Object);
+        await processor.Process(
+            new SimpleIntent { Verb = "drop", Noun = "sword", OriginalInput = "drop the sword and the lantern" },
+            target.Context, Repository.GetItem<Sword>(), Client.Object);
+
+        target.Context.HasItem<Sword>().Should().BeFalse();
+        target.Context.HasItem<Lantern>().Should().BeFalse();
+    }
+
+    [Test]
+    public async Task Take_MultiCandidate_NounLooselyMatchesAPocketedItem_DoesNotSilentlyTakeIt()
+    {
+        // Issue #536 through the multi-candidate branch: the zero-candidate fix only guards the
+        // empty-room path, but the same "take lower card pulls the ID card out of a pocket" substitution
+        // is reachable in a POPULATED room. The room-scoped parser returns the room's own items (>1), so
+        // the multi-candidate branch runs; following the player's noun through the loose GetItemInScope
+        // then drags the pocketed ID card up by its bare noun "card". Resolving the noun must require a
+        // *precise* name, exactly as the zero-candidate branch already does.
+        var target = GetTarget();
+        var location = Repository.GetLocation<NorthOfHouse>();
+        target.Context.CurrentLocation = location;
+        location.ItemPlacedHere(Repository.GetItem<Sword>());
+        location.ItemPlacedHere(Repository.GetItem<Lantern>());
+
+        var sack = Repository.GetItem<BrownSack>();
+        target.Context.Take(sack);
+        sack.IsOpen = true;
+        var idCard = Repository.GetItem<IdCard>();
+        sack.ItemPlacedHere(idCard);
+
+        TakeAndDropParser.Setup(s => s.GetListOfItemsToTake(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(["sword", "lantern"]);
+
+        IVerbProcessor processor = new TakeOrDropInteractionProcessor(TakeAndDropParser.Object);
+        var result = await processor.Process(
+            new SimpleIntent { Verb = "take", Noun = "lower card", OriginalInput = "take lower card" },
+            target.Context, Repository.GetItem<Sword>(), Client.Object);
+
+        result.Should().BeOfType<NoNounMatchInteractionResult>();
+        target.Context.HasItem<IdCard>().Should().BeFalse("the player never named the ID card");
+        idCard.CurrentLocation.Should().Be(sack, "the ID card must stay where it was stowed");
+    }
+
+    [Test]
+    public async Task Drop_MultiCandidate_NounLooselyMatchesAHeldItem_DoesNotSilentlyDropIt()
+    {
+        // Issue #536 through the multi-candidate DROP branch: with several items held the drop parser
+        // over-returns, and following the player's noun through the loose GetItemInInventory drags up a
+        // top-level-held item whose bare noun ("card" on the ID card) is a trailing word of the typed
+        // phrase. DropIt's flat guard only protects nested items, so a top-level ID card would be dropped
+        // on "drop lower card" - the same substitution. The resolved item must precisely match the noun.
+        var target = GetTarget();
+        target.Context.CurrentLocation = Repository.GetLocation<NorthOfHouse>();
+        var idCard = Repository.GetItem<IdCard>();
+        target.Context.Take(idCard);
+        target.Context.Take(Repository.GetItem<Sword>());
+        target.Context.Take(Repository.GetItem<Lantern>());
+
+        TakeAndDropParser.Setup(s => s.GetListOfItemsToDrop(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(["sword", "lantern"]);
+
+        IVerbProcessor processor = new TakeOrDropInteractionProcessor(TakeAndDropParser.Object);
+        var result = await processor.Process(
+            new SimpleIntent { Verb = "drop", Noun = "lower card", OriginalInput = "drop lower card" },
+            target.Context, Repository.GetItem<Sword>(), Client.Object);
+
+        result.Should().BeOfType<NoNounMatchInteractionResult>();
+        target.Context.HasItem<IdCard>().Should().BeTrue("the player never named the ID card");
+    }
+
+    [Test]
+    public async Task Take_SingleCandidate_NounLooselyMatchesAPocketedItem_DoesNotSilentlyTakeIt()
+    {
+        // Issue #536 through the single-candidate branch - the most common room shape. With exactly one
+        // describable item in the room the parser returns just that item, and ItemThePlayerActuallyNamed
+        // re-resolves the player's noun when it doesn't match that candidate. That re-resolution used the
+        // loose GetItemInScope, so "take lower card" pulled the pocketed ID card up by its bare noun
+        // "card" - the same substitution the zero- and multi-candidate branches were already guarded
+        // against. The re-resolution must require a precise name too.
+        var target = GetTarget();
+        var location = Repository.GetLocation<NorthOfHouse>();
+        target.Context.CurrentLocation = location;
+        location.ItemPlacedHere(Repository.GetItem<Sword>());
+
+        var sack = Repository.GetItem<BrownSack>();
+        target.Context.Take(sack);
+        sack.IsOpen = true;
+        var idCard = Repository.GetItem<IdCard>();
+        sack.ItemPlacedHere(idCard);
+
+        TakeAndDropParser.Setup(s => s.GetListOfItemsToTake(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(["sword"]);
+
+        IVerbProcessor processor = new TakeOrDropInteractionProcessor(TakeAndDropParser.Object);
+        var result = await processor.Process(
+            new SimpleIntent { Verb = "take", Noun = "lower card", OriginalInput = "take lower card" },
+            target.Context, Repository.GetItem<Sword>(), Client.Object);
+
+        result.Should().BeOfType<NoNounMatchInteractionResult>();
+        target.Context.HasItem<IdCard>().Should().BeFalse("the player never named the ID card");
+        target.Context.HasItem<Sword>().Should().BeFalse("the sword was never named either");
+        idCard.CurrentLocation.Should().Be(sack, "the ID card must stay where it was stowed");
+    }
+
+    [Test]
+    public async Task Drop_ZeroCandidates_NounLooselyMatchesATopLevelHeldItem_DoesNotSilentlyDropIt()
+    {
+        // Issue #536 through the zero-candidate DROP branch: when the drop parser returns nothing the
+        // fallback resolved action.Noun through the loose GetItemInInventory, so "drop lower card" with a
+        // top-level-held ID card dropped it by its bare noun "card". (DropIt's flat guard only protects
+        // nested items.) The zero-candidate drop path must resolve the player's noun strictly, like the
+        // take side.
+        var target = GetTarget();
+        target.Context.CurrentLocation = Repository.GetLocation<NorthOfHouse>();
+        var idCard = Repository.GetItem<IdCard>();
+        target.Context.Take(idCard);
+
+        TakeAndDropParser.Setup(s => s.GetListOfItemsToDrop(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync([]);
+
+        IVerbProcessor processor = new TakeOrDropInteractionProcessor(TakeAndDropParser.Object);
+        var result = await processor.Process(
+            new SimpleIntent { Verb = "drop", Noun = "lower card", OriginalInput = "drop lower card" },
+            target.Context, Repository.GetItem<Sword>(), Client.Object);
+
+        result.Should().BeOfType<NoNounMatchInteractionResult>();
+        target.Context.HasItem<IdCard>().Should().BeTrue("the player never named the ID card");
     }
 
     [Test]

--- a/UnitTests/SingleNounProcessors/TakeProcessorTests.cs
+++ b/UnitTests/SingleNounProcessors/TakeProcessorTests.cs
@@ -812,6 +812,65 @@ public class TakeProcessorTests : EngineTestsBase
     }
 
     [Test]
+    public async Task Drop_SingleCandidate_NounLooselyMatchesAHeldItem_DoesNotSilentlyDropIt()
+    {
+        // Issue #536 through the single-candidate DROP branch - the mirror of the take-side regression.
+        // With one droppable item the drop parser returns just it, and ItemThePlayerActuallyNamed
+        // re-resolves the player's noun when it doesn't match that candidate. That re-resolution routes
+        // through the same StrictlyNamedItem seam as take, so "drop lower card" must not drop a top-level
+        // ID card by its bare noun "card".
+        var target = GetTarget();
+        target.Context.CurrentLocation = Repository.GetLocation<NorthOfHouse>();
+        var idCard = Repository.GetItem<IdCard>();
+        target.Context.Take(idCard);
+        target.Context.Take(Repository.GetItem<Sword>());
+
+        TakeAndDropParser.Setup(s => s.GetListOfItemsToDrop(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(["sword"]);
+
+        IVerbProcessor processor = new TakeOrDropInteractionProcessor(TakeAndDropParser.Object);
+        var result = await processor.Process(
+            new SimpleIntent { Verb = "drop", Noun = "lower card", OriginalInput = "drop lower card" },
+            target.Context, Repository.GetItem<Sword>(), Client.Object);
+
+        result.Should().BeOfType<NoNounMatchInteractionResult>();
+        target.Context.HasItem<IdCard>().Should().BeTrue("the player never named the ID card");
+        target.Context.HasItem<Sword>().Should().BeTrue("the sword was never named either");
+    }
+
+    [Test]
+    public async Task Drop_MultiCandidate_NamedItemIsNested_RefusesWithoutDroppingHeldItems()
+    {
+        // Issue #537 drop plan point 5: the named item resolves precisely but is nested inside an open
+        // held container. DropIt is deliberately flat (only top-level held items drop), so the player must
+        // take a nested item out first - the command must produce "You don't have that!" for the nested
+        // item WITHOUT dropping the other held items the over-returning parser listed.
+        var target = GetTarget();
+        target.Context.CurrentLocation = Repository.GetLocation<NorthOfHouse>();
+
+        var sack = Repository.GetItem<BrownSack>();
+        target.Context.Take(sack);
+        sack.IsOpen = true;
+        var lunch = Repository.GetItem<Lunch>();
+        sack.ItemPlacedHere(lunch);
+        target.Context.Take(Repository.GetItem<Sword>());
+        target.Context.Take(Repository.GetItem<Lantern>());
+
+        TakeAndDropParser.Setup(s => s.GetListOfItemsToDrop(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(["sword", "lantern"]);
+
+        IVerbProcessor processor = new TakeOrDropInteractionProcessor(TakeAndDropParser.Object);
+        var result = await processor.Process(
+            new SimpleIntent { Verb = "drop", Noun = "lunch", OriginalInput = "drop lunch" },
+            target.Context, Repository.GetItem<Sword>(), Client.Object);
+
+        result!.InteractionMessage.Should().Contain("don't have that");
+        lunch.CurrentLocation.Should().Be(sack, "a nested item can't be dropped until it's taken out");
+        target.Context.HasItem<Sword>().Should().BeTrue("the sword was never named");
+        target.Context.HasItem<Lantern>().Should().BeTrue("the lantern was never named");
+    }
+
+    [Test]
     public async Task TakeItem_Disambiguation()
     {
         var target = GetTarget();


### PR DESCRIPTION
## What

Closes two sibling bugs (#536, #537) where a normal `take`/`drop` command moved an object the player never named.

The AI take/drop list-parser only ever sees the **room description** (take) or the **inventory listing** (drop), and is asked which of *those* things the player wants. #502/#508 taught the **single-candidate** branch that "the parser returned one thing" is not "the player asked for that thing" — but the **zero-** and **multi-candidate** branches never got the same lesson:

- **#536 (zero-candidate).** In an empty room, `take lower card` resolved the noun through the loose, container-reaching `GetItemInScope` and quietly pulled the ID card out of a worn pocket by its bare noun `card`, answering a bare `Taken.` — a real failure ("that isn't here") disguised as success.
- **#537 (multi-candidate).** In a room of several items, `take medicine` (medicine inside a held bottle) swept **every** portable item in the room and never took the medicine, because a multi-element parser result was treated as "take all".

## Why it happened

Both branches trusted the parser's item list over the noun the player typed. `Repository.GetItemInScope` / `GetItemInInventory` match by loose word-boundary containment and reach into worn/held containers, so a bare noun like the ID card's `card` is a trailing word of any `<adjective> card` phrase.

## The fix

Every branch that resolves the player's own noun now funnels through one seam, **`StrictlyNamedItem`**, which accepts the resolved object only when the noun *precisely* names it — `NounMatch.PreciselyNames`, an exact match against `NounsForPreciseMatching`. The port already distinguishes the two cards in exactly this vocabulary: `LowerElevatorAccessCard` registers `lower card` as a precise noun; `IdCard` does not.

Routing zero-, single-re-resolution, and multi-candidate paths (both take and drop) through the single guard means a loose suffix-word coincidence can never substitute a different object, and the guard cannot be added to one branch and forgotten in another. While wiring this up I also closed a previously-unspotted top-level-held variant on the zero-candidate **drop** path.

- Genuinely quantified commands (`take all`, `take X and Y`, `everything except Z`) are untouched — `NounMatch.NamesASingleObject` tells the two apart.
- The magnet fallback (a puzzle item the parser deliberately cannot describe) still works — `magnet` is one of its own nouns.

## Reviewer notes

- One deliberate trade-off: in the **parser-malfunction recovery path** (empty/over-returned list), an adjective the item only partially registers — e.g. `elongated sack` when the sack registers `elongated brown sack` but not `elongated sack` — is now refused, where the normal single-candidate path still accepts it via `CouldName`. Refusing a loose match there is preferable to taking an object the player never named.
- This change went through three rounds of `/code-review` at xhigh effort; the reviews are what surfaced the single-candidate and zero-candidate-drop gaps that the final unification closes.

## Original behavior (ZIL)

The original parser never substitutes an object: an unknown word is rejected outright and a known word for an object not in scope gets the standard refusal (`planetfall-source/verbs.zil:48-50`, cited via #508). Naming one object never causes a different object to move.

## Testing

TDD throughout — 12 new deterministic tests (real `Repository`, stubbed list-parser, no AI/random/network) proving each branch's substitution red-first, plus direct `PreciselyNames` predicate tests; the #502 guard rails stay green.

All suites pass: UnitTests 1169, Planetfall.Tests 3929, ZorkOne.Tests 1782, EscapeRoom.Tests 9, Stationfall.Tests 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
