### PR TITLE
Fix #545: stop Floyd's corpse from chatting, squealing, and going on adventures

### DIFF
--- a/GameEngine/ConversationHandler.cs
+++ b/GameEngine/ConversationHandler.cs
@@ -53,6 +53,16 @@ public class ConversationHandler(
             return await TryRouteNamelessSpeech(input, present, context);
         }
 
+        // A character who is gone for good is present in body only, and answers with one fixed line
+        // whatever was said to them. That makes the whole rewriter pipeline below pointless for them,
+        // so they get the deterministic route instead (#545 follow-up). Skipping it is not merely an
+        // optimization: ProcessConversation opens with an AWS Lambda round-trip that can only rewrite
+        // words the character will ignore, and the kill-switch below used to return null for a corpse,
+        // which meant addressing one in NoGeneratedResponses mode produced a blank response rather
+        // than the mourning line.
+        if (targetCharacter.IsGoneForGood)
+            return await RespondForGoneForGoodTalker(input, targetCharacter, context);
+
         // A talkable character is present. Routing the player's utterance to them relies on the AI
         // rewriter, so respect the generation kill-switch exactly as before (#182 behavior).
         if (generationClient.IsDisabled)
@@ -62,6 +72,38 @@ public class ConversationHandler(
         }
 
         return await ProcessConversation(input, targetCharacter, context);
+    }
+
+    /// <summary>
+    /// Answers the player who addressed a PRESENT character who is gone for good (a corpse in the
+    /// room). Their reply does not depend on what was said, so this deliberately does NOT consult the
+    /// <c>ParseConversation</c> rewriter the living path uses - that call is an AWS Lambda round-trip
+    /// whose only product is a command the character will never act on.
+    ///
+    /// Address detection therefore falls to <see cref="IsGenuineDirectAddress"/>, the same
+    /// deterministic test the absent path relies on. That is not a downgrade from the living path's
+    /// backstop: <see cref="TryStripDirectAddress"/> recognizes only the leading-name forms and leaves
+    /// imperative lead-ins ("ask floyd about the card") to the classifier, whereas
+    /// IsGenuineDirectAddress covers both - so a corpse is addressable by strictly more phrasings than
+    /// before, and deterministically, including in NoGeneratedResponses mode.
+    ///
+    /// Returns null when the input merely NAMES the character rather than addressing them ("examine
+    /// floyd", "take floyd"), so those keep falling through to the item's own handlers.
+    /// </summary>
+    private async Task<string?> RespondForGoneForGoodTalker(string input, ICanBeTalkedTo target, IContext context)
+    {
+        if (!IsGenuineDirectAddress(input, target))
+        {
+            logger?.LogDebug("[CONVERSATION DEBUG] Gone-for-good talker named but not addressed; falling through");
+            return null;
+        }
+
+        // The remainder is immaterial - the reply is a constant - but pass the words after the name
+        // when we can strip them, so the character still receives what was actually said to them.
+        TryStripDirectAddress(input, target, out var remainder);
+
+        logger?.LogDebug($"[CONVERSATION DEBUG] Gone-for-good talker addressed with '{remainder}'; answering directly");
+        return await target.OnBeingTalkedTo(remainder, context, generationClient);
     }
 
     /// <summary>

--- a/GameEngine/ConversationHandler.cs
+++ b/GameEngine/ConversationHandler.cs
@@ -231,6 +231,15 @@ public class ConversationHandler(
     {
         var fallback = target.NotHereDescription;
 
+        // A character who is gone for good is never handed to the narrator: asked where they are, it
+        // answers by inventing a whereabouts ("off on his own little adventure"), which reads as a
+        // joke one turn after the player watched them die. Their own static line mourns instead (#545).
+        if (target.IsGoneForGood)
+        {
+            logger?.LogDebug($"[CONVERSATION DEBUG] Talker is gone for good; static line: '{fallback}'");
+            return fallback;
+        }
+
         if (generationClient.IsDisabled)
         {
             logger?.LogDebug($"[CONVERSATION DEBUG] Generation disabled; absent talker fallback: '{fallback}'");

--- a/Model/Item/ICanBeTalkedTo.cs
+++ b/Model/Item/ICanBeTalkedTo.cs
@@ -18,6 +18,16 @@ public interface ICanBeTalkedTo : IInteractionTarget
     Task<string> OnBeingTalkedTo(string text, IContext context, IGenerationClient client);
 
     /// <summary>
+    /// True when this character is gone for good - dead - rather than merely somewhere else.
+    /// Addressing an absent character normally hands the reply to the narrator, which answers a
+    /// whereabouts question by inventing one ("Floyd must be off on his own little adventure") - a
+    /// grotesque thing to read one turn after watching that character die (issue #545). When this is
+    /// true the deterministic <see cref="NotHereDescription"/> is used instead, so the character's
+    /// own author decides how their absence is mourned. Defaults to false.
+    /// </summary>
+    bool IsGoneForGood => false;
+
+    /// <summary>
     /// The terse, static reply shown when the player directly addresses this character by name
     /// while they are not present — e.g. "Floyd isn't here.". This is a fixed string, never an AI
     /// generation, so it is deterministic. The default capitalizes the character's matching name;

--- a/Model/Item/ICanBeTalkedTo.cs
+++ b/Model/Item/ICanBeTalkedTo.cs
@@ -33,17 +33,24 @@ public interface ICanBeTalkedTo : IInteractionTarget
     /// generation, so it is deterministic. The default capitalizes the character's matching name;
     /// override it for non-default phrasing (e.g. "The ambassador isn't here.").
     /// </summary>
-    string NotHereDescription
-    {
-        get
-        {
-            var name = (this as IItem)?.Name;
-            if (string.IsNullOrWhiteSpace(name))
-                return "That character isn't here. ";
+    string NotHereDescription => DefaultNotHereDescription(this);
 
-            // Name defaults to the lowercase matching noun (e.g. "floyd"); player-facing text
-            // should read "Floyd isn't here.".
-            return char.ToUpperInvariant(name[0]) + name[1..] + " isn't here. ";
-        }
+    /// <summary>
+    /// The default phrasing behind <see cref="NotHereDescription"/>, exposed as a static helper.
+    /// C# gives an implementer no way to call a default interface member it has overridden, so
+    /// without this a character who wants to override the line only CONDITIONALLY - Floyd mourns
+    /// once he has died but is otherwise an ordinary "isn't here" - has to paste a copy of the
+    /// default string into its own override, where it silently stops tracking this one. Defer to
+    /// this instead of copying.
+    /// </summary>
+    static string DefaultNotHereDescription(ICanBeTalkedTo talker)
+    {
+        var name = (talker as IItem)?.Name;
+        if (string.IsNullOrWhiteSpace(name))
+            return "That character isn't here. ";
+
+        // Name defaults to the lowercase matching noun (e.g. "floyd"); player-facing text
+        // should read "Floyd isn't here.".
+        return char.ToUpperInvariant(name[0]) + name[1..] + " isn't here. ";
     }
 }

--- a/Planetfall.Tests/AbsentTalkableNpcTests.cs
+++ b/Planetfall.Tests/AbsentTalkableNpcTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using Model.AIGeneration.Requests;
 using Moq;
 using Planetfall.Item.Feinstein;
 using Planetfall.Item.Kalamontee.Mech.FloydPart;
@@ -54,6 +55,60 @@ public class AbsentTalkableNpcTests : EngineTestsBase
 
         response.Should().Contain("Floyd isn't here.");
         response.Should().NotContain("tune");
+    }
+
+    [Test]
+    public async Task AddressingBlather_AfterThePodLands_IsDeterministicNotNarrated()
+    {
+        // Issue #545 review: IsGoneForGood exists to stop the narrator answering "where is X?" by
+        // inventing a whereabouts, but only Floyd opted in. Once the escape pod is down on Resida the
+        // Feinstein and everyone still aboard are beyond reach forever, so Blather must get his own
+        // fixed line rather than an improvisation about what he might be up to.
+        var target = GetTarget();
+        StartHere<DeckNine>();
+        GetLocation<EscapePod>().LandedSafely = true;
+        Mock.Get(target.GenerationClient)
+            .Setup(c => c.GenerateNarration(It.IsAny<TalkingToAbsentCharacterRequest>(), It.IsAny<string>()))
+            .ReturnsAsync("Blather is probably off inspecting another deck.");
+
+        var response = await target.GetResponse("blather, go up");
+
+        response.Should().Contain("Blather isn't here.");
+        response.Should().NotContain("another deck");
+        Context.CurrentLocation.Should().BeOfType<DeckNine>();
+    }
+
+    [Test]
+    public async Task AddressingAmbassador_AfterThePodLands_IsDeterministicNotNarrated()
+    {
+        var target = GetTarget();
+        StartHere<DeckNine>();
+        GetLocation<EscapePod>().LandedSafely = true;
+        Mock.Get(target.GenerationClient)
+            .Setup(c => c.GenerateNarration(It.IsAny<TalkingToAbsentCharacterRequest>(), It.IsAny<string>()))
+            .ReturnsAsync("The ambassador has slithered off somewhere.");
+
+        var response = await target.GetResponse("ambassador, go up");
+
+        response.Should().Contain("The ambassador isn't here.");
+        response.Should().NotContain("slithered");
+    }
+
+    [Test]
+    public async Task AddressingBlather_WhileStillAboard_StillGetsTheNarratedAbsence()
+    {
+        // The gate must be keyed on the pod having landed, not on the explosion: Blather is alive
+        // and barking at the player for several turns after the ship is hit, so while the player is
+        // still aboard his absence is an ordinary "he's elsewhere" the narrator may phrase freely.
+        var target = GetTarget();
+        StartHere<DeckNine>();
+        Mock.Get(target.GenerationClient)
+            .Setup(c => c.GenerateNarration(It.IsAny<TalkingToAbsentCharacterRequest>(), It.IsAny<string>()))
+            .ReturnsAsync("Blather is probably off inspecting another deck.");
+
+        var response = await target.GetResponse("blather, go up");
+
+        response.Should().Contain("another deck");
     }
 
     [Test]

--- a/Planetfall.Tests/BioLockEastTests.cs
+++ b/Planetfall.Tests/BioLockEastTests.cs
@@ -513,7 +513,8 @@ public class BioLockEastTests : EngineTestsBase
     public async Task AfterSacrificeCompletes_ReenteringRoom_DeadFloydDoesNotNagToOpenTheDoor()
     {
         // Issue #493 review follow-up: EndSequence marks Floyd dead and lays his body back in this room but
-        // leaves IsOn true, so IsHereAndIsOn stays true for the corpse. With the leftover
+        // leaves IsOn true, so the old IsOn-only presence test stayed true for the corpse (liveness now
+        // reads Floyd.IsAlive, which excludes him - see #545). With the leftover
         // FloydHasSaidNeedToGetCard flag and a zero door-open counter, re-entering the room made
         // HandleTurnAction fall into the "waiting for door open" branch - the dead robot cheerfully asking
         // the player to open the door again. Once the sequence is Completed the actor must stay silent.

--- a/Planetfall.Tests/FloydTests.cs
+++ b/Planetfall.Tests/FloydTests.cs
@@ -487,6 +487,90 @@ public class FloydTests : EngineTestsBase
     }
 
     [Test]
+    public async Task TalkToFloyd_Dead_MournsInsteadOfChatting()
+    {
+        // Issue #545: EndSequence deliberately leaves the corpse's IsOn true, so the old
+        // !IsOn-only gate in OnBeingTalkedTo let the chat lambda answer for a dead Floyd
+        // ("Floyd says he is okay now that you are here."). The gate must consult HasDied.
+        var target = GetTarget();
+        StartHere<RobotShop>(); // RobotShop.Init places Floyd here, so he is a present talker.
+        var floyd = GetItem<Floyd>();
+        floyd.HasDied = true;
+        floyd.HasEverBeenOn = true;
+        floyd.IsOn = true;
+        var chat = new Mock<IChatWithFloyd>();
+        chat.Setup(s => s.AskFloydAsync(It.IsAny<string>()))
+            .ReturnsAsync(new CompanionResponse("Floyd says he is okay now that you are here.", null));
+        floyd.ChatWithFloyd = chat.Object;
+
+        var response = await target.GetResponse("floyd, are you okay");
+
+        response.Should().NotContain("okay now that you are here");
+        response.Should().Contain("no answer comes");
+        chat.Verify(s => s.AskFloydAsync(It.IsAny<string>()), Times.Never);
+    }
+
+    [Test]
+    public async Task TakeFloyd_Dead_DoesNotSquealAndScootAway()
+    {
+        // Issue #545: CannotBeTakenDescription keyed off IsOn alone, and the corpse's IsOn is
+        // deliberately left true, so "take floyd" served the living-Floyd refusal - the body
+        // giving "a surprised squeal" and moving "a respectable distance away".
+        var target = GetTarget();
+        StartHere<RobotShop>();
+        var floyd = GetItem<Floyd>();
+        floyd.HasDied = true;
+        floyd.HasEverBeenOn = true;
+        floyd.IsOn = true;
+
+        var response = await target.GetResponse("take floyd");
+
+        response.Should().NotContain("surprised squeal");
+        response.Should().Contain("lay him gently back down");
+    }
+
+    [Test]
+    public async Task TalkToFloyd_DeadAndAbsent_AcknowledgesDeathInsteadOfJokingAboutAdventures()
+    {
+        // Issue #545, trapped-death branch: Floyd dies inside the Bio Lab with CurrentLocation
+        // null, so addressing him takes the absent-talker path - which handed him to the narrator,
+        // who cheerfully invented a whereabouts ("off on his own little adventure") one turn after
+        // the player watched him die. A character who is gone for good gets their own static line.
+        var target = GetTarget();
+        StartHere<MessHall>(); // Floyd is not here.
+        var floyd = GetItem<Floyd>();
+        floyd.HasDied = true;
+        floyd.CurrentLocation = null;
+        Mock.Get(target.GenerationClient)
+            .Setup(c => c.GenerateNarration(It.IsAny<TalkingToAbsentCharacterRequest>(), It.IsAny<string>()))
+            .ReturnsAsync("Floyd must be off on his own little adventure.");
+
+        var response = await target.GetResponse("floyd, are you okay");
+
+        response.Should().NotContain("adventure");
+        response.Should().Contain("Floyd is gone");
+    }
+
+    [Test]
+    public async Task TalkToFloyd_AliveAndAbsent_StillGetsTheNarratedAbsence()
+    {
+        // The gone-for-good gate must not swallow the ordinary absent-Floyd narration (#264):
+        // while Floyd is merely elsewhere, the narrator still answers in its own voice.
+        var target = GetTarget();
+        StartHere<MessHall>();
+        var floyd = GetItem<Floyd>();
+        floyd.IsOn = true;
+        floyd.CurrentLocation = GetLocation<RobotShop>();
+        Mock.Get(target.GenerationClient)
+            .Setup(c => c.GenerateNarration(It.IsAny<TalkingToAbsentCharacterRequest>(), It.IsAny<string>()))
+            .ReturnsAsync("Floyd must be off on his own little adventure.");
+
+        var response = await target.GetResponse("floyd, are you okay");
+
+        response.Should().Contain("adventure");
+    }
+
+    [Test]
     public async Task TurnOff_FloydIsDead()
     {
         var target = GetTarget();

--- a/Planetfall.Tests/FloydTests.cs
+++ b/Planetfall.Tests/FloydTests.cs
@@ -487,6 +487,46 @@ public class FloydTests : EngineTestsBase
     }
 
     [Test]
+    public async Task TakeFloyd_Alive_SquealsAndMovesAway()
+    {
+        // The living half of the CannotBeTakenDescription gate. Without this the surviving branch of
+        // that nested ternary has no positive coverage at all, so inverting the nesting - serving the
+        // elegy to a living Floyd and the squeal to his corpse - would pass the entire suite.
+        var target = GetTarget();
+        StartHere<RobotShop>();
+        var floyd = GetItem<Floyd>();
+        floyd.IsOn = true;
+        floyd.HasEverBeenOn = true;
+
+        var response = await target.GetResponse("take floyd");
+
+        response.Should().Contain("surprised squeal");
+        response.Should().Contain("respectable distance away");
+    }
+
+    [Test]
+    public async Task TalkToFloyd_TurnedOffButAlive_SaysHeIsSwitchedOff()
+    {
+        // The middle case between the two gates in OnBeingTalkedTo: switched off but NOT dead. It had
+        // no coverage either, so writing the new gate as "HasDied || !IsOn" - which would hand the
+        // mourning line to a merely deactivated Floyd - would also have gone unnoticed.
+        var target = GetTarget();
+        StartHere<RobotShop>();
+        var floyd = GetItem<Floyd>();
+        floyd.IsOn = false;
+        var chat = new Mock<IChatWithFloyd>();
+        chat.Setup(s => s.AskFloydAsync(It.IsAny<string>()))
+            .ReturnsAsync(new CompanionResponse("CHAT-SHOULD-NOT-HAPPEN", null));
+        floyd.ChatWithFloyd = chat.Object;
+
+        var response = await target.GetResponse("floyd, are you okay");
+
+        response.Should().Contain("appears to be turned off");
+        response.Should().NotContain("no answer comes");
+        response.Should().NotContain("CHAT-SHOULD-NOT-HAPPEN");
+    }
+
+    [Test]
     public async Task TalkToFloyd_Dead_MournsInsteadOfChatting()
     {
         // Issue #545: EndSequence deliberately leaves the corpse's IsOn true, so the old
@@ -627,6 +667,29 @@ public class FloydTests : EngineTestsBase
         var response = await target.GetResponse("floyd, are you okay");
 
         response.Should().Contain("adventure");
+    }
+
+    [Test]
+    public void SaveGameRequest_FloydIsDead_DoesNotSpeakInHisExcitedVoice()
+    {
+        // Issue #545 review, found by routing every liveness test through one property: saving the
+        // game beside Floyd is narrated in HIS voice (FloydAfterSaveGameRequest - "Yippee! Time for
+        // the dangerous bit?"). The gate is IsHereAndIsOn, and the corpse is left switched on and
+        // lying in Bio Lock East - so saving one turn after the death scene, standing over the body,
+        // had the dead robot squeal with excitement. Unlike the other post-mortem leaks this one is
+        // plainly reachable: the player is in that room, with that body, and saving is routine.
+        var target = GetTarget();
+        var bioLockEast = StartHere<BioLockEast>();
+        var floyd = GetItem<Floyd>();
+        floyd.IsOn = true;
+        floyd.HasEverBeenOn = true;
+        floyd.HasDied = true;
+        floyd.CurrentLocation = bioLockEast;
+        bioLockEast.ItemPlacedHere(floyd);
+
+        var request = target.Context.GetSaveGameRequest("Bio Lock East");
+
+        request.Should().BeNull();
     }
 
     [Test]
@@ -1555,6 +1618,29 @@ public class FloydTests : EngineTestsBase
 
         var pfContext = target.Context;
         pfContext.PendingFloydActionCommentPrompt.Should().BeNull();
+    }
+
+    [Test]
+    public void CommentOnAction_DoesNotSetPrompt_WhenFloydIsDead()
+    {
+        // Issue #545 review: the queue's gate asked IsHereAndIsOn, and EndSequence leaves the corpse
+        // switched on, so a comment could be queued for a dead Floyd. Act() returns on HasDied before
+        // ever clearing PendingFloydActionCommentPrompt, so the queued prompt would also stay stuck
+        // forever, and the one-shot prompt would be burned unspoken.
+        var target = GetTarget();
+        var robotShop = StartHere<RobotShop>();
+        var floyd = GetItem<Floyd>();
+        floyd.IsOn = true;
+        floyd.HasEverBeenOn = true;
+        floyd.HasDied = true;
+        floyd.CurrentLocation = robotShop;
+        robotShop.ItemPlacedHere(floyd);
+
+        var queued = floyd.CommentOnAction("Test prompt", target.Context);
+
+        queued.Should().BeFalse();
+        target.Context.PendingFloydActionCommentPrompt.Should().BeNull();
+        target.Context.UsedFloydActionCommentPrompts.Should().NotContain("Test prompt");
     }
 
     [Test]

--- a/Planetfall.Tests/FloydTests.cs
+++ b/Planetfall.Tests/FloydTests.cs
@@ -706,6 +706,49 @@ public class FloydTests : EngineTestsBase
     }
 
     [Test]
+    public async Task DoesFloydOfferCard_HeIsDead()
+    {
+        // Issue #545 review: the reveal daemon's liveness test is "!floyd.IsOn", and EndSequence
+        // deliberately leaves the corpse's IsOn true - so the body satisfied it and would clap its
+        // hands with excitement while waving a card. Only geography kept this dormant in a real game
+        // (Floyd dies in Bio Lock East, which has no card slot); the guard itself has to be right.
+        var target = GetTarget();
+        StartHere<MessHall>();
+        Take<KitchenAccessCard>();
+        var floyd = GetItem<Floyd>();
+        floyd.IsOn = true;
+        floyd.HasDied = true;
+        floyd.CurrentLocation = GetLocation<MessHall>();
+        floyd.Chooser = Mock.Of<IRandomChooser>(r => r.RollDice(100) == 1); // within Day 1's window -> would reveal
+
+        var response = await target.GetResponse("slide kitchen access card through slot");
+
+        response.Should().NotContain("Floyd claps his hands with excitement");
+        floyd.ItemBeingHeld.Should().BeNull();
+        floyd.HasRevealedLowerElevatorCard.Should().BeFalse();
+    }
+
+    [Test]
+    public void SearchFloyd_Dead_DoesNotTickleTheCorpse()
+    {
+        // Issue #545 review: SearchFloyd's "is he alive" test is IsOn alone, which the corpse
+        // satisfies, so the body would giggle, clutch its side panels and stream oil from its eyes.
+        // Floyd.RespondToSimpleInteraction currently returns to base on HasDied before the search
+        // branch is reached, so no player input can reach this today - which is exactly why it is
+        // exercised against the manager directly. The guard must be correct in its own right, not
+        // merely shadowed by an earlier return in its single caller.
+        GetTarget();
+        var floyd = GetItem<Floyd>();
+        floyd.IsOn = true;
+        floyd.HasDied = true;
+
+        var result = new FloydInventoryManager(floyd).SearchFloyd(Context);
+
+        result.InteractionMessage.Should().NotContain("giggles");
+        result.InteractionMessage.Should().NotContain("tickling");
+    }
+
+    [Test]
     public async Task DoesFloydOfferCard_NoLongerHasIt()
     {
         var target = GetTarget();

--- a/Planetfall.Tests/FloydTests.cs
+++ b/Planetfall.Tests/FloydTests.cs
@@ -530,6 +530,65 @@ public class FloydTests : EngineTestsBase
     }
 
     [Test]
+    public async Task TalkToFloyd_DeadAndPresent_MournsEvenWithGenerationDisabled()
+    {
+        // #545 follow-up: with NoGeneratedResponses set (a per-request flag the Planetfall API
+        // exposes), the present-talker branch bailed out on the generation kill-switch before
+        // reaching OnBeingTalkedTo, so addressing the corpse produced a BLANK response - the fix
+        // never ran. Floyd's post-mortem line is a constant and owes the AI nothing.
+        var target = GetTarget();
+        StartHere<RobotShop>();
+        var floyd = GetItem<Floyd>();
+        floyd.HasDied = true;
+        floyd.HasEverBeenOn = true;
+        floyd.IsOn = true;
+        Mock.Get(target.GenerationClient).Setup(c => c.IsDisabled).Returns(true);
+
+        var response = await target.GetResponse("floyd, are you okay");
+
+        response.Should().Contain("no answer comes");
+    }
+
+    [Test]
+    public async Task TalkToFloyd_DeadAndPresent_DoesNotCallTheConversationClassifier()
+    {
+        // ParseConversation.ParseAsync is an AWS Lambda round-trip whose only job is rewriting the
+        // player's words into a command for Floyd. A dead Floyd answers with one constant, so that
+        // round-trip is pure waste on every utterance addressed to the body.
+        var target = GetTarget();
+        StartHere<RobotShop>();
+        var floyd = GetItem<Floyd>();
+        floyd.HasDied = true;
+        floyd.HasEverBeenOn = true;
+        floyd.IsOn = true;
+
+        var response = await target.GetResponse("floyd, are you okay");
+
+        response.Should().Contain("no answer comes");
+        ParseConversationMock.Verify(p => p.ParseAsync(It.IsAny<string>()), Times.Never);
+    }
+
+    [Test]
+    public async Task AskAboutFloyd_DeadAndPresent_MournsInsteadOfFallingThroughToTheParser()
+    {
+        // Imperative address ("ask floyd ...") never starts with the name, so the present path's
+        // deterministic backstop misses it and it used to depend entirely on the classifier. With the
+        // classifier no longer consulted for a dead Floyd, detection uses IsGenuineDirectAddress,
+        // which recognizes the imperative lead-ins too - so this phrasing now reaches the mourning
+        // line rather than leaking to the narrator.
+        var target = GetTarget();
+        StartHere<RobotShop>();
+        var floyd = GetItem<Floyd>();
+        floyd.HasDied = true;
+        floyd.HasEverBeenOn = true;
+        floyd.IsOn = true;
+
+        var response = await target.GetResponse("ask floyd about the card");
+
+        response.Should().Contain("no answer comes");
+    }
+
+    [Test]
     public async Task TalkToFloyd_DeadAndAbsent_AcknowledgesDeathInsteadOfJokingAboutAdventures()
     {
         // Issue #545, trapped-death branch: Floyd dies inside the Bio Lab with CurrentLocation

--- a/Planetfall.Tests/Walkthrough/WalkthroughBioLock.cs
+++ b/Planetfall.Tests/Walkthrough/WalkthroughBioLock.cs
@@ -38,9 +38,13 @@ public sealed class WalkthroughBioLock : WalkthroughTestBase
         var door = Repository.GetItem<BioLockInnerDoor>();
         door.IsOpen = false;
 
-        // Place Floyd in BioLockEast and turn him on
+        // Place Floyd in BioLockEast and bring him back to life. HasDied must be reset explicitly:
+        // the whole fixture shares one engine and Repository ([OneTimeSetUp]), so a preceding test
+        // that kills Floyd (PlayerWaitsTooLong_FloydDies) leaves the flag set on the singleton, and
+        // every liveness check now reads Floyd.IsAlive, which is IsOn AND not dead (issue #545).
         bioLockEast.ItemPlacedHere(floyd);
         floyd.IsOn = true;
+        floyd.HasDied = false;
 
         // Set the computer room concern flag
         computerRoom.FloydHasExpressedConcern = true;
@@ -87,6 +91,11 @@ public sealed class WalkthroughBioLock : WalkthroughTestBase
     [TestCase("close door", null, "The door closes", "And not a moment too soon", "From within the lab you hear ferocious growlings", "the sounds of a skirmish", "high-pitched metallic scream")]
     [TestCase("z", null, "Time passes", "You hear, slightly muffled by the door, three fast knocks", "followed by the distinctive sound of tearing metal")]
     [TestCase("z", null, "Time passes", "You hear a final metallic scream from behind the door", "followed by the sound of Floyd's body being torn apart", "Floyd is dead")]
+    // Issue #545: Floyd died trapped in the lab, so he has no location at all. Addressing him takes
+    // the absent-talker path, which used to hand him to the narrator - who answered a question about
+    // a friend the player had just heard torn apart by inventing a whereabouts for him.
+    [TestCase("floyd, are you okay", null, "Floyd is gone", "There will be no answer")]
+    [TestCase("ask floyd about the card", null, "Floyd is gone")]
     public async Task PlayerWaitsTooLong_FloydDies(string input, string? setup, params string[] expectedResponses)
         => await DoWithSetup(input, setup, expectedResponses);
 
@@ -98,6 +107,13 @@ public sealed class WalkthroughBioLock : WalkthroughTestBase
     [TestCase("z", null, "Time passes", "You hear, slightly muffled by the door, three fast knocks", "followed by the distinctive sound of tearing metal")]
     [TestCase("open door", null, "The door opens", "Floyd stumbles out of the Bio Lab", "clutching the mini-booth card", "The mutations rush toward the open doorway")]
     [TestCase("close door", null, "The door closes", "And not a moment too soon", "Floyd staggers to the ground", "dropping the mini card", "badly torn apart", "loose wires and broken circuits", "Oil flows from his lubrication system", "only moments to live", "You drop to your knees and cradle Floyd's head", "Floyd did it", "got card", "Floyd a good friend", "Floyd smiles with contentment", "his eyes close", "in memory of a brave friend")]
+    // Issue #545, proved against the state the player actually reaches rather than a hand-set
+    // HasDied: the body is lying in this room with its IsOn deliberately left true by EndSequence,
+    // which is exactly what made every post-mortem path serve living-Floyd responses.
+    [TestCase("floyd, are you okay", null, "You speak your friend's name", "no answer comes")]
+    [TestCase("take floyd", null, "lay him gently back down")]
+    [TestCase("examine floyd", null, "a tremendous sense of loss overcomes you")]
+    [TestCase("deactivate floyd", null, "already been turned off, permanently")]
     public async Task SuccessfulSequence_FloydSacrificesHimself(string input, string? setup, params string[] expectedResponses)
         => await DoWithSetup(input, setup, expectedResponses);
 

--- a/Planetfall/Item/Feinstein/Ambassador.cs
+++ b/Planetfall/Item/Feinstein/Ambassador.cs
@@ -27,6 +27,13 @@ internal class Ambassador : QuirkyCompanion, ICanBeExamined, ICanBeTalkedTo
         "are retracted. Green slime oozes from multiple orifices in his scaly skin. He speaks through a " +
         "mechanical translator slung around his neck. ";
 
+    // Once the escape pod is down on Resida, the Feinstein and everyone still aboard her are beyond
+    // reach for the rest of the game. Nothing can be learned about them any more, so the narrator must
+    // not be asked to improvise an answer to "where is he?" - it invents whereabouts (issue #545).
+    // This deliberately says nothing about their fate: the static line stays the plain "isn't here",
+    // which is the honest answer and matches what the original ever tells you.
+    public bool IsGoneForGood => Repository.GetLocation<EscapePod>().LandedSafely;
+
     // "ambassador" is a title rather than a name, so the default "Ambassador isn't here." reads
     // oddly; use the article form instead (see #264).
     public string NotHereDescription => "The ambassador isn't here. ";

--- a/Planetfall/Item/Feinstein/Blather.cs
+++ b/Planetfall/Item/Feinstein/Blather.cs
@@ -19,6 +19,13 @@ internal class Blather : QuirkyCompanion, IAmANamedPerson, ITurnBasedActor, ICan
 
     public override string[] NounsForMatching => ["blather", "ensign blather"];
 
+    // Once the escape pod is down on Resida, the Feinstein and everyone still aboard her are beyond
+    // reach for the rest of the game. Nothing can be learned about them any more, so the narrator must
+    // not be asked to improvise an answer to "where is he?" - it invents whereabouts (issue #545).
+    // This deliberately says nothing about their fate: the static line stays the plain "isn't here",
+    // which is the honest answer and matches what the original ever tells you.
+    public bool IsGoneForGood => Repository.GetLocation<EscapePod>().LandedSafely;
+
     public string ExaminationDescription =>
         "Ensign Blather is a tall, beefy officer with a tremendous, misshapen nose. His uniform is perfect in " +
         "every respect, and the crease in his trousers could probably slice diamonds in half. ";

--- a/Planetfall/Item/Kalamontee/Mech/FloydPart/Floyd.cs
+++ b/Planetfall/Item/Kalamontee/Mech/FloydPart/Floyd.cs
@@ -73,13 +73,28 @@ public class Floyd : QuirkyCompanion, IAmANamedPerson, ICanHoldItems, ICanBeGive
     [UsedImplicitly] public int TurnOnCountdown { get; set; } = 3;
 
     /// <summary>
-    /// Checks if Floyd is both turned on and in the same location as the player.
+    /// Whether Floyd is alive: switched on AND not dead. Ask this - never <see cref="IsOn"/> - whenever
+    /// the question is "would Floyd react?".
+    /// <para>
+    /// The trap this exists to close (issue #545): the Bio Lab sacrifice deliberately leaves the
+    /// corpse's <see cref="IsOn"/> true (BioLockStateMachineManager.EndSequence), because the body is
+    /// still the same object lying in the room. Every check written as a bare IsOn is therefore
+    /// satisfied by a dead Floyd, and each one found this way has been its own bug: the corpse chatting,
+    /// squealing when lifted, giggling when tickled, clapping while waving a card, and squealing with
+    /// excitement when the player saved the game beside his body. Reading liveness through one property
+    /// means the next such path cannot forget the second half of the question.
+    /// </para>
+    /// </summary>
+    public bool IsAlive => IsOn && !HasDied;
+
+    /// <summary>
+    /// Checks if Floyd is alive and in the same location as the player.
     /// </summary>
     /// <param name="context">The game context containing the player's current location.</param>
-    /// <returns>True if Floyd is on and in the player's current location; otherwise, false.</returns>
-    public bool IsHereAndIsOn(IContext context)
+    /// <returns>True if Floyd is alive and in the player's current location; otherwise, false.</returns>
+    public bool IsHereAndAlive(IContext context)
     {
-        return IsOn && IsInTheRoom(context);
+        return IsAlive && IsInTheRoom(context);
     }
 
     /// <summary>
@@ -94,8 +109,8 @@ public class Floyd : QuirkyCompanion, IAmANamedPerson, ICanHoldItems, ICanBeGive
     /// queue took — e.g. to decide between an empty response and a fallback line — can branch on this.</returns>
     public bool CommentOnAction(string prompt, IContext context)
     {
-        // Must be on and in the same location as player
-        if (!IsHereAndIsOn(context))
+        // Must be alive and in the same location as player
+        if (!IsHereAndAlive(context))
             return false;
 
         if (context is not PlanetfallContext planetfallContext)
@@ -150,7 +165,7 @@ public class Floyd : QuirkyCompanion, IAmANamedPerson, ICanHoldItems, ICanBeGive
     /// </summary>
     public string NotHereDescription => HasDied
         ? FloydConstants.NotHereDead
-        : "Floyd isn't here. ";
+        : ICanBeTalkedTo.DefaultNotHereDescription(this);
 
     protected override string SystemPrompt => FloydPrompts.SystemPrompt;
 
@@ -353,7 +368,7 @@ public class Floyd : QuirkyCompanion, IAmANamedPerson, ICanHoldItems, ICanBeGive
     public override async Task<InteractionResult?> RespondToMultiNounInteraction(MultiNounIntent action,
         IContext context)
     {
-        if (!IsOn || HasDied)
+        if (!IsAlive)
             return await base.RespondToMultiNounInteraction(action, context);
 
         // V-OIL with an explicit indirect object (syntax.zil:446-448, verbs.zil:1738-1757):

--- a/Planetfall/Item/Kalamontee/Mech/FloydPart/Floyd.cs
+++ b/Planetfall/Item/Kalamontee/Mech/FloydPart/Floyd.cs
@@ -128,9 +128,29 @@ public class Floyd : QuirkyCompanion, IAmANamedPerson, ICanHoldItems, ICanBeGive
 
     public override string[] NounsForMatching => ["floyd", "robot", "B-19-7", "multi-purpose robot"];
 
-    public override string? CannotBeTakenDescription => IsOn
-        ? FloydConstants.TakeFloyd
-        : null;
+    // HasDied is checked before IsOn, not folded into it: EndSequence deliberately leaves the
+    // corpse's IsOn true, so keying on IsOn alone served the living-Floyd refusal - the body
+    // squealing in surprise and scooting away from his own funeral (issue #545).
+    public override string? CannotBeTakenDescription => HasDied
+        ? FloydConstants.TakeDead
+        : IsOn
+            ? FloydConstants.TakeFloyd
+            : null;
+
+    /// <summary>
+    /// Floyd's death is permanent, so once he has died the engine must never let the narrator
+    /// improvise about where he has got to. See <see cref="ICanBeTalkedTo.IsGoneForGood"/>.
+    /// </summary>
+    public bool IsGoneForGood => HasDied;
+
+    /// <summary>
+    /// Answers the player who addresses Floyd by name while his body is elsewhere. After the
+    /// trapped-death branch he has no location at all (he dies inside the Bio Lab), so this is the
+    /// line that replaces the narrator's cheerful guesswork about his whereabouts.
+    /// </summary>
+    public string NotHereDescription => HasDied
+        ? FloydConstants.NotHereDead
+        : "Floyd isn't here. ";
 
     protected override string SystemPrompt => FloydPrompts.SystemPrompt;
 
@@ -176,6 +196,12 @@ public class Floyd : QuirkyCompanion, IAmANamedPerson, ICanHoldItems, ICanBeGive
     /// <returns>Floyd's response to the conversation, or an error message if he's off or the AI service fails.</returns>
     public async Task<string> OnBeingTalkedTo(string text, IContext context, IGenerationClient client)
     {
+        // HasDied first: the corpse keeps IsOn = true (EndSequence), so without this gate the chat
+        // lambda answered for a dead Floyd - "Floyd says he is okay now that you are here" beside
+        // his body (issue #545).
+        if (HasDied)
+            return FloydConstants.TalkToDead;
+
         if (!IsOn)
             return "The robot doesn't respond - it appears to be turned off.";
 

--- a/Planetfall/Item/Kalamontee/Mech/FloydPart/FloydConstants.cs
+++ b/Planetfall/Item/Kalamontee/Mech/FloydPart/FloydConstants.cs
@@ -68,6 +68,16 @@ public static class FloydConstants
     // interaction path has to consult HasDied instead - the paths that didn't were serving
     // living-Floyd responses to his body (issue #545). Register follows DEAD-FLOYD-F
     // (compone.zil:2303-2313): grief, never the living robot's chirp.
+    // LAMP-ON / LAMP-OFF on the corpse (DEAD-FLOYD-F, compone.zil:2307-2313). These two live here
+    // with the rest of the post-mortem voice rather than inline in FloydPowerManager, so the whole
+    // register can be read - and tuned - in one place.
+    internal const string ActivateDead =
+        "As you touch Floyd's on-off switch, it falls off in your hands. ";
+
+    internal const string DeactivateDead =
+        "I'm afraid that Floyd has already been turned off, permanently, and gone to that great robot " +
+        "shop in the sky. ";
+
     internal const string TakeDead =
         "You slip your arms beneath your friend and try to lift him, but Floyd is far too heavy, and " +
         "you have not the heart to drag him. You lay him gently back down. ";

--- a/Planetfall/Item/Kalamontee/Mech/FloydPart/FloydConstants.cs
+++ b/Planetfall/Item/Kalamontee/Mech/FloydPart/FloydConstants.cs
@@ -63,6 +63,24 @@ public static class FloydConstants
         "From its design, the robot seems to be of the multi-purpose sort. It is slightly cross-eyed, and its " +
         "mechanical mouth forms a lopsided grin. ";
 
+    // The three constants below answer the player once Floyd has died. The corpse's IsOn is
+    // deliberately left true by BioLockStateMachineManager.EndSequence, so every post-mortem
+    // interaction path has to consult HasDied instead - the paths that didn't were serving
+    // living-Floyd responses to his body (issue #545). Register follows DEAD-FLOYD-F
+    // (compone.zil:2303-2313): grief, never the living robot's chirp.
+    internal const string TakeDead =
+        "You slip your arms beneath your friend and try to lift him, but Floyd is far too heavy, and " +
+        "you have not the heart to drag him. You lay him gently back down. ";
+
+    internal const string TalkToDead =
+        "You speak your friend's name, but Floyd lies still and silent, and no answer comes. ";
+
+    // Used when the player addresses Floyd after his death while his body is elsewhere - most
+    // painfully, the trapped-death branch, where he dies inside the Bio Lab and has no location at
+    // all. See Floyd.NotHereDescription.
+    internal const string NotHereDead =
+        "Floyd is gone. There will be no answer. ";
+
     internal const string ExaminationDead =
         "You turn to look at Floyd, but a tremendous sense of loss overcomes you, and you turn away. ";
 

--- a/Planetfall/Item/Kalamontee/Mech/FloydPart/FloydInventoryManager.cs
+++ b/Planetfall/Item/Kalamontee/Mech/FloydPart/FloydInventoryManager.cs
@@ -27,13 +27,9 @@ public class FloydInventoryManager(Floyd floyd)
 
     public InteractionResult SearchFloyd(IContext context)
     {
-        // "Is he alive?" is HasDied AND IsOn, never IsOn alone: EndSequence deliberately leaves the
-        // corpse's IsOn true (BioLockStateMachineManager.cs:63-68), so an IsOn-only test has the body
-        // giggle and stream oil from its eyes at being tickled (issue #545). Floyd's own
-        // RespondToSimpleInteraction happens to return to base on HasDied before this is reached, but
-        // that is one caller's ordering, not a guarantee - the liveness test belongs here, where IsOn
-        // is actually read.
-        if (floyd.IsOn && !floyd.HasDied)
+        // Liveness, not IsOn: the corpse is left switched on, and an IsOn-only test had the body
+        // giggle and stream oil from its eyes at being tickled (issue #545). See Floyd.IsAlive.
+        if (floyd.IsAlive)
             return new PositiveInteractionResult(FloydConstants.TickleFloyd);
 
         if (!floyd.HasItem<LowerElevatorAccessCard>())
@@ -48,11 +44,9 @@ public class FloydInventoryManager(Floyd floyd)
     public string? OfferLowerElevatorCard(IContext context, IRandomChooser chooser)
     {
         if (!IsFloydInRoom(context) ||
-            !floyd.IsOn ||
-            // Same trap as SearchFloyd above: the corpse keeps IsOn = true, so without HasDied this
-            // daemon has a dead Floyd clap his hands with excitement and wave a card (issue #545).
-            // Only geography kept it dormant - he dies in Bio Lock East, which has no card slot.
-            floyd.HasDied ||
+            // Liveness, not IsOn (see Floyd.IsAlive): without it this daemon had a dead Floyd clap
+            // his hands with excitement and wave a card (issue #545).
+            !floyd.IsAlive ||
             !floyd.Items.Any() ||
             floyd.HasRevealedLowerElevatorCard ||
             !RevealChanceSucceeds(context, chooser))

--- a/Planetfall/Item/Kalamontee/Mech/FloydPart/FloydInventoryManager.cs
+++ b/Planetfall/Item/Kalamontee/Mech/FloydPart/FloydInventoryManager.cs
@@ -27,7 +27,13 @@ public class FloydInventoryManager(Floyd floyd)
 
     public InteractionResult SearchFloyd(IContext context)
     {
-        if (floyd.IsOn)
+        // "Is he alive?" is HasDied AND IsOn, never IsOn alone: EndSequence deliberately leaves the
+        // corpse's IsOn true (BioLockStateMachineManager.cs:63-68), so an IsOn-only test has the body
+        // giggle and stream oil from its eyes at being tickled (issue #545). Floyd's own
+        // RespondToSimpleInteraction happens to return to base on HasDied before this is reached, but
+        // that is one caller's ordering, not a guarantee - the liveness test belongs here, where IsOn
+        // is actually read.
+        if (floyd.IsOn && !floyd.HasDied)
             return new PositiveInteractionResult(FloydConstants.TickleFloyd);
 
         if (!floyd.HasItem<LowerElevatorAccessCard>())
@@ -43,6 +49,10 @@ public class FloydInventoryManager(Floyd floyd)
     {
         if (!IsFloydInRoom(context) ||
             !floyd.IsOn ||
+            // Same trap as SearchFloyd above: the corpse keeps IsOn = true, so without HasDied this
+            // daemon has a dead Floyd clap his hands with excitement and wave a card (issue #545).
+            // Only geography kept it dormant - he dies in Bio Lock East, which has no card slot.
+            floyd.HasDied ||
             !floyd.Items.Any() ||
             floyd.HasRevealedLowerElevatorCard ||
             !RevealChanceSucceeds(context, chooser))

--- a/Planetfall/Item/Kalamontee/Mech/FloydPart/FloydMovementManager.cs
+++ b/Planetfall/Item/Kalamontee/Mech/FloydPart/FloydMovementManager.cs
@@ -110,7 +110,7 @@ public class FloydMovementManager(Floyd floyd)
     /// </summary>
     public void StartWandering(IContext context)
     {
-        if (!floyd.IsOn || floyd.HasDied)
+        if (!floyd.IsAlive)
             return; // Can't wander if he's not on or dead
 
         floyd.IsOffWandering = true;

--- a/Planetfall/Item/Kalamontee/Mech/FloydPart/FloydPowerManager.cs
+++ b/Planetfall/Item/Kalamontee/Mech/FloydPart/FloydPowerManager.cs
@@ -5,7 +5,7 @@ public class FloydPowerManager(Floyd floyd)
     public InteractionResult Activate(IContext context)
     {
         if (floyd.HasDied)
-            return new PositiveInteractionResult("As you touch Floyd's on-off switch, it falls off in your hands. ");
+            return new PositiveInteractionResult(FloydConstants.ActivateDead);
 
         if (floyd.IsOn)
             return new PositiveInteractionResult("He's already been activated. ");
@@ -34,8 +34,7 @@ public class FloydPowerManager(Floyd floyd)
     public InteractionResult Deactivate(IContext context)
     {
         if (floyd.HasDied)
-            return
-                new PositiveInteractionResult("I'm afraid that Floyd has already been turned off, permanently, and gone to that great robot shop in the sky. ");
+            return new PositiveInteractionResult(FloydConstants.DeactivateDead);
         
         if (!floyd.IsOn)
             return new PositiveInteractionResult("The robot doesn't seem to be on. ");

--- a/Planetfall/Item/Kalamontee/Mech/FloydPart/FloydSocialResponses.cs
+++ b/Planetfall/Item/Kalamontee/Mech/FloydPart/FloydSocialResponses.cs
@@ -10,7 +10,7 @@ public class FloydSocialResponses(Floyd floyd)
 
     public InteractionResult? HandleSocialInteraction(SimpleIntent action, IContext context)
     {
-        if (!floyd.IsOn)
+        if (!floyd.IsAlive)
             return null;
 
         // V-OIL (verbs.zil:1738-1757): oiling a living Floyd is a flavor thank-you. The original

--- a/Planetfall/Location/Lawanda/ComputerRoom.cs
+++ b/Planetfall/Location/Lawanda/ComputerRoom.cs
@@ -58,7 +58,7 @@ internal class ComputerRoom : LocationBase, ITurnBasedActor
 
     public Task<string> Act(IContext context, IGenerationClient client)
     {
-        if (!Repository.GetItem<Floyd>().IsHereAndIsOn(context) || FloydHasExpressedConcern)
+        if (!Repository.GetItem<Floyd>().IsHereAndAlive(context) || FloydHasExpressedConcern)
             return Task.FromResult(string.Empty);
 
         FloydHasExpressedConcern = true;

--- a/Planetfall/Location/Lawanda/Infirmary.cs
+++ b/Planetfall/Location/Lawanda/Infirmary.cs
@@ -37,7 +37,7 @@ internal class Infirmary : LocationBase, ITurnBasedActor, IFloydDoesNotTalkHere
 
     public Task<string> Act(IContext context, IGenerationClient client)
     {
-        if (!Repository.GetItem<Floyd>().IsHereAndIsOn(context) || HasToldAboutLazarus)
+        if (!Repository.GetItem<Floyd>().IsHereAndAlive(context) || HasToldAboutLazarus)
             return Task.FromResult(string.Empty);
 
         TurnsInInfirmary++;

--- a/Planetfall/Location/Lawanda/Lab/BioLockEast.cs
+++ b/Planetfall/Location/Lawanda/Lab/BioLockEast.cs
@@ -120,7 +120,7 @@ internal class BioLockEast : LocationBase, ITurnBasedActor, IFloydDoesNotTalkHer
         var computerRoom = Repository.GetLocation<ComputerRoom>();
 
         var result = StateMachine.HandleTurnAction(
-            floyd.IsHereAndIsOn(context),
+            floyd.IsHereAndAlive(context),
             computerRoom.FloydHasExpressedConcern,
             context,
             floyd);

--- a/Planetfall/Location/Lawanda/Lab/BioLockStateMachineManager.cs
+++ b/Planetfall/Location/Lawanda/Lab/BioLockStateMachineManager.cs
@@ -58,14 +58,15 @@ public class BioLockStateMachineManager
     /// <summary>
     /// Handle turn-based actions for Floyd in BioLockEast
     /// </summary>
-    public string HandleTurnAction(bool isFloydHereAndOn, bool computerRoomFloydHasExpressedConcern, IContext context, Floyd floyd)
+    public string HandleTurnAction(bool isFloydHereAndAlive, bool computerRoomFloydHasExpressedConcern, IContext context, Floyd floyd)
     {
         // Once the sequence has finished - Floyd sacrificed himself and his body lies here (EndSequence),
         // or he died trapped in the lab (the NeedToReopenDoor terminal branch) - this actor must stay
-        // silent. EndSequence leaves the corpse's IsOn true and places it back in this room, so
-        // isFloydHereAndOn is true for the body; without this guard, re-entering the room re-registers the
-        // actor and the leftover FloydHasSaidNeedToGetCard flag falls into the "waiting for door open"
-        // branch below, making Floyd's corpse cheerfully ask the player to open the door again (issue #493).
+        // silent, or re-entering the room re-registers the actor and the leftover FloydHasSaidNeedToGetCard
+        // flag falls into the "waiting for door open" branch below, making Floyd's corpse cheerfully ask
+        // the player to open the door again (issue #493). This guard is now belt-and-braces: the caller
+        // passes Floyd.IsHereAndAlive, which is false for the body, where it used to pass a bare IsOn test
+        // that the corpse satisfied (EndSequence deliberately leaves IsOn true - see Floyd.IsAlive, #545).
         if (LabSequenceState == FloydLabSequenceState.Completed)
             return string.Empty;
 
@@ -75,7 +76,7 @@ public class BioLockStateMachineManager
                            LabSequenceState == FloydLabSequenceState.NeedToReopenDoor ||
                            LabSequenceState == FloydLabSequenceState.DoorReopenedNeedToCloseAgain;
 
-        if (!isFloydInLab && !isFloydHereAndOn)
+        if (!isFloydInLab && !isFloydHereAndAlive)
             return string.Empty;
 
         // First turn in BioLockEast: Floyd doesn't say anything yet
@@ -184,7 +185,7 @@ public class BioLockStateMachineManager
         var bioLockEast = Repository.GetLocation<BioLockEast>();
         var floyd = Repository.GetItem<Floyd>();
 
-        var isFloydReady = FloydHasSaidNeedToGetCard && floyd.IsHereAndIsOn(context);
+        var isFloydReady = FloydHasSaidNeedToGetCard && floyd.IsHereAndAlive(context);
 
         // If Floyd is ready to go get the card, start the sequence
         if (isFloydReady && LabSequenceState == FloydLabSequenceState.NotStarted)

--- a/Planetfall/Location/Lawanda/RepairRoom.cs
+++ b/Planetfall/Location/Lawanda/RepairRoom.cs
@@ -77,7 +77,7 @@ internal class RepairRoom : LocationBase, ITurnBasedActor, IFloydDoesNotTalkHere
 
     public Task<string> Act(IContext context, IGenerationClient client)
     {
-        if (!Repository.GetItem<Floyd>().IsHereAndIsOn(context) || HasToldMeAboutAchilles)
+        if (!Repository.GetItem<Floyd>().IsHereAndAlive(context) || HasToldMeAboutAchilles)
             return Task.FromResult(string.Empty);
 
         HasToldMeAboutAchilles = true;

--- a/Planetfall/PlanetfallContext.cs
+++ b/Planetfall/PlanetfallContext.cs
@@ -406,7 +406,7 @@ public class PlanetfallContext : Context<PlanetfallGame>, ITimeBasedContext, IGo
     public override Request? GetSaveGameRequest(string location)
     {
         var floyd = Repository.GetItem<Floyd>();
-        return floyd.IsHereAndIsOn(this) ?
+        return floyd.IsHereAndAlive(this) ?
             new FloydAfterSaveGameRequest(location) :
             null; // Use default AfterSaveGameRequest
     }

--- a/UnitTests/Engine/ConversationHandlerTests.cs
+++ b/UnitTests/Engine/ConversationHandlerTests.cs
@@ -414,6 +414,86 @@ public class ConversationHandlerTests
     }
 
     [Test]
+    public async Task CheckForConversation_PresentTalkerGoneForGood_AnswersEvenWhenGenerationDisabled()
+    {
+        // #545 follow-up: the gone-for-good short-circuit was wired only into the absent path, so a
+        // corpse standing in the room still fell through the present-talker branch's generation
+        // kill-switch and returned null - the player got a BLANK response instead of the mourning
+        // line. A gone-for-good character's reply is a fixed string, so it owes nothing to the AI and
+        // must stay available in NoGeneratedResponses mode.
+        var mockParser = new Mock<IParseConversation>();
+        var mockClient = new Mock<IGenerationClient>();
+        mockClient.Setup(c => c.IsDisabled).Returns(true);
+        var handler = new ConversationHandler(null, mockParser.Object, mockClient.Object,
+            new[] { typeof(GhostTalker) });
+        var context = new ZorkIContext();
+        context.Items.Add(Repository.GetItem<GhostTalker>());
+
+        var result = await handler.CheckForConversation("ghost, are you okay", context);
+
+        result.Should().Be("ghost talked");
+    }
+
+    [Test]
+    public async Task CheckForConversation_PresentTalkerGoneForGood_SkipsTheConversationClassifier()
+    {
+        // ParseAsync is an AWS Lambda round-trip (ChatLambda/ParseConversation.cs). Its only job is
+        // rewriting what the player said into a command for the character - worthless for a character
+        // whose every reply is one constant, so it must not be paid for on every utterance addressed
+        // to a corpse.
+        var mockParser = new Mock<IParseConversation>();
+        var handler = new ConversationHandler(null, mockParser.Object, Mock.Of<IGenerationClient>(),
+            new[] { typeof(GhostTalker) });
+        var context = new ZorkIContext();
+        context.Items.Add(Repository.GetItem<GhostTalker>());
+
+        var result = await handler.CheckForConversation("ghost, are you okay", context);
+
+        result.Should().Be("ghost talked");
+        mockParser.Verify(p => p.ParseAsync(It.IsAny<string>()), Times.Never);
+    }
+
+    [TestCase("ask ghost about the lamp")]
+    [TestCase("tell ghost to go north")]
+    [TestCase("talk to ghost")]
+    public async Task CheckForConversation_PresentTalkerGoneForGood_RecognizesImperativeAddress(string input)
+    {
+        // The present path normally leaves imperative lead-ins ("ask X ...") to the classifier, which
+        // we no longer call here. Detection therefore uses IsGenuineDirectAddress - the same
+        // deterministic test the absent path trusts - which covers the imperative forms too, so
+        // skipping the rewriter costs no coverage.
+        var mockParser = new Mock<IParseConversation>();
+        mockParser.Setup(p => p.ParseAsync(It.IsAny<string>())).ReturnsAsync((false, string.Empty));
+        var handler = new ConversationHandler(null, mockParser.Object, Mock.Of<IGenerationClient>(),
+            new[] { typeof(GhostTalker) });
+        var context = new ZorkIContext();
+        context.Items.Add(Repository.GetItem<GhostTalker>());
+
+        var result = await handler.CheckForConversation(input, context);
+
+        result.Should().Be("ghost talked");
+    }
+
+    [TestCase("examine ghost")]
+    [TestCase("take ghost")]
+    [TestCase("turn off ghost")]
+    public async Task CheckForConversation_PresentTalkerGoneForGood_DoesNotHijackOrdinaryCommands(string input)
+    {
+        // The short-circuit must not swallow real commands that merely NAME the character. "examine
+        // floyd" on the corpse has to keep reaching the item's own examine handler (the mourning
+        // description), not be answered as though the player spoke to the body.
+        var mockParser = new Mock<IParseConversation>();
+        var handler = new ConversationHandler(null, mockParser.Object, Mock.Of<IGenerationClient>(),
+            new[] { typeof(GhostTalker) });
+        var context = new ZorkIContext();
+        context.Items.Add(Repository.GetItem<GhostTalker>());
+
+        var result = await handler.CheckForConversation(input, context);
+
+        result.Should().BeNull();
+    }
+
+    [Test]
     public async Task CheckForConversation_AbsentTalkerGoneForGood_UsesStaticLineInsteadOfNarration()
     {
         // Issue #545: asked where an absent character is, the narrator answers by inventing a

--- a/UnitTests/Engine/ConversationHandlerTests.cs
+++ b/UnitTests/Engine/ConversationHandlerTests.cs
@@ -49,6 +49,24 @@ public class ConversationHandlerTests
     }
 
     /// <summary>
+    /// A known talker who is gone for good (dead), with their own mourning line — mirrors Floyd
+    /// after the Bio Lab sacrifice (issue #545).
+    /// </summary>
+    public class GhostTalker : ItemBase, ICanBeTalkedTo
+    {
+        public override string[] NounsForMatching => ["ghost"];
+
+        public override string GenericDescription(ILocation? currentLocation) => string.Empty;
+
+        public bool IsGoneForGood => true;
+
+        public string NotHereDescription => "The ghost is gone. There will be no answer. ";
+
+        public Task<string> OnBeingTalkedTo(string text, IContext context, IGenerationClient client) =>
+            Task.FromResult("ghost talked");
+    }
+
+    /// <summary>
     /// A known talker named "floyd" that also answers to the generic synonym "robot" — mirrors the
     /// real Floyd, used to verify the synonym is not treated as a name for direct address.
     /// </summary>
@@ -393,6 +411,27 @@ public class ConversationHandlerTests
         mockClient.Verify(c => c.GenerateNarration(It.IsAny<TalkingToAbsentCharacterRequest>(), It.IsAny<string>()),
             Times.Once);
         mockParser.Verify(p => p.ParseAsync(It.IsAny<string>()), Times.Never);
+    }
+
+    [Test]
+    public async Task CheckForConversation_AbsentTalkerGoneForGood_UsesStaticLineInsteadOfNarration()
+    {
+        // Issue #545: asked where an absent character is, the narrator answers by inventing a
+        // whereabouts - which, for a character the player just watched die, reads as a joke about
+        // the corpse being "off on his own little adventure". A gone-for-good talker gets their own
+        // deterministic mourning line and the narrator is never consulted at all.
+        var mockParser = new Mock<IParseConversation>();
+        var mockClient = new Mock<IGenerationClient>();
+        mockClient.Setup(c => c.GenerateNarration(It.IsAny<Request>(), It.IsAny<string>()))
+                  .ReturnsAsync("The ghost must be off on its own little adventure.");
+        var handler = new ConversationHandler(null, mockParser.Object, mockClient.Object,
+            new[] { typeof(GhostTalker) });
+        var context = new ZorkIContext();
+
+        var result = await handler.CheckForConversation("ghost, are you okay", context);
+
+        result.Should().Be("The ghost is gone. There will be no answer. ");
+        mockClient.Verify(c => c.GenerateNarration(It.IsAny<Request>(), It.IsAny<string>()), Times.Never);
     }
 
     [Test]


### PR DESCRIPTION
Fixes #545.

## The bug

Every post-mortem interaction path keyed off `IsOn`. `BioLockStateMachineManager.EndSequence` deliberately leaves `IsOn` **true** on the corpse (documented at `BioLockStateMachineManager.cs:63-68`), so one turn after the Bio Lab sacrifice the body kept serving living-Floyd responses. Three manifestations, one root cause: none of these paths consulted `HasDied`.

| # | Input | Prod (2.0.7) response |
|---|---|---|
| 1 | `floyd, are you okay` | *"Floyd says he is okay now that you are here."* |
| 2 | `take floyd` | *"...Floyd gives a surprised squeal and moves a respectable distance away."* |
| 3 | `floyd, are you okay` (trapped-death branch) | *"Floyd must be off on his own little adventure."* |

The #493 sweep fixed this class of bug for the actor/turn path (the corpse cheerfully asking to open the door); these are the interaction paths it missed.

## What changed

**1 & 2 — the corpse is present.** Gated on `HasDied` ahead of `IsOn`:

- `Floyd.OnBeingTalkedTo` (`Floyd.cs:199`) — the chat lambda is never called for the body.
- `Floyd.CannotBeTakenDescription` (`Floyd.cs:131`) — the take refusal is now mourning-appropriate.

**3 — the corpse is elsewhere.** In the trapped-death branch Floyd dies inside the Bio Lab with `CurrentLocation` null, so addressing him takes the absent-talker path — and `NarrateAbsence` overrides the character's static line with AI narration, which answers a whereabouts question by inventing one. Gating this needed an engine change:

- `ICanBeTalkedTo` gains `IsGoneForGood` (default `false`) — a character who is dead, not merely elsewhere.
- `ConversationHandler.NarrateAbsence` (`ConversationHandler.cs:234`) short-circuits to the character's own deterministic `NotHereDescription` for such a talker, never consulting the narrator.
- `Floyd` returns `HasDied` for it and mourns in `NotHereDescription`.

This also covers the sacrifice path once the player walks away from the body, not just the trapped branch.

**New text.** Three constants in `FloydConstants` (`TakeDead`, `TalkToDead`, `NotHereDead`), written in the register of the existing corpse lines — `ExaminationDead` and the "great robot shop in the sky" turn-off.

## ZIL check

`DEAD-FLOYD-F` (`planetfall-source/compone.zil:2303-2313`) is a **separate object** from living Floyd, and handles only `EXAMINE` / `LAMP-ON` / `LAMP-OFF`, leaving everything else to parser defaults. So the original never had a living-Floyd response reachable on the corpse at all — this port's shared-object design is what made these three leaks possible. The new lines are original C# in the spirit of that routine (grief, never the living robot's chirp), not ported text.

## TDD

Four tests in `Planetfall.Tests/FloydTests.cs`. Three failed before the fix with the issue's exact prod strings:

```
Did not expect response "Floyd says he is okay now that you are here."
Did not expect response "You manage to lift Floyd a few inches off the ground... surprised squeal..."
Did not expect response "Floyd must be off on his own little adventure."
```

The fourth — `TalkToFloyd_AliveAndAbsent_StillGetsTheNarratedAbsence` — passed from the start and guards that the new gate doesn't swallow the #264 narrated-absence behavior for a living, merely-elsewhere Floyd.

`UnitTests/Engine/ConversationHandlerTests.cs` proves the `IsGoneForGood` gate game-agnostically with a `GhostTalker` fixture (verified it fails when the gate is disabled), matching how the rest of the absent-talker routing is covered there.

## Verification

Every suite run separately, all green:

| Suite | Result |
|---|---|
| Planetfall.Tests | 3939 passed |
| UnitTests | 1148 passed, 1 skipped |
| ZorkOne.Tests | 1782 passed |
| EscapeRoom / Stationfall / Console.Tests | 9 / 4 / 16 passed |

## Reviewer note — one thing deliberately left out

The issue's manifestation 3 also mentions `examine floyd` on an absent dead Floyd. That does **not** travel the conversation handler: it falls to `NounNotPresentOperationRequest`, the generic "you don't see that here" narration shared by every unresolvable noun in every game (`SimpleInteractionEngine.cs:125`). Hooking a character-specific line in there would mean, for example, `examine robot` answering "Floyd is gone" anywhere the noun happens not to resolve. The issue frames that variant as optional ("could check"), and the reproduced repro step is the conversation, which is fixed here. Happy to take it on separately if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
