### PR TITLE
Close two gone-for-good conversation gaps left by #545's second review

### DIFF
--- a/GameEngine/ConversationHandler.cs
+++ b/GameEngine/ConversationHandler.cs
@@ -80,19 +80,27 @@ public class ConversationHandler(
     /// <c>ParseConversation</c> rewriter the living path uses - that call is an AWS Lambda round-trip
     /// whose only product is a command the character will never act on.
     ///
-    /// Address detection therefore falls to <see cref="IsGenuineDirectAddress"/>, the same
-    /// deterministic test the absent path relies on. That is not a downgrade from the living path's
-    /// backstop: <see cref="TryStripDirectAddress"/> recognizes only the leading-name forms and leaves
-    /// imperative lead-ins ("ask floyd about the card") to the classifier, whereas
-    /// IsGenuineDirectAddress covers both - so a corpse is addressable by strictly more phrasings than
-    /// before, and deterministically, including in NoGeneratedResponses mode.
+    /// Address detection is two-tier, mirroring the absent path exactly: the deterministic
+    /// <see cref="IsGenuineDirectAddress"/> first - which covers leading names AND imperative
+    /// lead-ins, so the common phrasings answer offline and without any round-trip - and the
+    /// classifier only as a backstop for what it misses.
+    ///
+    /// The backstop is not optional. An earlier version of this method used IsGenuineDirectAddress
+    /// alone, on the reasoning that it is strictly broader than <see cref="TryStripDirectAddress"/>.
+    /// That compared against the wrong thing: the pipeline actually replaced was the classifier OR
+    /// the strip, and looser phrasings the classifier alone recognized ("could you let floyd know
+    /// ...", which leads with neither a name nor a lead-in) stopped reaching the character and leaked
+    /// to the narrator - the exact outcome this route exists to prevent.
     ///
     /// Returns null when the input merely NAMES the character rather than addressing them ("examine
     /// floyd", "take floyd"), so those keep falling through to the item's own handlers.
     /// </summary>
     private async Task<string?> RespondForGoneForGoodTalker(string input, ICanBeTalkedTo target, IContext context)
     {
-        if (!IsGenuineDirectAddress(input, target))
+        // && short-circuits, so the classifier is never consulted for a phrasing the deterministic
+        // test already recognized - which is the overwhelming majority, and keeps the "no Lambda
+        // round-trip for a constant reply" win this route was created for.
+        if (!IsGenuineDirectAddress(input, target) && !await ClassifierSaysAddressed(input))
         {
             logger?.LogDebug("[CONVERSATION DEBUG] Gone-for-good talker named but not addressed; falling through");
             return null;
@@ -104,6 +112,22 @@ public class ConversationHandler(
 
         logger?.LogDebug($"[CONVERSATION DEBUG] Gone-for-good talker addressed with '{remainder}'; answering directly");
         return await target.OnBeingTalkedTo(remainder, context, generationClient);
+    }
+
+    /// <summary>
+    /// Backstop for address phrasings <see cref="IsGenuineDirectAddress"/> cannot recognize, kept
+    /// identical to <see cref="FindAddressedAbsentCharacter"/>'s: consult the conversation
+    /// classifier, but skip it when generation is disabled so the guard stays deterministic and
+    /// offline-safe in NoGeneratedResponses mode.
+    /// </summary>
+    private async Task<bool> ClassifierSaysAddressed(string input)
+    {
+        if (generationClient.IsDisabled)
+            return false;
+
+        var parseResult = await parseConversation.ParseAsync(input);
+        logger?.LogDebug($"[CONVERSATION DEBUG] Gone-for-good classifier isConversational: {parseResult.isConversational}");
+        return parseResult.isConversational;
     }
 
     /// <summary>
@@ -141,13 +165,25 @@ public class ConversationHandler(
             return null;
         }
 
+        var target = present[0];
+
+        // Same reasoning as the named branch in CheckForConversation, which this one was missed by
+        // (#545 round-2 review): a gone-for-good talker answers with a constant, so their reply owes
+        // generation nothing. Without this gate, saying "hello" over the body with
+        // NoGeneratedResponses set returned null at the kill-switch below and leaked the utterance
+        // back into normal parsing instead of mourning.
+        if (target.IsGoneForGood)
+        {
+            logger?.LogDebug("[CONVERSATION DEBUG] Nameless speech to a gone-for-good talker; answering directly");
+            return await target.OnBeingTalkedTo(speech, context, generationClient);
+        }
+
         if (generationClient.IsDisabled)
         {
             logger?.LogDebug("[CONVERSATION DEBUG] Conversations disabled via NoGeneratedResponses flag");
             return null;
         }
 
-        var target = present[0];
         logger?.LogDebug($"[CONVERSATION DEBUG] Routing nameless speech '{speech}' to the sole present talker");
         return await target.OnBeingTalkedTo(speech, context, generationClient);
     }

--- a/Planetfall.Tests/FloydTests.cs
+++ b/Planetfall.Tests/FloydTests.cs
@@ -589,6 +589,72 @@ public class FloydTests : EngineTestsBase
         response.Should().Contain("no answer comes");
     }
 
+    // #545 round-2 review, finding 2. The IsGoneForGood gate was added to CheckForConversation's
+    // NAMED branch but not to TryRouteNamelessSpeech, which still bails on the generation
+    // kill-switch. Standing over the body and saying "hello" with NoGeneratedResponses set produced
+    // a BLANK response - no mourning line, and the utterance leaked back into normal parsing. A
+    // gone-for-good talker's reply is a constant and owes generation nothing on this branch either.
+    [Test]
+    public async Task SpeakingNamelesslyToDeadFloyd_MournsEvenWithGenerationDisabled()
+    {
+        var target = GetTarget();
+        StartHere<RobotShop>(); // Floyd is placed here by Init, so he is the sole present talker.
+        var floyd = GetItem<Floyd>();
+        floyd.HasDied = true;
+        floyd.HasEverBeenOn = true;
+        floyd.IsOn = true;
+        Mock.Get(target.GenerationClient).Setup(c => c.IsDisabled).Returns(true);
+
+        var response = await target.GetResponse("say hello");
+
+        response.Should().Contain("no answer comes");
+    }
+
+    // #545 round-2 review, finding 3. RespondForGoneForGoodTalker replaced a two-part detector
+    // (deterministic strip OR the ParseConversation classifier) with IsGenuineDirectAddress alone.
+    // That misses the looser phrasings only the classifier recognized - "could you let floyd know
+    // ..." leads with "could", which is neither a leading name nor an address lead-in - so they
+    // stopped reaching Floyd and leaked to the narrator, the exact outcome #545 exists to prevent.
+    // Mirrors the absent path, which has kept the classifier as its fallback all along (see
+    // AbsentTalkableNpcTests.AddressingAbsentFloydWithUnusualPhrasing_DefersToClassifier_SaysNotHere).
+    [Test]
+    public async Task AddressingDeadFloydWithUnusualPhrasing_DefersToClassifier_AndMourns()
+    {
+        var target = GetTarget();
+        StartHere<RobotShop>();
+        var floyd = GetItem<Floyd>();
+        floyd.HasDied = true;
+        floyd.HasEverBeenOn = true;
+        floyd.IsOn = true;
+        ParseConversationMock
+            .Setup(p => p.ParseAsync("could you let floyd know to wait for me"))
+            .ReturnsAsync((true, ""));
+
+        var response = await target.GetResponse("could you let floyd know to wait for me");
+
+        response.Should().Contain("no answer comes");
+    }
+
+    // The classifier fallback must stay deterministic offline, exactly as the absent path is: with
+    // generation disabled the loose phrasing is not classified at all, so it falls through rather
+    // than guessing. The common phrasings IsGenuineDirectAddress covers still mourn (see
+    // TalkToFloyd_DeadAndPresent_MournsEvenWithGenerationDisabled), so nothing regresses offline.
+    [Test]
+    public async Task AddressingDeadFloydWithUnusualPhrasing_GenerationDisabled_DoesNotConsultClassifier()
+    {
+        var target = GetTarget();
+        StartHere<RobotShop>();
+        var floyd = GetItem<Floyd>();
+        floyd.HasDied = true;
+        floyd.HasEverBeenOn = true;
+        floyd.IsOn = true;
+        Mock.Get(target.GenerationClient).Setup(c => c.IsDisabled).Returns(true);
+
+        await target.GetResponse("could you let floyd know to wait for me");
+
+        ParseConversationMock.Verify(p => p.ParseAsync(It.IsAny<string>()), Times.Never);
+    }
+
     [Test]
     public async Task TalkToFloyd_DeadAndPresent_DoesNotCallTheConversationClassifier()
     {


### PR DESCRIPTION
A second `/code-review` round ran on [#548](https://github.com/arsindelve/ZorkAI/pull/548) at 17:09, six minutes before it merged at 17:15. Nine findings, **none actioned**. This PR takes the two that are live player-facing regressions; the rest are triaged at the bottom.

Both reproduce the same way: a **blank response** — the utterance leaking out of the conversation system entirely, which is exactly the failure the gone-for-good route was created to stop.

## 1. Nameless speech to a corpse still blanks offline

`TryRouteNamelessSpeech` never got the `IsGoneForGood` gate that `CheckForConversation`'s *named* branch got. Standing over Floyd's body with `NoGeneratedResponses` set (a per-request flag the Planetfall API exposes) and saying `hello`:

```
> say hello
                       <-- blank
```

It bails at the generation kill-switch before ever reaching `OnBeingTalkedTo`. A gone-for-good talker's reply is a compile-time constant and owes generation nothing on this branch either.

## 2. Loose address phrasings stopped reaching the corpse

`RespondForGoneForGoodTalker` replaced a two-part detector — the `ParseConversation` classifier **OR** the deterministic strip — with `IsGenuineDirectAddress` alone.

That compared against the wrong baseline. `IsGenuineDirectAddress` *is* broader than `TryStripDirectAddress`, but it is **not** broader than the pipeline actually replaced. Phrasings only the classifier recognized — `could you let floyd know to wait for me`, which leads with neither a name nor an address lead-in — stopped reaching Floyd and leaked to the narrator, who then improvises about a robot the player watched die. The method's own XML doc asserted the opposite ("strictly more phrasings than before"); **corrected here**.

The fix restores the classifier as a backstop, mirroring `FindAddressedAbsentCharacter` exactly — including its rule of skipping the classifier when generation is disabled, so the guard stays deterministic offline.

**The round-trip saving is preserved.** `&&` short-circuits, so the classifier is never consulted for a phrasing `IsGenuineDirectAddress` already recognizes — the overwhelming majority. The existing `TalkToFloyd_DeadAndPresent_DoesNotCallTheConversationClassifier` passes unchanged, which is the proof.

## Tests

Three new deterministic tests in `FloydTests`, red before the fix and red for the right reason (both returned `""`):

- `SpeakingNamelesslyToDeadFloyd_MournsEvenWithGenerationDisabled`
- `AddressingDeadFloydWithUnusualPhrasing_DefersToClassifier_AndMourns`
- `AddressingDeadFloydWithUnusualPhrasing_GenerationDisabled_DoesNotConsultClassifier` — pins the offline determinism, so the backstop can't quietly become an online-only dependency.

All suites green: Planetfall 3960, UnitTests 1180, ZorkOne 1782, EscapeRoom 9, Stationfall 62, Console 16.

## The rest of that review round, triaged

I verified all nine against `main`. All are real; these six are not in this PR:

| Finding | Kind |
|---|---|
| `SleepEngine.cs:273` — corpse teleports to you nightly | **Fixed in [#555](https://github.com/arsindelve/ZorkAI/pull/555)** |
| `BoothBase.cs:57` — booth gates on presence with no liveness test | Latent; was reachable only via the SleepEngine bug, worth fixing on its own merits |
| `Floyd.Act():301` — `HasDied` return sits above the block clearing `PendingFloydActionCommentPrompt`, so a prompt queued the turn Floyd dies is burned unspoken and occupies the slot permanently in saved state | Real, narrow |
| `WalkthroughBioLock.cs:41` — fixture reset covers `HasDied` but not `IsAwayOnScriptedSequence`, `IsOffWandering`, `ItemBeingHeld`, `HasRevealedLowerElevatorCard` | Test fragility |
| `FloydConstants.cs:66` — header says "The three constants below"; there are five | Cosmetic |
| `Docs/hints/planetfall/02-state-audit.md:53` — still names the renamed `IsHereAndIsOn` | Stale doc |

(Round 1 of that review — a separate 10 findings — was worked to completion and shipped in #548; I verified each against `main`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)