### PR TITLE
Stop Floyd's corpse from teleporting into your bedroom every night

### DIFF
--- a/Planetfall.Tests/SleepEngineTests.cs
+++ b/Planetfall.Tests/SleepEngineTests.cs
@@ -7,6 +7,7 @@ using Planetfall.Item.Kalamontee.Mech.FloydPart;
 using Planetfall.Location.Kalamontee;
 using Planetfall.Location.Kalamontee.Admin;
 using Planetfall.Location.Kalamontee.Dorm;
+using Planetfall.Location.Lawanda.Lab;
 using Utilities;
 
 namespace Planetfall.Tests;
@@ -822,6 +823,60 @@ public class SleepEngineTests : EngineTestsBase
             result.Should().Contain("Floyd");
             result.Should().Contain("sleeping on the floor");
         }
+    }
+
+    // Floyd's corpse keeps IsOn = true - BioLockStateMachineManager.EndSequence leaves it that way
+    // deliberately, because the body is still the same object lying in the room. The wake-up greeting
+    // gated on "HasEverBeenOn && IsOn", which the corpse satisfies, so every night after the Bio Lab
+    // sacrifice the body was dragged out of Bio Lock East into the player's bedroom to chirp "About
+    // time you woke up, you lazy bones! Let's explore around some more!" Found during the #545 review.
+    [Test]
+    public void WakeUp_FloydIsDead_DoesNotGreetThePlayer()
+    {
+        var target = GetTarget();
+        var pfContext = target.Context;
+        StartHere<BedLocation>();
+
+        var floyd = GetItem<Floyd>();
+        floyd.HasEverBeenOn = true;
+        floyd.IsOn = true;      // as EndSequence leaves him
+        floyd.HasDied = true;
+
+        pfContext.Day = 1;
+        pfContext.SleepNotifications.QueueFallAsleep(pfContext.CurrentTime);
+
+        var result = SleepEngine.ProcessFallAsleep(pfContext);
+
+        result.Should().NotContain("lazy bones");
+        result.Should().NotContain("Let's explore around some more");
+        result.Should().NotContain("Floyd");
+    }
+
+    // The other half of the same guard, and the half that corrupts state rather than just tone: the
+    // greeting block moves Floyd into the player's location before it speaks. Sleeping anywhere would
+    // silently relocate the body out of the room the player watched him die in.
+    [Test]
+    public void WakeUp_FloydIsDead_LeavesTheBodyWhereItFell()
+    {
+        var target = GetTarget();
+        var pfContext = target.Context;
+        StartHere<BedLocation>();
+
+        var floyd = GetItem<Floyd>();
+        floyd.HasEverBeenOn = true;
+        floyd.IsOn = true;
+        floyd.HasDied = true;
+        var bioLockEast = GetLocation<BioLockEast>();
+        bioLockEast.ItemPlacedHere(floyd);
+
+        pfContext.Day = 1;
+        pfContext.SleepNotifications.QueueFallAsleep(pfContext.CurrentTime);
+
+        SleepEngine.ProcessFallAsleep(pfContext);
+
+        floyd.CurrentLocation.Should().Be(bioLockEast);
+        bioLockEast.Items.Should().Contain(floyd);
+        GetLocation<BedLocation>().Items.Should().NotContain(floyd);
     }
 
     [Test]

--- a/Planetfall/SleepEngine.cs
+++ b/Planetfall/SleepEngine.cs
@@ -268,9 +268,15 @@ public class SleepEngine
         if (transition.WokeFamished)
             message += "You are also incredibly famished. Better get some breakfast! ";
 
-        // Floyd greeting (if present and active)
+        // Floyd greeting (if present and alive)
         var floyd = Repository.GetItem<Floyd>();
-        if (floyd.HasEverBeenOn && floyd.IsOn)
+        // IsAlive, not "HasEverBeenOn && IsOn": EndSequence deliberately leaves the corpse switched
+        // on, so the old pair was satisfied by a dead Floyd - and this block MOVES him before it
+        // speaks, so every night after the sacrifice dragged the body out of Bio Lock East into the
+        // player's bedroom to chirp "About time you woke up, you lazy bones!" (found in the #545
+        // review). The dropped HasEverBeenOn clause was redundant: IsOn is only ever set alongside
+        // it, by Activate and by the wake-up countdown.
+        if (floyd.IsAlive)
         {
             // Move Floyd to player's location
             floyd.CurrentLocation?.RemoveItem(floyd);


### PR DESCRIPTION
Found during the [#548](https://github.com/arsindelve/ZorkAI/pull/548) review but not shipped with it — that PR merged before the fix was written, so this is live on `main` today.

## The bug

[`SleepEngine.cs:273`](Planetfall/SleepEngine.cs:273) gated the wake-up greeting on `floyd.HasEverBeenOn && floyd.IsOn`. The Bio Lab sacrifice deliberately leaves the corpse's `IsOn` true (`BioLockStateMachineManager.EndSequence`) because the body is still the same object lying in the room — so a dead Floyd satisfies the guard.

The tone is bad enough. The real damage is that **the block moves Floyd into the player's location before it speaks**:

```csharp
floyd.CurrentLocation?.RemoveItem(floyd);
context.CurrentLocation.ItemPlacedHere(floyd);
```

So every night after the sacrifice, sleeping anywhere dragged the body out of Bio Lock East into the player's bedroom, where it bounced impatiently and said:

> "About time you woke up, you lazy bones! Let's explore around some more!"

Recurring for the rest of the game, one turn after the emotional climax. Both halves reproduced against the real `ProcessFallAsleep`.

## The fix

Gate on `Floyd.IsAlive` — the single liveness property #545 introduced for exactly this trap. One line.

The dropped `HasEverBeenOn` clause was redundant: `IsOn` is only ever set alongside it, by `FloydPowerManager.Activate` and by the wake-up countdown.

## Sweep

`SleepEngine` was the last *reachable* `IsOn`-as-liveness bug in Planetfall. Two other `IsOn` reads remain, neither of them a defect:

- `FloydPowerManager` — the on/off switch itself, not a liveness test, and both `Activate` and `Deactivate` already early-return on `HasDied`.
- `Floyd.CannotBeTakenDescription` (`Floyd.cs:150`) — spelled `HasDied ? TakeDead : IsOn ? TakeFloyd : null`. The `IsOn` branch is only evaluated when `HasDied` is already false, so it is `IsAlive` by construction. Correct, but it reads as a bare `IsOn` in the very file that defines the "never ask `IsOn`" rule; worth tidying separately.

(An earlier version of this description claimed `SleepEngine` was the last bare-`IsOn` read outright. That was wrong — my grep matched only `.IsOn` and missed the unqualified occurrence inside `Floyd.cs` itself.)

## Tests

Two new deterministic tests in `SleepEngineTests`, red before the fix and red for the right reason (the failure output is the corpse bouncing at the foot of the bed):

- `WakeUp_FloydIsDead_DoesNotGreetThePlayer` — the tonal half.
- `WakeUp_FloydIsDead_LeavesTheBodyWhereItFell` — the state-corruption half, which is the one that actually moves the world.

The two pre-existing `WakeUp_FloydGreets*` tests still pass unchanged, so the living-Floyd greeting is preserved on both the in-bed and on-the-floor paths.

All suites green: Planetfall 3959, UnitTests 1180, ZorkOne 1782, EscapeRoom 9, Stationfall 4, Console 16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
