### PR TITLE
Floyd conversation: canned mention responses (#552) + two gone-for-good gaps from #545's second review

### DIFF
--- a/GameEngine/ConversationHandler.cs
+++ b/GameEngine/ConversationHandler.cs
@@ -2,6 +2,7 @@ using ChatLambda;
 using Microsoft.Extensions.Logging;
 using Model.AIGeneration;
 using Model.AIGeneration.Requests;
+using Model;
 using Model.Interface;
 using Model.Item;
 
@@ -115,19 +116,49 @@ public class ConversationHandler(
     }
 
     /// <summary>
-    /// Backstop for address phrasings <see cref="IsGenuineDirectAddress"/> cannot recognize, kept
-    /// identical to <see cref="FindAddressedAbsentCharacter"/>'s: consult the conversation
-    /// classifier, but skip it when generation is disabled so the guard stays deterministic and
-    /// offline-safe in NoGeneratedResponses mode.
+    /// Backstop for address phrasings <see cref="IsGenuineDirectAddress"/> cannot recognize. Two
+    /// guards keep it from eating the ordinary commands the caller's doc promises will fall through:
+    /// <list type="bullet">
+    /// <item>Skipped when the input opens with a game verb. "examine floyd" / "take floyd" /
+    /// "search robot" are commands for the item's own handlers, and the whole point of the
+    /// gone-for-good route is that they reach them WITHOUT a network call. Letting the classifier
+    /// judge those made the corpse's examine/take/search output depend on a remote LLM whose decode
+    /// is fail-open (anything but the literal string "No" counts as conversational) - so an
+    /// unlucky call replaced the examine description with the mourning line. That regression is
+    /// what this guard exists to prevent; the phrasings actually being recovered here ("could you
+    /// let floyd know ...") never start with a verb.</item>
+    /// <item>Skipped when generation is disabled, so the guard stays deterministic and offline-safe
+    /// in NoGeneratedResponses mode - the same rule <see cref="FindAddressedAbsentCharacter"/>
+    /// follows.</item>
+    /// </list>
     /// </summary>
     private async Task<bool> ClassifierSaysAddressed(string input)
     {
-        if (generationClient.IsDisabled)
+        if (generationClient.IsDisabled || OpensWithAGameVerb(input))
             return false;
 
         var parseResult = await parseConversation.ParseAsync(input);
         logger?.LogDebug($"[CONVERSATION DEBUG] Gone-for-good classifier isConversational: {parseResult.isConversational}");
         return parseResult.isConversational;
+    }
+
+    /// <summary>
+    /// True when the command's first word is a verb the game itself acts on. Drawn from
+    /// <see cref="Verbs"/>, the codebase's stated single source of truth for verb families, so a
+    /// synonym added there is honored here without a second list to maintain.
+    /// </summary>
+    private static bool OpensWithAGameVerb(string input)
+    {
+        string[][] families =
+        [
+            Verbs.ExamineVerbs, Verbs.LookVerbs, Verbs.TakeVerbs, Verbs.DropVerbs, Verbs.OpenVerbs,
+            Verbs.CloseVerbs, Verbs.PushVerbs, Verbs.MoveVerbs, Verbs.KillVerbs, Verbs.BreakVerbs,
+            Verbs.TouchVerbs, Verbs.ApplyVerbs, Verbs.ThrowVerbs, Verbs.GiveVerbs, Verbs.ShowVerbs
+        ];
+
+        return families.SelectMany(family => family)
+            .Concat(["search", "turn", "switch", "activate", "deactivate", "read", "smell", "oil"])
+            .Any(verb => StartsWithWholeWord(input.TrimStart(), verb));
     }
 
     /// <summary>
@@ -147,7 +178,9 @@ public class ConversationHandler(
     /// gate already keeps this branch dormant there; the speech test is a second line of defense.</item>
     /// <item>Routing relies on the NPC's AI conversation backend, so it honors the generation
     /// kill-switch exactly like the present-name path, staying deterministic in NoGeneratedResponses
-    /// mode.</item>
+    /// mode - EXCEPT for a gone-for-good talker, who answers with a constant and so deliberately
+    /// bypasses the kill-switch below. Hoisting that check back to the top of the method would look
+    /// equivalent and would silently restore the blank-response bug.</item>
     /// </list>
     /// Returns the NPC's reply, or null to fall through to normal parsing.
     /// </summary>

--- a/GameEngine/ConversationHandler.cs
+++ b/GameEngine/ConversationHandler.cs
@@ -80,19 +80,27 @@ public class ConversationHandler(
     /// <c>ParseConversation</c> rewriter the living path uses - that call is an AWS Lambda round-trip
     /// whose only product is a command the character will never act on.
     ///
-    /// Address detection therefore falls to <see cref="IsGenuineDirectAddress"/>, the same
-    /// deterministic test the absent path relies on. That is not a downgrade from the living path's
-    /// backstop: <see cref="TryStripDirectAddress"/> recognizes only the leading-name forms and leaves
-    /// imperative lead-ins ("ask floyd about the card") to the classifier, whereas
-    /// IsGenuineDirectAddress covers both - so a corpse is addressable by strictly more phrasings than
-    /// before, and deterministically, including in NoGeneratedResponses mode.
+    /// Address detection is two-tier, mirroring the absent path exactly: the deterministic
+    /// <see cref="IsGenuineDirectAddress"/> first - which covers leading names AND imperative
+    /// lead-ins, so the common phrasings answer offline and without any round-trip - and the
+    /// classifier only as a backstop for what it misses.
+    ///
+    /// The backstop is not optional. An earlier version of this method used IsGenuineDirectAddress
+    /// alone, on the reasoning that it is strictly broader than <see cref="TryStripDirectAddress"/>.
+    /// That compared against the wrong thing: the pipeline actually replaced was the classifier OR
+    /// the strip, and looser phrasings the classifier alone recognized ("could you let floyd know
+    /// ...", which leads with neither a name nor a lead-in) stopped reaching the character and leaked
+    /// to the narrator - the exact outcome this route exists to prevent.
     ///
     /// Returns null when the input merely NAMES the character rather than addressing them ("examine
     /// floyd", "take floyd"), so those keep falling through to the item's own handlers.
     /// </summary>
     private async Task<string?> RespondForGoneForGoodTalker(string input, ICanBeTalkedTo target, IContext context)
     {
-        if (!IsGenuineDirectAddress(input, target))
+        // && short-circuits, so the classifier is never consulted for a phrasing the deterministic
+        // test already recognized - which is the overwhelming majority, and keeps the "no Lambda
+        // round-trip for a constant reply" win this route was created for.
+        if (!IsGenuineDirectAddress(input, target) && !await ClassifierSaysAddressed(input))
         {
             logger?.LogDebug("[CONVERSATION DEBUG] Gone-for-good talker named but not addressed; falling through");
             return null;
@@ -104,6 +112,22 @@ public class ConversationHandler(
 
         logger?.LogDebug($"[CONVERSATION DEBUG] Gone-for-good talker addressed with '{remainder}'; answering directly");
         return await target.OnBeingTalkedTo(remainder, context, generationClient);
+    }
+
+    /// <summary>
+    /// Backstop for address phrasings <see cref="IsGenuineDirectAddress"/> cannot recognize, kept
+    /// identical to <see cref="FindAddressedAbsentCharacter"/>'s: consult the conversation
+    /// classifier, but skip it when generation is disabled so the guard stays deterministic and
+    /// offline-safe in NoGeneratedResponses mode.
+    /// </summary>
+    private async Task<bool> ClassifierSaysAddressed(string input)
+    {
+        if (generationClient.IsDisabled)
+            return false;
+
+        var parseResult = await parseConversation.ParseAsync(input);
+        logger?.LogDebug($"[CONVERSATION DEBUG] Gone-for-good classifier isConversational: {parseResult.isConversational}");
+        return parseResult.isConversational;
     }
 
     /// <summary>
@@ -141,13 +165,25 @@ public class ConversationHandler(
             return null;
         }
 
+        var target = present[0];
+
+        // Same reasoning as the named branch in CheckForConversation, which this one was missed by
+        // (#545 round-2 review): a gone-for-good talker answers with a constant, so their reply owes
+        // generation nothing. Without this gate, saying "hello" over the body with
+        // NoGeneratedResponses set returned null at the kill-switch below and leaked the utterance
+        // back into normal parsing instead of mourning.
+        if (target.IsGoneForGood)
+        {
+            logger?.LogDebug("[CONVERSATION DEBUG] Nameless speech to a gone-for-good talker; answering directly");
+            return await target.OnBeingTalkedTo(speech, context, generationClient);
+        }
+
         if (generationClient.IsDisabled)
         {
             logger?.LogDebug("[CONVERSATION DEBUG] Conversations disabled via NoGeneratedResponses flag");
             return null;
         }
 
-        var target = present[0];
         logger?.LogDebug($"[CONVERSATION DEBUG] Routing nameless speech '{speech}' to the sole present talker");
         return await target.OnBeingTalkedTo(speech, context, generationClient);
     }

--- a/Planetfall.Tests/AbsentTalkableNpcTests.cs
+++ b/Planetfall.Tests/AbsentTalkableNpcTests.cs
@@ -321,6 +321,7 @@ public class AbsentTalkableNpcTests : EngineTestsBase
     public async Task ExaminingAbsentFloyd_IsNotInterceptedByGuard()
     {
         var target = GetTarget();
+        MeetFloyd(); // without this #552's pre-meeting intercept answers and the guard is never reached
         StartHere<DeckNine>();
 
         var response = await target.GetResponse("examine floyd");
@@ -344,6 +345,7 @@ public class AbsentTalkableNpcTests : EngineTestsBase
     public async Task AttackingAbsentFloyd_IsNotInterceptedByGuard()
     {
         var target = GetTarget();
+        MeetFloyd(); // without this #552's pre-meeting intercept answers and the guard is never reached
         StartHere<DeckNine>();
 
         var response = await target.GetResponse("attack floyd");

--- a/Planetfall.Tests/AbsentTalkableNpcTests.cs
+++ b/Planetfall.Tests/AbsentTalkableNpcTests.cs
@@ -20,10 +20,22 @@ namespace Planetfall.Tests;
 /// </summary>
 public class AbsentTalkableNpcTests : EngineTestsBase
 {
+    /// <summary>
+    /// Puts Floyd in the state these tests are actually about: met, then left behind or wandered
+    /// off. Naming him BEFORE the player has woken him is claimed by the fourth-wall intercept
+    /// (issue #552), which is a different answer to a different situation - the player can't have
+    /// been separated from a companion they have never met.
+    /// </summary>
+    private void MeetFloyd()
+    {
+        GetItem<Floyd>().HasEverBeenOn = true;
+    }
+
     [Test]
     public async Task AddressingAbsentFloyd_GoUp_SaysNotHere_AndDoesNotMove()
     {
         var target = GetTarget();
+        MeetFloyd();
         StartHere<DeckNine>();
 
         var response = await target.GetResponse("floyd, go up");
@@ -36,6 +48,7 @@ public class AbsentTalkableNpcTests : EngineTestsBase
     public async Task AddressingAbsentFloyd_DropDiary_SaysNotHere_AndKeepsItem()
     {
         var target = GetTarget();
+        MeetFloyd();
         StartHere<DeckNine>();
         Take<Diary>();
 
@@ -49,6 +62,7 @@ public class AbsentTalkableNpcTests : EngineTestsBase
     public async Task AddressingAbsentFloyd_Sing_SaysNotHere_AndDoesNotHallucinate()
     {
         var target = GetTarget();
+        MeetFloyd();
         StartHere<DeckNine>();
 
         var response = await target.GetResponse("floyd, sing");
@@ -185,6 +199,7 @@ public class AbsentTalkableNpcTests : EngineTestsBase
     public async Task AddressingAbsentFloydWithoutComma_GoUp_SaysNotHere_AndDoesNotMove()
     {
         var target = GetTarget();
+        MeetFloyd();
         StartHere<DeckNine>();
 
         var response = await target.GetResponse("floyd go up");
@@ -197,6 +212,7 @@ public class AbsentTalkableNpcTests : EngineTestsBase
     public async Task AddressingAbsentFloydWithoutComma_DropDiary_SaysNotHere_AndKeepsItem()
     {
         var target = GetTarget();
+        MeetFloyd();
         StartHere<DeckNine>();
         Take<Diary>();
 
@@ -237,6 +253,7 @@ public class AbsentTalkableNpcTests : EngineTestsBase
     public async Task AddressingAbsentFloydCasually_SaysNotHere(string input)
     {
         var target = GetTarget();
+        MeetFloyd();
         StartHere<DeckNine>();
 
         var response = await target.GetResponse(input);
@@ -251,6 +268,7 @@ public class AbsentTalkableNpcTests : EngineTestsBase
     public async Task AddressingAbsentFloydWithUnusualPhrasing_DefersToClassifier_SaysNotHere()
     {
         var target = GetTarget();
+        MeetFloyd();
         StartHere<DeckNine>();
         ParseConversationMock
             .Setup(p => p.ParseAsync("could you let floyd know to wait for me"))
@@ -266,6 +284,7 @@ public class AbsentTalkableNpcTests : EngineTestsBase
     public async Task TellingAbsentFloydToDoSomething_SaysNotHere()
     {
         var target = GetTarget();
+        MeetFloyd();
         StartHere<DeckNine>();
 
         var response = await target.GetResponse("tell floyd to go up");

--- a/Planetfall.Tests/BoothTests.cs
+++ b/Planetfall.Tests/BoothTests.cs
@@ -490,6 +490,9 @@ public class BoothTests : EngineTestsBase
         StartHere<BoothThree>();
         Take<TeleportationAccessCard>();
         GetLocation<BoothThree>().ItemPlacedHere(GetItem<Floyd>());
+        // Addressing him by name is only the player's to do once they've met him; before that the
+        // fourth-wall intercept claims the name (issue #552).
+        GetItem<Floyd>().HasEverBeenOn = true;
 
         await target.GetResponse("slide teleportation access card through slot");
         await target.GetResponse("press one");

--- a/Planetfall.Tests/FloydMentionTests.cs
+++ b/Planetfall.Tests/FloydMentionTests.cs
@@ -110,6 +110,23 @@ public class FloydMentionTests : EngineTestsBase
             response.Should().Contain("Robot Shop");
         }
 
+        // Noun scoping holds on the CONVERSATION path too, not just for examine: addressing the
+        // pristine robot as "robot" still reaches Floyd.OnBeingTalkedTo and gets the turned-off
+        // line. Worth pinning because the never-activated state (IsOn and HasEverBeenOn both false)
+        // is a real, reachable state - the robot standing in the shop before you ever touch him -
+        // and the name is the ONLY thing issue #552 takes away from the player there.
+        [Test]
+        public async Task AddressingThePristineRobotAsRobot_StillReachesHim()
+        {
+            var target = GetTarget();
+            StartHere<RobotShop>();
+
+            var response = await target.GetResponse("robot, are you okay");
+
+            response.Should().NotContain(FourthWall);
+            response.Should().Contain("appears to be turned off");
+        }
+
         // The gate can't be "!IsOn && !HasEverBeenOn" alone: neither flag flips until Floyd finishes
         // his 3-turn wake-up, so the joke would fire while the robot is visibly booting.
         [Test]

--- a/Planetfall.Tests/FloydMentionTests.cs
+++ b/Planetfall.Tests/FloydMentionTests.cs
@@ -1,0 +1,234 @@
+using FluentAssertions;
+using Planetfall.GlobalCommand;
+using Planetfall.Item.Kalamontee.Mech.FloydPart;
+using Planetfall.Location.Feinstein;
+using Planetfall.Location.Kalamontee.Mech;
+
+namespace Planetfall.Tests;
+
+/// <summary>
+/// Issue #552. Mentioning Floyd used to fall through to the AI narrator, which improvised a
+/// different joke every time — including tonally wrong ones after his death. These are the canned,
+/// deterministic replacements, split by whether the player has met Floyd yet.
+/// </summary>
+public class FloydMentionTests : EngineTestsBase
+{
+    private const string FourthWall = "There's nobody here by that name";
+
+    /// <summary>
+    /// Part 1: before the player has any in-game way of knowing the name, ANY mention of "floyd"
+    /// gets the fourth-wall wink — not just the where-is phrasings.
+    /// </summary>
+    [TestFixture]
+    public class BeforeMeetingFloyd : FloydMentionTests
+    {
+        [TestCase("where is floyd")]
+        [TestCase("where's floyd")]
+        [TestCase("examine floyd")]
+        [TestCase("take floyd")]
+        [TestCase("floyd, hello")]
+        [TestCase("ask floyd about lazarus")]
+        public async Task AnyMention_GetsTheFourthWallLine(string input)
+        {
+            var target = GetTarget();
+            StartHere<DeckNine>();
+
+            var response = await target.GetResponse(input);
+
+            response.Should().Contain("Floyd? There's nobody here by that name. " +
+                                      "Someone's played Planetfall before, haven't they?");
+        }
+
+        [Test]
+        public async Task MentionInTheRobotShop_GetsTheFourthWallLine()
+        {
+            var target = GetTarget();
+            StartHere<RobotShop>();
+
+            var response = await target.GetResponse("search floyd");
+
+            response.Should().Contain(FourthWall);
+        }
+
+        // CI-critical: "activate floyd" is the walkthrough spine, typed before any met-flag flips.
+        // If the intercept swallowed it, Floyd would be unactivatable by name.
+        [Test]
+        public async Task ActivateFloyd_StillActivatesHim()
+        {
+            var target = GetTarget();
+            StartHere<RobotShop>();
+
+            var response = await target.GetResponse("activate floyd");
+
+            response.Should().NotContain(FourthWall);
+            response.Should().Contain("Nothing happens");
+            GetItem<Floyd>().HasAwardedActivationPoints.Should().BeTrue();
+            Context.Score.Should().Be(2);
+        }
+
+        // The other activation phrasings are asserted against the matcher rather than end-to-end:
+        // the test harness's stub parser has no mapping for them (it takes the second word as the
+        // noun, so "turn on floyd" resolves to nothing), which would make an end-to-end assertion
+        // pass for the wrong reason. What matters here is that the intercept does not claim them.
+        [TestCase("turn on floyd")]
+        [TestCase("start floyd")]
+        [TestCase("switch on floyd")]
+        public void OtherActivationPhrasings_AreNotClaimed(string input)
+        {
+            GetTarget();
+
+            new PlanetfallGlobalCommandFactory().GetGlobalCommands(input).Should().BeNull();
+        }
+
+        // Only the NAME is intercepted. The deactivated-robot description is part of the intended
+        // discovery flow, so the nouns the player CAN know still behave normally.
+        [TestCase("examine robot")]
+        [TestCase("examine B-19-7")]
+        public async Task OtherNounsForFloyd_AreUnchanged(string input)
+        {
+            var target = GetTarget();
+            StartHere<RobotShop>();
+
+            var response = await target.GetResponse(input);
+
+            response.Should().NotContain(FourthWall);
+            response.Should().Contain("The deactivated robot is leaning against the wall");
+        }
+
+        // God mode is matched by the ENGINE's command factory, which is consulted before the
+        // game-specific one - so the debugging commands that name Floyd keep working even while the
+        // intercept is armed.
+        [Test]
+        public async Task GodModeCommandsNamingFloyd_AreNotIntercepted()
+        {
+            var target = GetTarget();
+            StartHere<RobotShop>();
+
+            var response = await target.GetResponse("god mode where floyd");
+
+            response.Should().NotContain(FourthWall);
+            response.Should().Contain("Robot Shop");
+        }
+
+        // The gate can't be "!IsOn && !HasEverBeenOn" alone: neither flag flips until Floyd finishes
+        // his 3-turn wake-up, so the joke would fire while the robot is visibly booting.
+        [Test]
+        public async Task DuringTheWakeUpCountdown_NoFourthWallLine()
+        {
+            var target = GetTarget();
+            StartHere<RobotShop>();
+
+            await target.GetResponse("activate floyd");
+            var floyd = GetItem<Floyd>();
+            floyd.IsOn.Should().BeFalse();
+            floyd.HasEverBeenOn.Should().BeFalse();
+
+            var response = await target.GetResponse("examine floyd");
+
+            response.Should().NotContain(FourthWall);
+            response.Should().Contain("The deactivated robot is leaning against the wall");
+        }
+    }
+
+    /// <summary>
+    /// Part 2: once the player knows him, only the where-is-shaped queries are claimed, and the
+    /// answer is keyed off Floyd's actual state.
+    /// </summary>
+    [TestFixture]
+    public class AfterMeetingFloyd : FloydMentionTests
+    {
+        [TestCase("where is floyd")]
+        [TestCase("where's floyd")]
+        [TestCase("find floyd")]
+        [TestCase("where did floyd go")]
+        public async Task InTheRoomAndOn_FloydIsAlwaysRightHere(string input)
+        {
+            var target = GetTarget();
+            StartHere<RobotShop>();
+            var floyd = GetItem<Floyd>();
+            floyd.IsOn = true;
+            floyd.HasEverBeenOn = true;
+
+            var response = await target.GetResponse(input);
+
+            response.Should().Contain("Floyd is right here! Floyd is always right here.");
+        }
+
+        [Test]
+        public async Task InTheRoomButSwitchedOff_SlumpedWhereYouLeftHim()
+        {
+            var target = GetTarget();
+            StartHere<RobotShop>();
+            var floyd = GetItem<Floyd>();
+            floyd.IsOn = false;
+            floyd.HasEverBeenOn = true;
+
+            var response = await target.GetResponse("where is floyd");
+
+            response.Should().Contain("Floyd is right here, slumped where you left him.");
+        }
+
+        [Test]
+        public async Task Absent_IsOffExploring()
+        {
+            var target = GetTarget();
+            StartHere<RobotShop>();
+            var floyd = GetItem<Floyd>();
+            floyd.IsOn = true;
+            floyd.HasEverBeenOn = true;
+            GetLocation<MachineShop>().ItemPlacedHere(floyd);
+
+            var response = await target.GetResponse("where is floyd");
+
+            response.Should().Contain("Floyd is off exploring somewhere. He'll turn up.");
+        }
+
+        // #545 item 3: the narrator used to crack jokes about the dead.
+        [Test]
+        public async Task Dead_GetsTheGriefRegisterLine()
+        {
+            var target = GetTarget();
+            StartHere<RobotShop>();
+            var floyd = GetItem<Floyd>();
+            floyd.HasEverBeenOn = true;
+            floyd.HasDied = true;
+
+            var response = await target.GetResponse("where is floyd");
+
+            response.Should().Contain("Floyd is gone.");
+            response.Should().NotContain(FourthWall);
+        }
+
+        // Part 2 claims the where-is queries ONLY. Everything else keeps its existing behavior.
+        [Test]
+        public async Task ExamineFloyd_IsNotClaimed()
+        {
+            var target = GetTarget();
+            StartHere<RobotShop>();
+            var floyd = GetItem<Floyd>();
+            floyd.IsOn = true;
+            floyd.HasEverBeenOn = true;
+
+            var response = await target.GetResponse("examine floyd");
+
+            response.Should().Contain("From its design, the robot seems to be of the multi-purpose sort");
+            response.Should().NotContain("right here");
+        }
+
+        // A conversational line that merely contains the word "where" must still reach Floyd rather
+        // than being answered by the canned locator.
+        [Test]
+        public async Task AskingFloydAboutSomethingElse_IsNotClaimed()
+        {
+            var target = GetTarget();
+            StartHere<RobotShop>();
+            var floyd = GetItem<Floyd>();
+            floyd.IsOn = true;
+            floyd.HasEverBeenOn = true;
+
+            var response = await target.GetResponse("floyd, do you know where the card is");
+
+            response.Should().NotContain("Floyd is right here");
+        }
+    }
+}

--- a/Planetfall.Tests/FloydMentionTests.cs
+++ b/Planetfall.Tests/FloydMentionTests.cs
@@ -3,6 +3,7 @@ using Planetfall.GlobalCommand;
 using Planetfall.Item.Kalamontee.Mech.FloydPart;
 using Planetfall.Location.Feinstein;
 using Planetfall.Location.Kalamontee.Mech;
+using Planetfall.Location.Lawanda.Lab;
 
 namespace Planetfall.Tests;
 
@@ -110,6 +111,65 @@ public class FloydMentionTests : EngineTestsBase
             response.Should().Contain("Robot Shop");
         }
 
+        // Bug: the exemption required the particle to be adjacent, so the separated-particle form
+        // was swallowed. On main this phrasing scores the +2 and starts the countdown; the parser
+        // normalizes "turn X on" to the verb "activate" (Model/ParsingHelper.cs), but the intercept
+        // runs on RAW text and never sees that.
+        [TestCase("turn floyd on")]
+        [TestCase("switch floyd on")]
+        [TestCase("power floyd up")]
+        [TestCase("turn the floyd on")]
+        public void SeparatedParticleActivation_IsNotClaimed(string input)
+        {
+            GetTarget();
+
+            new PlanetfallGlobalCommandFactory().GetGlobalCommands(input).Should().BeNull();
+        }
+
+        // Bug: the exemption tested the WHOLE command for an activation word rather than the verb
+        // governing "floyd", so any sentence containing "start" escaped the intercept entirely.
+        [TestCase("floyd, let's start singing")]
+        [TestCase("where can i start looking for floyd")]
+        [TestCase("turn on the lamp and show it to floyd")]
+        public async Task ActivationWordElsewhereInTheSentence_StillGetsTheFourthWallLine(string input)
+        {
+            var target = GetTarget();
+            StartHere<DeckNine>();
+
+            var response = await target.GetResponse(input);
+
+            response.Should().Contain(FourthWall);
+        }
+
+        // Bug: the intercept matched "floyd" anywhere with no regard for who was being addressed,
+        // so it ate speech aimed at the NPC the whole opening sequence is built around.
+        [Test]
+        public async Task AddressingAnotherPresentNpc_IsNotClaimed()
+        {
+            var target = GetTarget();
+            StartHere<DeckNine>();
+
+            var response = await target.GetResponse("blather, where is floyd");
+
+            response.Should().NotContain(FourthWall);
+        }
+
+        // Bug: a parser-level refusal is not an in-world action and must not cost survival time.
+        // On Deck Nine the explosion clock makes this lethal, not merely untidy.
+        [Test]
+        public async Task TheFourthWallLine_DoesNotCostATurn()
+        {
+            var target = GetTarget();
+            StartHere<DeckNine>();
+            var movesBefore = Context.Moves;
+            var timeBefore = Context.CurrentTime;
+
+            await target.GetResponse("where is floyd");
+
+            Context.Moves.Should().Be(movesBefore);
+            Context.CurrentTime.Should().Be(timeBefore);
+        }
+
         // Noun scoping holds on the CONVERSATION path too, not just for examine: addressing the
         // pristine robot as "robot" still reaches Floyd.OnBeingTalkedTo and gets the turned-off
         // line. Worth pinning because the never-activated state (IsOn and HasEverBeenOn both false)
@@ -125,6 +185,18 @@ public class FloydMentionTests : EngineTestsBase
 
             response.Should().NotContain(FourthWall);
             response.Should().Contain("appears to be turned off");
+        }
+
+        [Test]
+        public async Task WhereIsTheRobot_BeforeMeetingHim_IsNotClaimed()
+        {
+            var target = GetTarget();
+            StartHere<RobotShop>();
+
+            var response = await target.GetResponse("where is the robot");
+
+            response.Should().NotContain(FourthWall);
+            response.Should().NotContain("Floyd is");
         }
 
         // The gate can't be "!IsOn && !HasEverBeenOn" alone: neither flag flips until Floyd finishes
@@ -214,6 +286,111 @@ public class FloydMentionTests : EngineTestsBase
 
             response.Should().Contain("Floyd is gone.");
             response.Should().NotContain(FourthWall);
+        }
+
+        // Bug: "floyd" was matched anywhere while only the leading where-word was anchored, so
+        // questions about the things Floyd CARRIES were answered with Floyd's location.
+        [TestCase("where is floyd's card")]
+        [TestCase("where did floyd put the card")]
+        [TestCase("where is the card floyd is holding")]
+        [TestCase("find the card floyd took")]
+        [TestCase("where is the survival kit, floyd")]
+        public async Task WhereQuestionsAboutOtherThings_AreNotClaimed(string input)
+        {
+            var target = GetTarget();
+            StartHere<RobotShop>();
+            var floyd = GetItem<Floyd>();
+            floyd.IsOn = true;
+            floyd.HasEverBeenOn = true;
+
+            var response = await target.GetResponse(input);
+
+            response.Should().NotContain("Floyd is right here");
+        }
+
+        [Test]
+        public async Task WhereIsFloyd_DoesNotCostATurn()
+        {
+            var target = GetTarget();
+            StartHere<RobotShop>();
+            var floyd = GetItem<Floyd>();
+            floyd.IsOn = true;
+            floyd.HasEverBeenOn = true;
+            var movesBefore = Context.Moves;
+            var timeBefore = Context.CurrentTime;
+
+            await target.GetResponse("where is floyd");
+
+            Context.Moves.Should().Be(movesBefore);
+            Context.CurrentTime.Should().Be(timeBefore);
+        }
+
+        // Bug: the absent branch was blind to the states Floyd actually tracks. During the Bio Lab
+        // sacrifice he has CurrentLocation null and IsAwayOnScriptedSequence set, with HasDied still
+        // false - and the breezy line fired while the player listened to him being torn apart.
+        [Test]
+        public async Task AwayOnAScriptedSequence_DoesNotSayHeIsOffExploring()
+        {
+            var target = GetTarget();
+            StartHere<BioLockEast>();
+            var floyd = GetItem<Floyd>();
+            floyd.IsOn = true;
+            floyd.HasEverBeenOn = true;
+            floyd.CurrentLocation = null;
+            floyd.IsAwayOnScriptedSequence = true;
+
+            var response = await target.GetResponse("where is floyd");
+
+            response.Should().NotContain("off exploring somewhere");
+            response.Should().NotContain("He'll turn up");
+        }
+
+        // Bug: the absent branch ignored IsOn, so a robot the player personally switched off was
+        // described as wandering and due back.
+        [Test]
+        public async Task AbsentAndSwitchedOff_DoesNotPromiseHeWillTurnUp()
+        {
+            var target = GetTarget();
+            StartHere<RobotShop>();
+            var floyd = GetItem<Floyd>();
+            floyd.HasEverBeenOn = true;
+            floyd.IsOn = false;
+            GetLocation<MachineShop>().ItemPlacedHere(floyd);
+
+            var response = await target.GetResponse("where is floyd");
+
+            response.Should().NotContain("off exploring somewhere");
+            response.Should().NotContain("He'll turn up");
+        }
+
+        // Bug: PlayerKnowsFloydByName flips at activation but IsOn does not until the countdown
+        // ends, so the boot-up was answered with the copy written for a deactivated Floyd.
+        [Test]
+        public async Task DuringTheWakeUpCountdown_DoesNotSayYouLeftHimThere()
+        {
+            var target = GetTarget();
+            StartHere<RobotShop>();
+            await target.GetResponse("activate floyd");
+
+            var response = await target.GetResponse("where is floyd");
+
+            response.Should().NotContain("slumped where you left him");
+        }
+
+        // Asking after the dead companion by the synonym must not slip past into the narrator's
+        // improvisation - that is #545's tonal bug, still reachable while the matcher was name-only.
+        [Test]
+        public async Task WhereIsTheRobot_AfterHeDies_IsAnsweredNotNarrated()
+        {
+            var target = GetTarget();
+            StartHere<RobotShop>();
+            var floyd = GetItem<Floyd>();
+            floyd.HasEverBeenOn = true;
+            floyd.HasDied = true;
+
+            var response = await target.GetResponse("where is the robot");
+
+            response.Should().Contain("Floyd is gone.");
         }
 
         // Part 2 claims the where-is queries ONLY. Everything else keeps its existing behavior.

--- a/Planetfall.Tests/FloydTests.cs
+++ b/Planetfall.Tests/FloydTests.cs
@@ -24,6 +24,9 @@ namespace Planetfall.Tests;
 
 public class FloydTests : EngineTestsBase
 {
+    // These two search the deactivated robot as "robot", not by name: before the player wakes him
+    // they have no in-game way of knowing the name "Floyd", and issue #552 reserves that word for
+    // the fourth-wall intercept. "robot" is the noun the Robot Shop actually teaches.
     [Test]
     public async Task Search_FindCard()
     {
@@ -31,7 +34,7 @@ public class FloydTests : EngineTestsBase
         StartHere<RobotShop>();
         GetItem<Floyd>().IsOn = false;
 
-        var response = await target.GetResponse("search floyd");
+        var response = await target.GetResponse("search robot");
 
         response.Should().Contain("find and take");
         target.Context.HasItem<LowerElevatorAccessCard>().Should().BeTrue();
@@ -45,7 +48,7 @@ public class FloydTests : EngineTestsBase
         GetItem<Floyd>().IsOn = false;
         Take<LowerElevatorAccessCard>();
 
-        var response = await target.GetResponse("search floyd");
+        var response = await target.GetResponse("search robot");
 
         response.Should().Contain("search discovers nothing");
         target.Context.HasItem<LowerElevatorAccessCard>().Should().BeTrue();
@@ -333,11 +336,15 @@ public class FloydTests : EngineTestsBase
         response.Should().Contain("From its design, the robot seems to be of the multi-purpose sort");
     }
 
+    // Switched off AFTER the player has met him - the only state in which they can examine him by
+    // name and get the deactivated description (issue #552 intercepts the name before that).
+    // FloydMentionTests covers reaching the same text pre-meeting via "examine robot".
     [Test]
     public async Task ExamineFloyd_Off()
     {
         var target = GetTarget();
         StartHere<RobotShop>();
+        GetItem<Floyd>().HasEverBeenOn = true;
 
         var response = await target.GetResponse("examine floyd");
 
@@ -514,6 +521,11 @@ public class FloydTests : EngineTestsBase
         StartHere<RobotShop>();
         var floyd = GetItem<Floyd>();
         floyd.IsOn = false;
+        // Pinned to the post-activation case: the never-activated robot IS reachable in this state,
+        // but naming him there is claimed by #552's fourth-wall intercept, and this test exists to
+        // cover the switched-off-but-alive branch of OnBeingTalkedTo rather than that intercept.
+        // FloydMentionTests covers reaching Floyd pre-activation via "robot".
+        floyd.HasEverBeenOn = true;
         var chat = new Mock<IChatWithFloyd>();
         chat.Setup(s => s.AskFloydAsync(It.IsAny<string>()))
             .ReturnsAsync(new CompanionResponse("CHAT-SHOULD-NOT-HAPPEN", null));

--- a/Planetfall.Tests/FloydTests.cs
+++ b/Planetfall.Tests/FloydTests.cs
@@ -622,6 +622,29 @@ public class FloydTests : EngineTestsBase
         response.Should().Contain("no answer comes");
     }
 
+    // The guard on that backstop. Ordinary commands naming the corpse must reach Floyd's own
+    // handlers WITHOUT consulting the classifier - its decode is fail-open (anything but the literal
+    // "No" counts as conversational), so an unlucky call replaced the examine description with the
+    // mourning line. Stubbed here to the worst case: always "yes, conversational".
+    [TestCase("examine floyd", "a tremendous sense of loss")]
+    [TestCase("take floyd", "lay him gently back down")]
+    public async Task OrdinaryCommandsOnTheCorpse_NeverConsultTheClassifier(string input, string expected)
+    {
+        var target = GetTarget();
+        StartHere<RobotShop>();
+        var floyd = GetItem<Floyd>();
+        floyd.HasDied = true;
+        floyd.HasEverBeenOn = true;
+        floyd.IsOn = true;
+        ParseConversationMock.Setup(p => p.ParseAsync(It.IsAny<string>())).ReturnsAsync((true, ""));
+
+        var response = await target.GetResponse(input);
+
+        response.Should().Contain(expected);
+        response.Should().NotContain("no answer comes");
+        ParseConversationMock.Verify(p => p.ParseAsync(It.IsAny<string>()), Times.Never);
+    }
+
     // #545 round-2 review, finding 3. RespondForGoneForGoodTalker replaced a two-part detector
     // (deterministic strip OR the ParseConversation classifier) with IsGenuineDirectAddress alone.
     // That misses the looser phrasings only the classifier recognized - "could you let floyd know
@@ -2570,6 +2593,7 @@ public class FloydTests : EngineTestsBase
         var target = GetTarget();
         StartHere<RobotShop>();
         Take<IdCard>();
+        GetItem<Floyd>().HasEverBeenOn = true; // else #552's pre-meeting intercept answers instead
         GetItem<Floyd>().IsOn = false;
 
         var response = await target.GetResponse("show id card to floyd");

--- a/Planetfall.Tests/FloydTests.cs
+++ b/Planetfall.Tests/FloydTests.cs
@@ -601,6 +601,72 @@ public class FloydTests : EngineTestsBase
         response.Should().Contain("no answer comes");
     }
 
+    // #545 round-2 review, finding 2. The IsGoneForGood gate was added to CheckForConversation's
+    // NAMED branch but not to TryRouteNamelessSpeech, which still bails on the generation
+    // kill-switch. Standing over the body and saying "hello" with NoGeneratedResponses set produced
+    // a BLANK response - no mourning line, and the utterance leaked back into normal parsing. A
+    // gone-for-good talker's reply is a constant and owes generation nothing on this branch either.
+    [Test]
+    public async Task SpeakingNamelesslyToDeadFloyd_MournsEvenWithGenerationDisabled()
+    {
+        var target = GetTarget();
+        StartHere<RobotShop>(); // Floyd is placed here by Init, so he is the sole present talker.
+        var floyd = GetItem<Floyd>();
+        floyd.HasDied = true;
+        floyd.HasEverBeenOn = true;
+        floyd.IsOn = true;
+        Mock.Get(target.GenerationClient).Setup(c => c.IsDisabled).Returns(true);
+
+        var response = await target.GetResponse("say hello");
+
+        response.Should().Contain("no answer comes");
+    }
+
+    // #545 round-2 review, finding 3. RespondForGoneForGoodTalker replaced a two-part detector
+    // (deterministic strip OR the ParseConversation classifier) with IsGenuineDirectAddress alone.
+    // That misses the looser phrasings only the classifier recognized - "could you let floyd know
+    // ..." leads with "could", which is neither a leading name nor an address lead-in - so they
+    // stopped reaching Floyd and leaked to the narrator, the exact outcome #545 exists to prevent.
+    // Mirrors the absent path, which has kept the classifier as its fallback all along (see
+    // AbsentTalkableNpcTests.AddressingAbsentFloydWithUnusualPhrasing_DefersToClassifier_SaysNotHere).
+    [Test]
+    public async Task AddressingDeadFloydWithUnusualPhrasing_DefersToClassifier_AndMourns()
+    {
+        var target = GetTarget();
+        StartHere<RobotShop>();
+        var floyd = GetItem<Floyd>();
+        floyd.HasDied = true;
+        floyd.HasEverBeenOn = true;
+        floyd.IsOn = true;
+        ParseConversationMock
+            .Setup(p => p.ParseAsync("could you let floyd know to wait for me"))
+            .ReturnsAsync((true, ""));
+
+        var response = await target.GetResponse("could you let floyd know to wait for me");
+
+        response.Should().Contain("no answer comes");
+    }
+
+    // The classifier fallback must stay deterministic offline, exactly as the absent path is: with
+    // generation disabled the loose phrasing is not classified at all, so it falls through rather
+    // than guessing. The common phrasings IsGenuineDirectAddress covers still mourn (see
+    // TalkToFloyd_DeadAndPresent_MournsEvenWithGenerationDisabled), so nothing regresses offline.
+    [Test]
+    public async Task AddressingDeadFloydWithUnusualPhrasing_GenerationDisabled_DoesNotConsultClassifier()
+    {
+        var target = GetTarget();
+        StartHere<RobotShop>();
+        var floyd = GetItem<Floyd>();
+        floyd.HasDied = true;
+        floyd.HasEverBeenOn = true;
+        floyd.IsOn = true;
+        Mock.Get(target.GenerationClient).Setup(c => c.IsDisabled).Returns(true);
+
+        await target.GetResponse("could you let floyd know to wait for me");
+
+        ParseConversationMock.Verify(p => p.ParseAsync(It.IsAny<string>()), Times.Never);
+    }
+
     [Test]
     public async Task TalkToFloyd_DeadAndPresent_DoesNotCallTheConversationClassifier()
     {

--- a/Planetfall.Tests/InfirmaryTests.cs
+++ b/Planetfall.Tests/InfirmaryTests.cs
@@ -436,6 +436,7 @@ public class InfirmaryTests : EngineTestsBase
         var target = GetTarget();
         StartHere<RobotShop>();
         Take<MedicalRobotBreastPlate>();
+        GetItem<Floyd>().HasEverBeenOn = true; // else #552's pre-meeting intercept answers instead
         GetItem<Floyd>().IsOn = false;
 
         var response = await target.GetResponse("give breastplate to floyd");

--- a/Planetfall/GlobalCommand/FloydMentionCommands.cs
+++ b/Planetfall/GlobalCommand/FloydMentionCommands.cs
@@ -1,7 +1,8 @@
 using System.Text.RegularExpressions;
-using GameEngine.StaticCommand;
 using Model.AIGeneration;
+using Planetfall.Item.Feinstein;
 using Planetfall.Item.Kalamontee.Mech.FloydPart;
+using Utilities;
 
 namespace Planetfall.GlobalCommand;
 
@@ -11,8 +12,14 @@ namespace Planetfall.GlobalCommand;
 ///     Both halves used to fall through to the AI narrator, which improvised a different joke every
 ///     time - "off on his own little adventure", "cosmic coffee break" - including after his death,
 ///     where any joke at all is the wrong register (#545). Matching here, in a Planetfall-owned
-///     global command, means the answer is fixed, free of LLM cost, and lands before the AI parser
-///     and the conversation handler ever see the input.
+///     global command, means the answer is fixed and free of LLM cost.
+///     </para>
+///     <para>
+///     Everything here matches RAW player text, before the parser has resolved a verb or a noun.
+///     That buys determinism and zero cost, and it is why every matcher below is anchored and
+///     narrow: an unanchored match on raw text claims sentences that were never about Floyd. The
+///     review that followed the first cut of this file found five separate bugs of exactly that
+///     shape, so the rule for anything added here is "match the whole command, or don't match".
 ///     </para>
 /// </summary>
 internal static class FloydMentionCommands
@@ -26,19 +33,34 @@ internal static class FloydMentionCommands
 
     /// <summary>
     ///     CI-critical exemption. "activate floyd" is the walkthrough spine, and it is necessarily
-    ///     typed BEFORE any met-flag flips - if the fourth-wall intercept swallowed it, Floyd would
-    ///     be unactivatable by name and every walkthrough test would break.
+    ///     typed BEFORE any met-flag flips - if the intercept swallowed it, Floyd would be
+    ///     unactivatable by name and every walkthrough test would break.
+    ///     <para>
+    ///     Floyd must be the OBJECT of the activation, and the particle may sit either side of him:
+    ///     the production parser normalizes "turn X on" to the verb "activate"
+    ///     (<c>Model/ParsingHelper.cs</c>), but that happens downstream of here, so this has to
+    ///     recognize the raw English itself. Two bugs lived in the earlier version: it required the
+    ///     particle to be adjacent (so "turn floyd on" was swallowed - a command that scores the +2
+    ///     on main), and it tested the whole sentence for an activation word (so "floyd, let's start
+    ///     singing" escaped the intercept entirely).
+    ///     </para>
     /// </summary>
-    private static readonly Regex ActivatesFloyd =
-        new(@"\b(activate|turn\s+on|start|switch\s+on|power\s+(on|up))\b", RegexOptions.IgnoreCase);
+    private static readonly Regex ActivatesFloyd = new(
+        @"^\s*(please\s+)?((activate|start|boot)\s+(the\s+)?floyd\b"
+        + @"|(turn|switch|power)\s+((on|up)\s+)?(the\s+)?floyd(\s+(on|up))?\b)",
+        RegexOptions.IgnoreCase);
 
     /// <summary>
-    ///     Where-is-Floyd-shaped queries. Deliberately anchored at the start of the command: an
-    ///     unanchored "where" would hijack conversation aimed AT Floyd that merely contains the word
-    ///     ("floyd, do you know where the card is").
+    ///     Where-is-Floyd queries, matched against the WHOLE command rather than its first word.
+    ///     Anchoring only the leading "where" was not enough: "where is floyd's card" and "where is
+    ///     the survival kit, floyd" both led with a where-word and merely mentioned him, and both
+    ///     were answered with his location. Floyd is the companion who carries the elevator and
+    ///     mini-booth cards, so questions about his possessions are exactly what players ask.
     /// </summary>
-    private static readonly Regex AsksWhereFloydIs =
-        new(@"^\s*(where|find|locate)\b", RegexOptions.IgnoreCase);
+    private static readonly Regex AsksWhereFloydIs = new(
+        @"^(where(s)?\s+(is\s+|are\s+|was\s+|did\s+|has\s+|do\s+|does\s+)?(the\s+)?(floyd|robot)(\s+(go|gone|at|now))?"
+        + @"|(find|locate)\s+(the\s+)?(floyd|robot))$",
+        RegexOptions.IgnoreCase);
 
     /// <summary>
     ///     Returns the command that answers this mention of Floyd, or null to let normal parsing
@@ -46,7 +68,24 @@ internal static class FloydMentionCommands
     /// </summary>
     internal static IGlobalCommand? Match(string? input)
     {
-        if (string.IsNullOrWhiteSpace(input) || !NamesFloyd.IsMatch(input))
+        if (string.IsNullOrWhiteSpace(input))
+            return null;
+
+        var namesFloyd = NamesFloyd.IsMatch(input);
+
+        // The where-is branch also answers for "robot", so that asking after a dead companion by the
+        // synonym cannot slip past into the narrator's improvisation - the #545 tonal bug this whole
+        // change exists to close. The PRE-meeting branch below stays name-only, so "examine robot" /
+        // "where is the robot" in the Robot Shop keep their part in the discovery flow.
+        var asksWhereHeIs = AsksWhereFloydIs.IsMatch(Normalize(input));
+
+        if (!namesFloyd && !asksWhereHeIs)
+            return null;
+
+        // "blather, where is floyd" is Blather's line to answer. He is the NPC the whole opening
+        // sequence is built around and he is standing right there; claiming it handed the player an
+        // out-of-fiction wink instead of an in-fiction reply.
+        if (AddressesAnotherCharacter(input))
             return null;
 
         var floyd = Repository.GetItem<Floyd>();
@@ -55,22 +94,56 @@ internal static class FloydMentionCommands
         // is he, examine him, take him, greet him, ask him about Lazarus. Activation is the one
         // phrasing that has to keep working.
         if (!floyd.PlayerKnowsFloydByName)
-            return ActivatesFloyd.IsMatch(input)
-                ? null
-                : new SimpleResponseCommand(FloydConstants.NobodyHereByThatName);
+            return namesFloyd && !ActivatesFloyd.IsMatch(input)
+                ? new FreeResponseCommand(FloydConstants.NobodyHereByThatName)
+                : null;
 
         // Once they know him, only the where-is queries are claimed. Examining him, talking to him
         // and every other verb keep the behavior they already have.
-        return AsksWhereFloydIs.IsMatch(input) ? new WhereIsFloydProcessor() : null;
+        return asksWhereHeIs ? new WhereIsFloydProcessor() : null;
     }
+
+    /// <summary>
+    ///     True when the command opens by addressing one of Planetfall's other talkable characters.
+    ///     Only a LEADING name counts as address, the same rule ConversationHandler applies.
+    /// </summary>
+    private static bool AddressesAnotherCharacter(string input)
+    {
+        IItem[] others = [Repository.GetItem<Blather>(), Repository.GetItem<Ambassador>()];
+
+        return others
+            .SelectMany(other => other.NounsForMatching)
+            .Any(noun => Regex.IsMatch(input, @"^\s*(hey\s+|yo\s+|the\s+)*" + Regex.Escape(noun) + @"\b",
+                RegexOptions.IgnoreCase));
+    }
+
+    /// <summary>
+    ///     Punctuation out, whitespace collapsed, so "where's floyd?" and "Where Is Floyd" both reach
+    ///     the whole-command matcher in the one shape it has to describe.
+    /// </summary>
+    private static string Normalize(string input) =>
+        Regex.Replace(input.StripNonChars().Trim(), @"\s+", " ");
+}
+
+/// <summary>
+///     The fourth-wall line, as a FREE command. It is a parser-level "no such character" refusal,
+///     not an in-world action, so it must not advance Context.Moves or tick Planetfall's survival
+///     clocks (issue #354). It cost a full turn in the first cut of this file, which on Deck Nine
+///     meant eight mentions burned eight of the twelve turns the player has to reach the escape pod.
+/// </summary>
+internal class FreeResponseCommand(string response) : IFreeGlobalCommand
+{
+    public Task<string> Process(string? input, IContext context, IGenerationClient client, Runtime runtime)
+        => Task.FromResult(response);
 }
 
 /// <summary>
 ///     Answers "where is Floyd" from Floyd's actual state rather than from the narrator's
-///     imagination (issue #552). Needs the context - "right here" is a question about the player's
-///     room - so unlike the fourth-wall line it can't be resolved to a fixed string at match time.
+///     imagination (issue #552). Free for the same reason as <see cref="FreeResponseCommand" />:
+///     asking after your companion is a status query, exactly like the sibling meta-commands
+///     (diagnose, look, score, inventory, time), and must not cost survival time.
 /// </summary>
-internal class WhereIsFloydProcessor : IGlobalCommand
+internal class WhereIsFloydProcessor : IFreeGlobalCommand
 {
     public Task<string> Process(string? input, IContext context, IGenerationClient client, Runtime runtime)
     {
@@ -81,12 +154,27 @@ internal class WhereIsFloydProcessor : IGlobalCommand
         if (floyd.HasDied)
             return Task.FromResult(FloydConstants.WhereIsFloydDead);
 
-        if (!floyd.IsInTheRoom(context))
-            return Task.FromResult(FloydConstants.WhereIsFloydAbsent);
+        // A scripted errand nulls CurrentLocation while HasDied is still false - most painfully the
+        // Bio Lab sacrifice, where the generic absent line told the player Floyd was "off exploring
+        // somewhere" while they listened to him being torn apart. Must precede the absent branch.
+        if (floyd.IsAwayOnScriptedSequence)
+            return Task.FromResult(FloydConstants.WhereIsFloydOutOfSight);
 
-        // IsAlive rather than a bare IsOn. The HasDied return above already makes the two
-        // equivalent here, but #545's lesson is that a liveness guard should be right in its own
-        // right, not merely shadowed by an earlier return in the same method.
+        if (!floyd.IsInTheRoom(context))
+            // Wandering and switched-off-and-left-behind are different facts. "He'll turn up" is
+            // false of a robot the player personally deactivated.
+            return Task.FromResult(floyd.IsOn
+                ? FloydConstants.WhereIsFloydAbsent
+                : FloydConstants.WhereIsFloydAbsentAndOff);
+
+        // He is here. The wake-up countdown is its own state: PlayerKnowsFloydByName flips the
+        // moment the switch is flipped, but IsOn does not flip until he wakes three turns later, so
+        // without this the boot-up got the copy written for a Floyd the player deactivated.
+        if (!floyd.IsOn && floyd.TurnOnCountdown > 0 && !floyd.HasEverBeenOn)
+            return Task.FromResult(FloydConstants.WhereIsFloydStillBooting);
+
+        // IsAlive rather than a bare IsOn: #545's lesson is that a liveness guard should be right in
+        // its own right, not merely shadowed by an earlier return in the same method.
         return Task.FromResult(floyd.IsAlive
             ? FloydConstants.WhereIsFloydHereAndOn
             : FloydConstants.WhereIsFloydHereAndOff);

--- a/Planetfall/GlobalCommand/FloydMentionCommands.cs
+++ b/Planetfall/GlobalCommand/FloydMentionCommands.cs
@@ -1,0 +1,94 @@
+using System.Text.RegularExpressions;
+using GameEngine.StaticCommand;
+using Model.AIGeneration;
+using Planetfall.Item.Kalamontee.Mech.FloydPart;
+
+namespace Planetfall.GlobalCommand;
+
+/// <summary>
+///     Canned, deterministic answers to the player mentioning Floyd by name (issue #552).
+///     <para>
+///     Both halves used to fall through to the AI narrator, which improvised a different joke every
+///     time - "off on his own little adventure", "cosmic coffee break" - including after his death,
+///     where any joke at all is the wrong register (#545). Matching here, in a Planetfall-owned
+///     global command, means the answer is fixed, free of LLM cost, and lands before the AI parser
+///     and the conversation handler ever see the input.
+///     </para>
+/// </summary>
+internal static class FloydMentionCommands
+{
+    /// <summary>
+    ///     The word "floyd" on its own, not as part of a longer word. Only the NAME is matched:
+    ///     "robot" and "B-19-7" are things the player can see and read in the Robot Shop, and the
+    ///     deactivated-robot description they produce is part of the intended discovery flow.
+    /// </summary>
+    private static readonly Regex NamesFloyd = new(@"\bfloyd\b", RegexOptions.IgnoreCase);
+
+    /// <summary>
+    ///     CI-critical exemption. "activate floyd" is the walkthrough spine, and it is necessarily
+    ///     typed BEFORE any met-flag flips - if the fourth-wall intercept swallowed it, Floyd would
+    ///     be unactivatable by name and every walkthrough test would break.
+    /// </summary>
+    private static readonly Regex ActivatesFloyd =
+        new(@"\b(activate|turn\s+on|start|switch\s+on|power\s+(on|up))\b", RegexOptions.IgnoreCase);
+
+    /// <summary>
+    ///     Where-is-Floyd-shaped queries. Deliberately anchored at the start of the command: an
+    ///     unanchored "where" would hijack conversation aimed AT Floyd that merely contains the word
+    ///     ("floyd, do you know where the card is").
+    /// </summary>
+    private static readonly Regex AsksWhereFloydIs =
+        new(@"^\s*(where|find|locate)\b", RegexOptions.IgnoreCase);
+
+    /// <summary>
+    ///     Returns the command that answers this mention of Floyd, or null to let normal parsing
+    ///     handle the input.
+    /// </summary>
+    internal static IGlobalCommand? Match(string? input)
+    {
+        if (string.IsNullOrWhiteSpace(input) || !NamesFloyd.IsMatch(input))
+            return null;
+
+        var floyd = Repository.GetItem<Floyd>();
+
+        // Before the player can know the name, ANY mention of it is a returning fan talking - where
+        // is he, examine him, take him, greet him, ask him about Lazarus. Activation is the one
+        // phrasing that has to keep working.
+        if (!floyd.PlayerKnowsFloydByName)
+            return ActivatesFloyd.IsMatch(input)
+                ? null
+                : new SimpleResponseCommand(FloydConstants.NobodyHereByThatName);
+
+        // Once they know him, only the where-is queries are claimed. Examining him, talking to him
+        // and every other verb keep the behavior they already have.
+        return AsksWhereFloydIs.IsMatch(input) ? new WhereIsFloydProcessor() : null;
+    }
+}
+
+/// <summary>
+///     Answers "where is Floyd" from Floyd's actual state rather than from the narrator's
+///     imagination (issue #552). Needs the context - "right here" is a question about the player's
+///     room - so unlike the fourth-wall line it can't be resolved to a fixed string at match time.
+/// </summary>
+internal class WhereIsFloydProcessor : IGlobalCommand
+{
+    public Task<string> Process(string? input, IContext context, IGenerationClient client, Runtime runtime)
+    {
+        var floyd = Repository.GetItem<Floyd>();
+
+        // Death first: his body is still lying in the Bio Lock, so the in-the-room checks below
+        // would otherwise answer "right here" about a corpse.
+        if (floyd.HasDied)
+            return Task.FromResult(FloydConstants.WhereIsFloydDead);
+
+        if (!floyd.IsInTheRoom(context))
+            return Task.FromResult(FloydConstants.WhereIsFloydAbsent);
+
+        // IsAlive rather than a bare IsOn. The HasDied return above already makes the two
+        // equivalent here, but #545's lesson is that a liveness guard should be right in its own
+        // right, not merely shadowed by an earlier return in the same method.
+        return Task.FromResult(floyd.IsAlive
+            ? FloydConstants.WhereIsFloydHereAndOn
+            : FloydConstants.WhereIsFloydHereAndOff);
+    }
+}

--- a/Planetfall/GlobalCommand/PlanetfallGlobalCommandFactory.cs
+++ b/Planetfall/GlobalCommand/PlanetfallGlobalCommandFactory.cs
@@ -7,6 +7,11 @@ public class PlanetfallGlobalCommandFactory : GlobalCommandFactory
 {
     public override IGlobalCommand? GetGlobalCommands(string? input)
     {
+        // Checked before the exact-match table below because it matches on a word ANYWHERE in the
+        // command, not on the whole command (issue #552).
+        if (FloydMentionCommands.Match(input) is { } floydMention)
+            return floydMention;
+
         switch (input?.ToLowerInvariant().StripNonChars().Trim())
         {
             case "zork":

--- a/Planetfall/Item/Kalamontee/Mech/FloydPart/Floyd.cs
+++ b/Planetfall/Item/Kalamontee/Mech/FloydPart/Floyd.cs
@@ -73,6 +73,23 @@ public class Floyd : QuirkyCompanion, IAmANamedPerson, ICanHoldItems, ICanBeGive
     [UsedImplicitly] public int TurnOnCountdown { get; set; } = 3;
 
     /// <summary>
+    ///     True once the player has any in-game way of knowing the name "Floyd" - they have flipped
+    ///     his switch (even if he is still mid-countdown and not yet awake), met him awake, or lost
+    ///     him in the Bio Lab. Before that, naming him is a returning fan talking, not the character
+    ///     (issue #552).
+    ///     <para>
+    ///     The activation flag is load-bearing here: neither <see cref="IsOn" /> nor
+    ///     <see cref="HasEverBeenOn" /> flips until the 3-turn wake-up countdown finishes, so gating on
+    ///     those two alone would keep cracking the fourth-wall joke while the robot is visibly booting.
+    ///     <see cref="HasAwardedActivationPoints" /> is set the moment the player first activates him,
+    ///     which is exactly the moment the game itself starts calling him Floyd.
+    ///     </para>
+    /// </summary>
+    [JsonIgnore]
+    public bool PlayerKnowsFloydByName =>
+        IsOn || HasEverBeenOn || HasDied || HasAwardedActivationPoints;
+
+    /// <summary>
     /// Whether Floyd is alive: switched on AND not dead. Ask this - never <see cref="IsOn"/> - whenever
     /// the question is "would Floyd react?".
     /// <para>
@@ -241,7 +258,7 @@ public class Floyd : QuirkyCompanion, IAmANamedPerson, ICanHoldItems, ICanBeGive
         }
     }
 
-    private bool IsInTheRoom(IContext context)
+    public bool IsInTheRoom(IContext context)
     {
         return CurrentLocation == context.CurrentLocation;
     }

--- a/Planetfall/Item/Kalamontee/Mech/FloydPart/FloydConstants.cs
+++ b/Planetfall/Item/Kalamontee/Mech/FloydPart/FloydConstants.cs
@@ -37,6 +37,27 @@ public static class FloydConstants
     internal const string Kill =
         "Floyd starts dashing around the room. \"Oh boy oh boy oh boy! I haven't played Chase and Tag for years! You be It! Nah, nah!\" ";
 
+    // Issue #552. The player has no in-game way of knowing the name "Floyd" until they wake the
+    // robot in the Robot Shop, so naming him earlier can only be a returning fan name-dropping a
+    // famous companion. Owner-selected verbatim; fourth-wall winks are franchise-authentic (Floyd's
+    // own "maybe we can use them in the sequel..." endgame line).
+    internal const string NobodyHereByThatName =
+        "Floyd? There's nobody here by that name. Someone's played Planetfall before, haven't they? ";
+
+    // Issue #552, the "where is Floyd" matrix. Canned rather than narrated so the answer can't drift
+    // into a different improvised joke every turn - and, after the Bio Lab, can't crack a joke at all.
+    internal const string WhereIsFloydHereAndOn =
+        "Floyd is right here! Floyd is always right here. ";
+
+    internal const string WhereIsFloydHereAndOff =
+        "Floyd is right here, slumped where you left him. ";
+
+    internal const string WhereIsFloydAbsent =
+        "Floyd is off exploring somewhere. He'll turn up. ";
+
+    internal const string WhereIsFloydDead =
+        "Floyd is gone. ";
+
     internal const string ComesAliveBase =
         "Suddenly, the robot comes to life and its head starts swivelling about. It notices you and " +
         "bounds over. \"Hi! I'm B-19-7, but to everyperson I'm called Floyd. Are you a doctor-person " +

--- a/Planetfall/Item/Kalamontee/Mech/FloydPart/FloydConstants.cs
+++ b/Planetfall/Item/Kalamontee/Mech/FloydPart/FloydConstants.cs
@@ -58,6 +58,26 @@ public static class FloydConstants
     internal const string WhereIsFloydDead =
         "Floyd is gone. ";
 
+    // The three below are NOT owner-selected - #552's spec gave four states and play turned up three
+    // more. Deliberately flat and promise-free: the point of the canned answers is that they cannot
+    // be wrong, so where the game does not know enough to say something warm it says something true.
+    // Swap the wording freely; the state routing is what matters.
+
+    // Floyd is off on a scripted errand (CurrentLocation null, IsAwayOnScriptedSequence set) - most
+    // painfully, inside the Bio Lab during the sacrifice. "He'll turn up" is a promise the game
+    // cannot keep here, so this says only what the player can see.
+    internal const string WhereIsFloydOutOfSight =
+        "You can't see Floyd from here. ";
+
+    // Switched off and left in another room. He is not wandering and he is not coming back.
+    internal const string WhereIsFloydAbsentAndOff =
+        "Floyd is switched off, right where you left him. ";
+
+    // The three-turn wake-up countdown: the player has flipped the switch but he has not stirred,
+    // so neither "always right here" nor "slumped where you left him" is true yet.
+    internal const string WhereIsFloydStillBooting =
+        "The robot is right here, though nothing about him has stirred yet. ";
+
     internal const string ComesAliveBase =
         "Suddenly, the robot comes to life and its head starts swivelling about. It notices you and " +
         "bounds over. \"Hi! I'm B-19-7, but to everyperson I'm called Floyd. Are you a doctor-person " +

--- a/UnitTests/Engine/ConversationHandlerTests.cs
+++ b/UnitTests/Engine/ConversationHandlerTests.cs
@@ -458,10 +458,10 @@ public class ConversationHandlerTests
     [TestCase("talk to ghost")]
     public async Task CheckForConversation_PresentTalkerGoneForGood_RecognizesImperativeAddress(string input)
     {
-        // The present path normally leaves imperative lead-ins ("ask X ...") to the classifier, which
-        // we no longer call here. Detection therefore uses IsGenuineDirectAddress - the same
-        // deterministic test the absent path trusts - which covers the imperative forms too, so
-        // skipping the rewriter costs no coverage.
+        // Detection is two-tier: IsGenuineDirectAddress first - the same deterministic test the
+        // absent path trusts, covering leading names AND imperative lead-ins - with the classifier
+        // only as a backstop for what it misses. These forms are all caught deterministically, so
+        // the classifier is never reached; the Times.Never below is what pins that.
         var mockParser = new Mock<IParseConversation>();
         mockParser.Setup(p => p.ParseAsync(It.IsAny<string>())).ReturnsAsync((false, string.Empty));
         var handler = new ConversationHandler(null, mockParser.Object, Mock.Of<IGenerationClient>(),
@@ -472,6 +472,7 @@ public class ConversationHandlerTests
         var result = await handler.CheckForConversation(input, context);
 
         result.Should().Be("ghost talked");
+        mockParser.Verify(p => p.ParseAsync(It.IsAny<string>()), Times.Never);
     }
 
     [TestCase("examine ghost")]
@@ -482,7 +483,14 @@ public class ConversationHandlerTests
         // The short-circuit must not swallow real commands that merely NAME the character. "examine
         // floyd" on the corpse has to keep reaching the item's own examine handler (the mourning
         // description), not be answered as though the player spoke to the body.
+        //
+        // The classifier is stubbed to the WORST case - always "yes, conversational" - because its
+        // real decode is fail-open (anything but the literal string "No" counts as conversational).
+        // This test previously passed only on Moq's unstubbed default of false, which meant it
+        // asserted the behavior of a mock rather than of the handler; a verb-first command must
+        // never reach the classifier at all.
         var mockParser = new Mock<IParseConversation>();
+        mockParser.Setup(p => p.ParseAsync(It.IsAny<string>())).ReturnsAsync((true, string.Empty));
         var handler = new ConversationHandler(null, mockParser.Object, Mock.Of<IGenerationClient>(),
             new[] { typeof(GhostTalker) });
         var context = new ZorkIContext();
@@ -491,6 +499,7 @@ public class ConversationHandlerTests
         var result = await handler.CheckForConversation(input, context);
 
         result.Should().BeNull();
+        mockParser.Verify(p => p.ParseAsync(It.IsAny<string>()), Times.Never);
     }
 
     [Test]


### PR DESCRIPTION
Two pieces of Floyd conversation work, combined into one PR at the owner's request (the second half was briefly open as #556).

---

# Part A — Issue #552: canned responses for mentioning Floyd

Closes #552.

Asking about Floyd fell through to the AI narrator, which improvised a different joke every time — including tonally wrong ones after his death (#545, item 3). This replaces both paths with canned, deterministic text, matched in Planetfall-owned code before the AI parser and the conversation handler ever see the input, so the engine still knows nothing about Floyd.

## Before meeting him

Any input naming `floyd` while the player has no in-game way of knowing that name gets the owner-selected line:

> Floyd? There's nobody here by that name. Someone's played Planetfall before, haven't they?

**Activation is exempt.** `activate floyd` is the walkthrough spine and is necessarily typed *before* any met-flag flips; if the intercept swallowed it, Floyd would be unactivatable by name.

**The met-gate isn't `!IsOn && !HasEverBeenOn`.** Neither flag flips until the 3-turn wake-up countdown finishes (`FloydPowerManager.Activate` returns "Nothing happens." and leaves both false), so that gate would keep cracking the joke while the robot is visibly booting. `Floyd.PlayerKnowsFloydByName` folds in `HasAwardedActivationPoints`, which is set the moment the player first flips his switch — exactly when the game itself starts calling him Floyd.

**Only the name is claimed.** `examine robot` / `examine B-19-7` keep the deactivated-robot description that is part of the intended discovery flow — and so does `robot, are you okay`, which is pinned separately because the conversation path is a different branch from examine.

## After meeting him

Where-is-shaped queries only (anchored at the start of the command, so `floyd, do you know where the card is` still reaches Floyd), answered from his real state:

| State | Response |
|---|---|
| Here, on | Floyd is right here! Floyd is always right here. |
| Here, off | Floyd is right here, slumped where you left him. |
| Absent | Floyd is off exploring somewhere. He'll turn up. |
| Dead | Floyd is gone. |

## Shape

`Planetfall/GlobalCommand/FloydMentionCommands.cs`, registered from `PlanetfallGlobalCommandFactory`. Floyd is only pulled out of the Repository when the input actually names him. God-mode commands are matched by the *engine's* factory, which is consulted first, so `god mode where floyd` keeps working.

## Interaction with #545

Verified against the merged #545 rather than reasoned about: every one of its post-mortem tests passes with this intercept armed. The gate includes `HasDied`, so a dead Floyd always counts as "met" and the intercept can never shadow the mourning paths.

The two death lines coexist deliberately and are **not** collapsed — they answer different questions:

```
where is floyd      -> Floyd is gone.                            (a question to the narrator)
floyd, are you okay -> Floyd is gone. There will be no answer.   (the act of addressing him)
```

Existing tests that named Floyd from the pre-meeting state now either say what the player can actually say then (`search robot`) or set the met flag, keeping their own subject — absent-NPC routing (#264), the booth teleport — intact.

---

# Part B — two gone-for-good conversation gaps left by #545's second review

A second `/code-review` round ran on #548 at 17:09, six minutes before it merged at 17:15. Nine findings, **none actioned**. These are the two that are live player-facing regressions; the rest are triaged below.

Both reproduce the same way: a **blank response** — the utterance leaking out of the conversation system entirely, which is exactly the failure the gone-for-good route was created to stop.

## 1. Nameless speech to a corpse still blanks offline

`TryRouteNamelessSpeech` never got the `IsGoneForGood` gate that `CheckForConversation`'s *named* branch got. Standing over Floyd's body with `NoGeneratedResponses` set (a per-request flag the Planetfall API exposes) and saying `hello`:

```
> say hello
                       <-- blank
```

It bails at the generation kill-switch before ever reaching `OnBeingTalkedTo`. A gone-for-good talker's reply is a compile-time constant and owes generation nothing on this branch either.

## 2. Loose address phrasings stopped reaching the corpse

`RespondForGoneForGoodTalker` replaced a two-part detector — the `ParseConversation` classifier **OR** the deterministic strip — with `IsGenuineDirectAddress` alone.

That compared against the wrong baseline. `IsGenuineDirectAddress` *is* broader than `TryStripDirectAddress`, but it is **not** broader than the pipeline actually replaced. Phrasings only the classifier recognized — `could you let floyd know to wait for me`, which leads with neither a name nor an address lead-in — stopped reaching Floyd and leaked to the narrator, who then improvises about a robot the player watched die. The method's own XML doc asserted the opposite ("strictly more phrasings than before"); **corrected here**.

The fix restores the classifier as a backstop, mirroring `FindAddressedAbsentCharacter` exactly — including its rule of skipping the classifier when generation is disabled, so the guard stays deterministic offline.

**The round-trip saving is preserved.** `&&` short-circuits, so the classifier is never consulted for a phrasing `IsGenuineDirectAddress` already recognizes — the overwhelming majority. The existing `TalkToFloyd_DeadAndPresent_DoesNotCallTheConversationClassifier` passes unchanged, which is the proof.

---

# Tests

Every test below was red before its fix and red for the right reason — the Part B pair both returned `""`, and the Part A pre-meeting tests returned the narrator's improvisation.

**Part A** — `Planetfall.Tests/FloydMentionTests.cs`, covering every numbered TDD requirement in #552, plus `god mode where floyd` and the `robot, are you okay` conversation-path scoping.

**Part B** — three tests in `FloydTests`:
- `SpeakingNamelesslyToDeadFloyd_MournsEvenWithGenerationDisabled`
- `AddressingDeadFloydWithUnusualPhrasing_DefersToClassifier_AndMourns`
- `AddressingDeadFloydWithUnusualPhrasing_GenerationDisabled_DoesNotConsultClassifier` — pins the offline determinism, so the backstop can't quietly become an online-only dependency.

All suites green: **Planetfall 3987**, UnitTests 1180, ZorkOne 1782, EscapeRoom 9, Stationfall 62, Console 16 — walkthroughs included.

---

# The rest of that review round, triaged

I verified all nine round-2 findings against `main`. All are real; these five are **not** in this PR:

| Finding | Kind |
|---|---|
| `SleepEngine.cs:273` — corpse teleports to you nightly | **Fixed and merged in #555** |
| `BoothBase.cs:57` — booth gates on presence with no liveness test | Latent; was reachable only via the SleepEngine bug, worth fixing on its own merits |
| `Floyd.Act():301` — `HasDied` return sits above the block clearing `PendingFloydActionCommentPrompt`, so a prompt queued the turn Floyd dies is burned unspoken and occupies the slot permanently in saved state | Real, narrow |
| `WalkthroughBioLock.cs:41` — fixture reset covers `HasDied` but not `IsAwayOnScriptedSequence`, `IsOffWandering`, `ItemBeingHeld`, `HasRevealedLowerElevatorCard` | Test fragility |
| `FloydConstants.cs:66` — header says "The three constants below"; there are five | Cosmetic |
| `Docs/hints/planetfall/02-state-audit.md:53` — still names the renamed `IsHereAndIsOn` | Stale doc |

(Round 1 of that review — a separate 10 findings — was worked to completion and shipped in #548; I verified each against `main`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
