### PR TITLE
Make the Duffy's fittings real objects, not scenery and special cases

### DIFF
--- a/Docs/Stationfall-Port-Plan.md
+++ b/Docs/Stationfall-Port-Plan.md
@@ -50,7 +50,7 @@ Measured against the original, not from memory. Update this table as phases land
 | Region objects | 20 | 116 |
 | Background daemons | ~4 | 32 |
 | **Reachable score** | **8** | **80** |
-| Tests | 85 | — |
+| Tests | 109 | — |
 
 Landed so far:
 
@@ -60,6 +60,9 @@ Landed so far:
 - **Phase 3** — the survival clocks and the day boundary, built on a new shared `StellarPatrol`
   library extracted from Planetfall. Also restored per-action time costs, which the port had been
   flattening to a single value per turn.
+- **Opening content pass** — the fittings of the opening rooms, as opposed to their puzzle chain:
+  the things a player pokes at on the way through. Phase 2 built the chain and left much of the
+  furniture as examine-only scenery or as strings matched in a room's input handler.
 
 For scale: Planetfall in this engine is 127 location files and 142 item files. Stationfall is the
 bigger game.

--- a/Stationfall.Tests/DuffyContentTests.cs
+++ b/Stationfall.Tests/DuffyContentTests.cs
@@ -1,0 +1,352 @@
+using FluentAssertions;
+using GameEngine;
+using Model.Interface;
+using Moq;
+using Stationfall.Item.Duffy;
+using Stationfall.Location.Duffy;
+
+namespace Stationfall.Tests;
+
+/// <summary>
+///     The Duffy's fittings: the things a player pokes at on the way through rather than the puzzle
+///     chain itself. Phase 2 built the chain; these are the objects that make the ship feel inhabited,
+///     and each one here answers for a verb the original answers for.
+/// </summary>
+[TestFixture]
+public class DuffyContentTests : EngineTestsBase
+{
+    private GameEngine<StationfallGame, StationfallContext> _target = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _target = GetTarget();
+    }
+
+    private async Task WalkToCargoBay()
+    {
+        await _target.GetResponse("east");
+        await _target.GetResponse("east");
+    }
+
+    private async Task BoardTheTruck()
+    {
+        await WalkToCargoBay();
+        await _target.GetResponse("open hatch");
+        await _target.GetResponse("in");
+    }
+
+    private async Task GoToRobotPool()
+    {
+        await _target.GetResponse("east");
+        await _target.GetResponse("north");
+    }
+
+    [TestFixture]
+    public class TheHatch : DuffyContentTests
+    {
+        [Test]
+        public async Task IsTheSameHatch_SeenFromEveryRoomItAppearsIn()
+        {
+            await WalkToCargoBay();
+            await _target.GetResponse("open hatch");
+            await _target.GetResponse("in");
+
+            // Opened from the cargo bay; the cab must agree, because there is only one hatch.
+            var response = await _target.GetResponse("examine hatch");
+
+            response.Should().Contain("open");
+            Repository.GetItem<SpacetruckCabHatch>().IsOpen.Should().BeTrue();
+            Repository.GetItem<SpacetruckHatch>().IsOpen.Should().BeTrue();
+        }
+
+        [Test]
+        public async Task ShuttingItFromTheCab_ShutsItEverywhere()
+        {
+            await BoardTheTruck();
+
+            await _target.GetResponse("close hatch");
+
+            Repository.GetItem<SpacetruckHatch>().IsOpen.Should()
+                .BeFalse("the cargo bay's view of the hatch is the same hatch");
+            Repository.GetItem<DockingBayHatch>().IsOpen.Should().BeFalse();
+        }
+
+        [Test]
+        public async Task RefusesToOpenInDeepSpace()
+        {
+            await BoardTheTruck();
+            await _target.GetResponse("close hatch");
+            Repository.GetLocation<Spacetruck>().LaunchCounter = 1;
+
+            var response = await _target.GetResponse("open hatch");
+
+            response.Should().Contain("deep space");
+            Repository.GetItem<SpacetruckHatch>().IsOpen.Should().BeFalse();
+        }
+    }
+
+    [TestFixture]
+    public class TheRadio : DuffyContentTests
+    {
+        [Test]
+        public async Task SaysSoWhenYouListenToItSwitchedOff()
+        {
+            await BoardTheTruck();
+
+            (await _target.GetResponse("listen to radio")).Should().Contain("isn't on");
+        }
+
+        [Test]
+        public async Task TurnsOnAndOff()
+        {
+            await BoardTheTruck();
+
+            (await _target.GetResponse("turn on radio")).Should().Contain("static");
+            Repository.GetItem<Radio>().IsOn.Should().BeTrue();
+            (await _target.GetResponse("listen to radio")).Should().Contain("Crackle");
+
+            (await _target.GetResponse("turn off radio")).Should().Contain("switch the radio off");
+            Repository.GetItem<Radio>().IsOn.Should().BeFalse();
+        }
+
+        [Test]
+        public async Task ChattersWhileYouAreAboard()
+        {
+            await BoardTheTruck();
+            await _target.GetResponse("turn on radio");
+
+            var alwaysChatter = new Mock<IRandomChooser>();
+            alwaysChatter.Setup(r => r.RollDice(100)).Returns(1);
+            alwaysChatter.Setup(r => r.Choose(It.IsAny<List<string>>())).Returns("Test traffic.");
+            Repository.GetItem<Radio>().Chooser = alwaysChatter.Object;
+
+            (await _target.GetResponse("wait")).Should().Contain("Breaker. Test traffic. Over.");
+        }
+
+        [Test]
+        public async Task IsSilentOnceYouHaveLeftTheCab()
+        {
+            await BoardTheTruck();
+            await _target.GetResponse("turn on radio");
+
+            var alwaysChatter = new Mock<IRandomChooser>();
+            alwaysChatter.Setup(r => r.RollDice(100)).Returns(1);
+            alwaysChatter.Setup(r => r.Choose(It.IsAny<List<string>>())).Returns("Test traffic.");
+            Repository.GetItem<Radio>().Chooser = alwaysChatter.Object;
+
+            await _target.GetResponse("out");
+
+            // A radio left on and left behind must not narrate over the rest of the game.
+            (await _target.GetResponse("wait")).Should().NotContain("Breaker");
+        }
+    }
+
+    [TestFixture]
+    public class TheEmergencyBeacon : DuffyContentTests
+    {
+        [Test]
+        public async Task RefusesWhileYouAreNotActuallyInTrouble()
+        {
+            await BoardTheTruck();
+
+            (await _target.GetResponse("push red button")).Should().Contain("court-martial");
+        }
+
+        [Test]
+        public async Task PlaysItsRecording_OnceTheFlightIsOver()
+        {
+            await BoardTheTruck();
+            // The counter reaching its last step is what matters, not whether you arrived anywhere -
+            // which is exactly the case where a player would reach for the beacon.
+            Repository.GetLocation<Spacetruck>().LaunchCounter = 5;
+
+            (await _target.GetResponse("push red button")).Should().Contain("Nothing can go wrong");
+        }
+    }
+
+    [TestFixture]
+    public class TheRobotPoolBins : DuffyContentTests
+    {
+        [Test]
+        public async Task EachOneShowsTheRobotStandingInIt()
+        {
+            await GoToRobotPool();
+
+            (await _target.GetResponse("look in first bin")).Should().Contain("Rex");
+            (await _target.GetResponse("look in second bin")).Should().Contain("Helen");
+            (await _target.GetResponse("look in third bin")).Should().Contain("hopeful");
+        }
+
+        [Test]
+        public async Task AreEmptyOnceTheirRobotHasBeenRequisitioned()
+        {
+            await GoToRobotPool();
+            await _target.GetResponse("put authorization in slot");
+            await _target.GetResponse("type 3");
+
+            (await _target.GetResponse("look in third bin")).Should().Contain("empty");
+        }
+
+        [Test]
+        public async Task AreNotForClimbingInto()
+        {
+            await GoToRobotPool();
+
+            (await _target.GetResponse("enter first bin")).Should().Contain("only for robots");
+        }
+    }
+
+    [TestFixture]
+    public class TheFormsStorageRoom : DuffyContentTests
+    {
+        [Test]
+        public async Task TheFormsAreSealedInTheirBoxes()
+        {
+            await _target.GetResponse("south");
+
+            (await _target.GetResponse("examine forms")).Should().Contain("sealed inside the boxes");
+        }
+
+        [Test]
+        public async Task DestroyingPatrolPaperworkIsRefused()
+        {
+            await _target.GetResponse("south");
+
+            (await _target.GetResponse("tear forms")).Should().Contain("Uniform Code of Paperwork");
+        }
+
+        [Test]
+        public async Task OpeningABoxIsItsOwnPunishment()
+        {
+            await _target.GetResponse("south");
+
+            var response = await _target.GetResponse("open box");
+
+            response.Should().Contain("and forms");
+            response.Should().Contain("reseal");
+        }
+    }
+
+    [TestFixture]
+    public class ThePortDoor : DuffyContentTests
+    {
+        [Test]
+        public async Task NamesWhatWouldOpenIt()
+        {
+            // The refusal has to name the remedy, or the player is left rattling a door for no reason.
+            (await _target.GetResponse("open door")).Should().Contain("validated Assignment Completion Form");
+        }
+
+        [Test]
+        public async Task StaysShutWhenYouWalkAtIt()
+        {
+            (await _target.GetResponse("west")).Should().Contain("The door is closed");
+            Ctx.CurrentLocation.Should().BeOfType<DeckTwelve>();
+        }
+    }
+
+    [TestFixture]
+    public class TheSoup : DuffyContentTests
+    {
+        [Test]
+        public async Task StartsSteamingHot()
+        {
+            await BoardTheTruck();
+            await _target.GetResponse("open kit");
+            // The Thermos is opaque, so the soup is not in scope until it is open.
+            await _target.GetResponse("open thermos");
+
+            (await _target.GetResponse("examine soup")).Should().Contain("steaming hot");
+        }
+
+        [Test]
+        public async Task CoolsOnlyOnceYouAreAboard()
+        {
+            // Before boarding, the clock has not started - a player who dawdles on the ship should not
+            // find cold soup waiting.
+            Repository.GetItem<Chronometer>().CurrentTime += 5000;
+            await _target.GetResponse("wait");
+            Repository.GetItem<BlueSoup>().Warmth.Should().Be(100);
+
+            await BoardTheTruck();
+            var start = Repository.GetItem<BlueSoup>().Warmth;
+
+            Repository.GetItem<Chronometer>().CurrentTime += 100;
+            await _target.GetResponse("wait");
+
+            Repository.GetItem<BlueSoup>().Warmth.Should().BeLessThan(start);
+        }
+
+        [Test]
+        public async Task CoolsFasterWithTheThermosOpen()
+        {
+            await BoardTheTruck();
+            await _target.GetResponse("open kit");
+            await _target.GetResponse("open thermos");
+
+            var soup = Repository.GetItem<BlueSoup>();
+            var start = soup.Warmth;
+
+            Repository.GetItem<Chronometer>().CurrentTime += 100;
+            await _target.GetResponse("wait");
+
+            // Four degrees with the lid off against one with it on.
+            (start - soup.Warmth).Should().Be(4);
+        }
+
+        [Test]
+        public async Task IsStillReachable_ThroughTheThermosThatHoldsIt()
+        {
+            // Regression: a container's RespondToSimpleInteraction offers the action to the items
+            // INSIDE it before considering itself, so a container override that early-returns
+            // NoNounMatch for a noun that isn't its own silently deletes its contents from the parser.
+            // The soup answered to nothing at all until this was fixed.
+            await BoardTheTruck();
+            await _target.GetResponse("open kit");
+            await _target.GetResponse("open thermos");
+
+            (await _target.GetResponse("examine soup")).Should()
+                .Contain("soup", "the Thermos must not shadow what it contains");
+        }
+
+        [Test]
+        public async Task CanBePouredOut_AndIsThenGoneForGood()
+        {
+            await BoardTheTruck();
+            await _target.GetResponse("open kit");
+
+            var response = await _target.GetResponse("empty thermos");
+
+            response.Should().Contain("blueberries");
+            Repository.GetItem<Thermos>().Items.Should().NotContain(Repository.GetItem<BlueSoup>());
+        }
+    }
+
+    [TestFixture]
+    public class TheSurvivalKit : DuffyContentTests
+    {
+        [Test]
+        public async Task TheThermosNeckIsTooNarrowForAnythingElse()
+        {
+            await BoardTheTruck();
+            await _target.GetResponse("open kit");
+
+            (await _target.GetResponse("put authorization in thermos")).Should().Contain("too narrow");
+        }
+
+        [Test]
+        public async Task TheGooCannotBePickedUp_AndTheRefusalSaysWhatToDoInstead()
+        {
+            await BoardTheTruck();
+            await _target.GetResponse("open kit");
+
+            var response = await _target.GetResponse("take gray goo");
+
+            response.Should().Contain("ooze through your fingers");
+            response.Should().Contain("survival kit");
+        }
+    }
+
+    protected StationfallContext Ctx => _target.Context;
+}

--- a/Stationfall/Item/Duffy/BlueSoup.cs
+++ b/Stationfall/Item/Duffy/BlueSoup.cs
@@ -1,17 +1,99 @@
+using Model.AIGeneration;
+
 namespace Stationfall.Item.Duffy;
 
 /// <summary>
-///     The soup in the Thermos (ship.zil:1335-1343). In the original it slowly cools; that timer only
-///     matters for flavor, so the port keeps the soup simple until the survival clocks land in Phase 3.
+///     The soup in the Thermos (ship.zil SOUP-F). It has a temperature, and that temperature falls the
+///     whole time you are carrying it — four times faster with the lid off (ship.zil I-THERMOS). Nothing
+///     hangs on it mechanically; it is there so that the one comfort the Patrol issued you visibly
+///     stops being one.
 /// </summary>
-public class BlueSoup : ItemBase, ICanBeExamined, ICanBeEaten
+public class BlueSoup : ItemBase, ICanBeExamined, ICanBeEaten, ITurnBasedActor
 {
-    public override string[] NounsForMatching => ["blue soup", "soup"];
+    /// <summary>
+    ///     Millichrons between one degree of cooling and the next.
+    /// </summary>
+    private const int CoolingInterval = 100;
+
+    private const int DegreesLostSealed = 1;
+
+    /// <summary>
+    ///     An open Thermos is barely a Thermos (ship.zil I-THERMOS).
+    /// </summary>
+    private const int DegreesLostOpen = 4;
+
+    /// <summary>
+    ///     How much a night's sleep costs the soup (globals.zil:1150-1155).
+    /// </summary>
+    public const int DegreesLostOvernight = 30;
+
+    // Adjectives are matched too, so "drink the hot soup" works while it still is hot - and stops
+    // working, correctly, once it isn't.
+    public override string[] NounsForMatching =>
+        ["blue soup", "soup", "blueberry soup", "walnut soup", "hot soup", "steaming soup",
+         "lukewarm soup", "cool soup", "cold soup"];
 
     public override int Size => 2;
 
-    public string ExaminationDescription =>
-        "A serving of blue soup — blueberry and walnut, according to the Thermos. It is still warm. ";
+    /// <summary>
+    ///     100 is straight from the urn; 0 is stone cold.
+    /// </summary>
+    [UsedImplicitly]
+    public int Warmth { get; set; } = 100;
+
+    /// <summary>
+    ///     When the next degree comes off. Zero until the clock is started, which the original does the
+    ///     first time the player boards the truck rather than at the start of the game.
+    /// </summary>
+    [UsedImplicitly]
+    public int NextCoolingAt { get; set; }
+
+    public string ExaminationDescription => $"The soup seems to be {TemperatureWord}. ";
+
+    /// <summary>
+    ///     The original's six-step ladder (ship.zil DESCRIBE-SOUP-TEMPERATURE).
+    /// </summary>
+    public string TemperatureWord => Warmth switch
+    {
+        > 80 => "steaming hot",
+        > 60 => "quite hot",
+        > 40 => "fairly hot",
+        > 20 => "lukewarm",
+        > 0 => "tepid",
+        _ => "on the cool side"
+    };
+
+    /// <summary>
+    ///     Starts the soup cooling. Called the first time the player boards the truck; calling it again
+    ///     is harmless, so it does not need its own has-this-happened flag.
+    /// </summary>
+    public void StartCooling(IContext context)
+    {
+        if (NextCoolingAt == 0 && context is StationfallContext stationfall)
+            NextCoolingAt = stationfall.CurrentTime + CoolingInterval;
+
+        context.RegisterActor(this);
+    }
+
+    public Task<string> Act(IContext context, IGenerationClient client)
+    {
+        if (NextCoolingAt == 0 || context is not StationfallContext stationfall)
+            return Task.FromResult(string.Empty);
+
+        if (stationfall.CurrentTime < NextCoolingAt)
+            return Task.FromResult(string.Empty);
+
+        Cool(Repository.GetItem<Thermos>().IsOpen ? DegreesLostOpen : DegreesLostSealed);
+        NextCoolingAt = stationfall.CurrentTime + CoolingInterval;
+
+        // Cooling is never announced - the player finds out by looking, which is the whole point.
+        return Task.FromResult(string.Empty);
+    }
+
+    public void Cool(int degrees)
+    {
+        Warmth = Math.Max(0, Warmth - degrees);
+    }
 
     public (string Message, bool WasConsumed) OnEating(IContext context)
     {
@@ -23,8 +105,8 @@ public class BlueSoup : ItemBase, ICanBeExamined, ICanBeEaten
             stationfallContext.Eat();
         }
 
-        return ("You drink the soup. It is sweet, faintly nutty, and by a wide margin the best thing " +
-                "the Patrol has ever fed you. ", true);
+        return ($"You drink the soup. It is sweet, faintly nutty, {TemperatureWord}, and by a wide " +
+                "margin the best thing the Patrol has ever fed you. ", true);
     }
 
     public override string GenericDescription(ILocation? currentLocation)

--- a/Stationfall/Item/Duffy/BoxedForms.cs
+++ b/Stationfall/Item/Duffy/BoxedForms.cs
@@ -1,0 +1,42 @@
+using Model.AIGeneration;
+
+namespace Stationfall.Item.Duffy;
+
+/// <summary>
+///     The forms inside the boxes in the Forms Storage Room (ship.zil BOXED-FORMS-F). You can see that
+///     they are forms and you can reach the boxes, but the forms themselves stay sealed — which is the
+///     joke: a room three decks tall, filled entirely with paperwork you are not authorized to touch.
+/// </summary>
+public class BoxedForms : ItemBase, ICanBeExamined
+{
+    public override string[] NounsForMatching => ["form", "forms", "boxed forms", "sealed forms"];
+
+    public string ExaminationDescription => "The forms are sealed inside the boxes. ";
+
+    public override string CannotBeTakenDescription =>
+        "The forms are sealed inside the boxes, and breaking a Patrol seal is an offense with its own " +
+        "form. ";
+
+    public override string NeverPickedUpDescription(ILocation currentLocation)
+    {
+        return string.Empty;
+    }
+
+    public override async Task<InteractionResult?> RespondToSimpleInteraction(SimpleIntent action,
+        IContext context, IGenerationClient client, IItemProcessorFactory itemProcessorFactory)
+    {
+        if (!action.MatchNounAndAdjective(NounsForMatching))
+            return new NoNounMatchInteractionResult();
+
+        if (action.MatchVerb(["touch", "feel", "examine", "look at", "inspect", "read"]))
+            return new PositiveInteractionResult(ExaminationDescription);
+
+        // Damaging Patrol paperwork is, of course, a violation of an Act.
+        if (action.MatchVerb(["crumple", "tear", "rip", "destroy", "break", "smash", "burn", "eat"]))
+            return new PositiveInteractionResult(
+                "Willful destruction of Patrol forms is a violation of the Uniform Code of Paperwork, " +
+                "Section Nine, and you have no wish to explain yourself at a hearing. ");
+
+        return await base.RespondToSimpleInteraction(action, context, client, itemProcessorFactory);
+    }
+}

--- a/Stationfall/Item/Duffy/DockingBayHatch.cs
+++ b/Stationfall/Item/Duffy/DockingBayHatch.cs
@@ -1,0 +1,7 @@
+namespace Stationfall.Item.Duffy;
+
+/// <summary>
+///     The hatch as seen from Docking Bay #2, once the truck has arrived. Reports and changes the same
+///     flag as <see cref="SpacetruckHatch" />; see <see cref="SpacetruckHatchBase" />.
+/// </summary>
+public class DockingBayHatch : SpacetruckHatchBase;

--- a/Stationfall/Item/Duffy/FirstBin.cs
+++ b/Stationfall/Item/Duffy/FirstBin.cs
@@ -1,0 +1,9 @@
+namespace Stationfall.Item.Duffy;
+
+/// <summary>The leftmost bin in the Robot Pool. See <see cref="RobotBin" />.</summary>
+public class FirstBin : RobotBin
+{
+    protected override int BinNumber => 1;
+
+    public override string[] NounsForMatching => ["first bin", "bin one", "bin 1", "one bin"];
+}

--- a/Stationfall/Item/Duffy/GooBase.cs
+++ b/Stationfall/Item/Duffy/GooBase.cs
@@ -1,3 +1,5 @@
+using Model.AIGeneration;
+
 namespace Stationfall.Item.Duffy;
 
 /// <summary>
@@ -17,6 +19,27 @@ public abstract class GooBase : ItemBase, ICanBeExamined, ICanBeEaten
 
     public string ExaminationDescription =>
         $"A blob of {Color} goo, officially {OfficialName}. It jiggles when the deck plates hum. ";
+
+    public override async Task<InteractionResult?> RespondToSimpleInteraction(SimpleIntent action,
+        IContext context, IGenerationClient client, IItemProcessorFactory itemProcessorFactory)
+    {
+        if (!action.MatchNounAndAdjective(NounsForMatching))
+            return new NoNounMatchInteractionResult();
+
+        // Both refusals end by naming the only thing that does work, so the player is never left
+        // holding a food item they cannot figure out how to eat.
+        if (action.MatchVerb(["take", "get", "pick up", "remove", "grab"]))
+            return new PositiveInteractionResult(
+                "It would ooze through your fingers. You'll have to eat it right out of the survival " +
+                "kit. ");
+
+        if (action.MatchVerb(["drop", "put down", "throw"]))
+            return new PositiveInteractionResult(
+                "The goo, being gooey, sticks where it is. You'll have to eat it right out of the " +
+                "survival kit. ");
+
+        return await base.RespondToSimpleInteraction(action, context, client, itemProcessorFactory);
+    }
 
     public (string Message, bool WasConsumed) OnEating(IContext context)
     {

--- a/Stationfall/Item/Duffy/Pallets.cs
+++ b/Stationfall/Item/Duffy/Pallets.cs
@@ -1,3 +1,5 @@
+using Model.AIGeneration;
+
 namespace Stationfall.Item.Duffy;
 
 /// <summary>
@@ -23,6 +25,24 @@ public class Pallets : ItemBase, ICanBeExamined, ICanBeRead
     public override string NeverPickedUpDescription(ILocation currentLocation)
     {
         return string.Empty;
+    }
+
+    public override async Task<InteractionResult?> RespondToSimpleInteraction(SimpleIntent action,
+        IContext context, IGenerationClient client, IItemProcessorFactory itemProcessorFactory)
+    {
+        if (!action.MatchNounAndAdjective(NounsForMatching))
+            return new NoNounMatchInteractionResult();
+
+        // Opening a box is a joke with a long windup, and the length is the joke (ship.zil PALLETS-F).
+        if (action.MatchVerb(["open", "look in", "look inside", "search", "empty", "unseal"]))
+            return new PositiveInteractionResult(
+                "You work a box open. Inside are forms" + string.Concat(Enumerable.Repeat(" and forms", 50)) +
+                ". Horrified, you reseal the box. ");
+
+        if (action.MatchVerb(["close", "shut", "seal"]))
+            return new PositiveInteractionResult("The boxes are already sealed. ");
+
+        return await base.RespondToSimpleInteraction(action, context, client, itemProcessorFactory);
     }
 
     public override string GenericDescription(ILocation? currentLocation)

--- a/Stationfall/Item/Duffy/PortDoor.cs
+++ b/Stationfall/Item/Duffy/PortDoor.cs
@@ -1,0 +1,47 @@
+using Model.AIGeneration;
+
+namespace Stationfall.Item.Duffy;
+
+/// <summary>
+///     The door to port on Deck Twelve (ship.zil FAKE-DOOR-F). It never opens: the slot beside it wants
+///     a validated Assignment Completion Form, and nothing aboard will validate one. The door's job is
+///     to tell you that clearly enough that you stop trying and go the other way.
+/// </summary>
+public class PortDoor : ItemBase, ICanBeExamined
+{
+    public override string[] NounsForMatching => ["door", "port door", "closed door", "sealed door"];
+
+    public string ExaminationDescription =>
+        "A heavy door leading to the rest of the Duffy. It is firmly closed, and there is a slot set " +
+        "into the bulkhead beside it. ";
+
+    public override string CannotBeTakenDescription => "The door is part of the ship. ";
+
+    public override string NeverPickedUpDescription(ILocation currentLocation)
+    {
+        return string.Empty;
+    }
+
+    public override async Task<InteractionResult?> RespondToSimpleInteraction(SimpleIntent action,
+        IContext context, IGenerationClient client, IItemProcessorFactory itemProcessorFactory)
+    {
+        if (!action.MatchNounAndAdjective(NounsForMatching))
+            return new NoNounMatchInteractionResult();
+
+        // The refusal names the remedy, which is the point: it sends the player looking for a way to
+        // validate the form rather than leaving them rattling a door with no explanation.
+        if (action.MatchVerb(["open", "unlock", "unseal", "force", "pull", "push", "pry"]))
+            return new PositiveInteractionResult(
+                "You must insert a validated Assignment Completion Form in the slot. ");
+
+        if (action.MatchVerb(["close", "shut"]))
+            return new PositiveInteractionResult("It's already closed. ");
+
+        if (action.MatchVerb(["knock", "knock on"]))
+            return new PositiveInteractionResult(
+                "You knock. Somewhere beyond the door, the business of the Patrol continues without " +
+                "you. ");
+
+        return await base.RespondToSimpleInteraction(action, context, client, itemProcessorFactory);
+    }
+}

--- a/Stationfall/Item/Duffy/Radio.cs
+++ b/Stationfall/Item/Duffy/Radio.cs
@@ -1,0 +1,109 @@
+using Newtonsoft.Json;
+using Model.AIGeneration;
+
+namespace Stationfall.Item.Duffy;
+
+/// <summary>
+///     The truck's space-band radio (ship.zil RADIO-F, interrupts.zil I-RADIO). Its microphone is
+///     missing, so it receives and never transmits: you can listen to the lanes but you cannot answer,
+///     which is the point of it. Switched on, it chatters occasionally while you are aboard.
+/// </summary>
+public class Radio : ItemBase, ICanBeExamined, ITurnBasedActor
+{
+    /// <summary>
+    ///     Percentage chance per turn of a snatch of traffic, checked first (I-RADIO).
+    /// </summary>
+    private const int ChanceOfChatter = 30;
+
+    /// <summary>
+    ///     Percentage chance, when no traffic came through, of a music station drifting past instead.
+    /// </summary>
+    private const int ChanceOfMusic = 20;
+
+    [UsedImplicitly] [JsonIgnore] public IRandomChooser Chooser { get; set; } = new RandomChooser();
+
+    [UsedImplicitly] public bool IsOn { get; set; }
+
+    public override string[] NounsForMatching =>
+        ["radio", "sb radio", "space band radio", "spaceband radio", "space-band radio"];
+
+    public string ExaminationDescription =>
+        "A space-band radio built into the console. It seems to be damaged: the microphone is missing, " +
+        $"so you can listen but never answer. It is currently {(IsOn ? "on" : "off")}. ";
+
+    public override string CannotBeTakenDescription => "The radio is built into the console. ";
+
+    /// <summary>
+    ///     Chatter written for this port. The originals are trucker-radio jokes transplanted to
+    ///     spacelanes; these are the same idea in different words.
+    /// </summary>
+    private static readonly List<string> Chatter =
+    [
+        "Keep it under twenty-six thousand kilometers per millichron through lane 630-461, people. " +
+        "There's a patrol cutter parked behind the third beacon.",
+        "Anybody running the Nebulon sector tonight? Looking for a word on the inspection posts.",
+        "Somebody give me a traffic report on lane 317-455 before I commit to it.",
+        "Second time this shift I've been routed around the same dead beacon. Somebody file a form.",
+        "If the outfit hauling nine hundred tons of blank requisition slips is listening: your load is " +
+        "not secured, and I have the paperwork to prove it."
+    ];
+
+    public override string NeverPickedUpDescription(ILocation currentLocation)
+    {
+        return string.Empty;
+    }
+
+    public override async Task<InteractionResult?> RespondToSimpleInteraction(SimpleIntent action,
+        IContext context, IGenerationClient client, IItemProcessorFactory itemProcessorFactory)
+    {
+        if (!action.MatchNounAndAdjective(NounsForMatching))
+            return new NoNounMatchInteractionResult();
+
+        if (action.MatchVerb(["listen", "listen to", "hear"]))
+            return new PositiveInteractionResult(
+                IsOn ? "\"Hiss. Crackle.\" " : "The radio isn't on! ");
+
+        if (action.MatchVerb(["turn on", "switch on", "activate", "start"]))
+        {
+            if (IsOn)
+                return new PositiveInteractionResult("It's already on. ");
+
+            IsOn = true;
+            context.RegisterActor(this);
+            return new PositiveInteractionResult("The radio comes on with a wash of static. ");
+        }
+
+        if (action.MatchVerb(["turn off", "switch off", "deactivate", "stop", "silence"]))
+        {
+            if (!IsOn)
+                return new PositiveInteractionResult("It's already off. ");
+
+            IsOn = false;
+            context.RemoveActor(this);
+            return new PositiveInteractionResult("You switch the radio off. ");
+        }
+
+        return await base.RespondToSimpleInteraction(action, context, client, itemProcessorFactory);
+    }
+
+    /// <summary>
+    ///     Chatter only reaches you in the cab. The original checks the player's room rather than the
+    ///     radio's, so a radio left on and left behind is silent — which is also what stops it talking
+    ///     over the rest of the game once you have walked away from the truck.
+    /// </summary>
+    public Task<string> Act(IContext context, IGenerationClient client)
+    {
+        if (!IsOn || context.CurrentLocation is not Spacetruck)
+            return Task.FromResult(string.Empty);
+
+        if (Chooser.RollDice(100) <= ChanceOfChatter)
+            return Task.FromResult($"The radio crackles to life. \"Breaker. {Chooser.Choose(Chatter)} Over.\" ");
+
+        if (Chooser.RollDice(100) <= ChanceOfMusic)
+            return Task.FromResult(
+                "A country and western station drifts into tune for a moment, long enough for someone " +
+                "to be badly wronged in three-quarter time, and then fades out again. ");
+
+        return Task.FromResult(string.Empty);
+    }
+}

--- a/Stationfall/Item/Duffy/RedButton.cs
+++ b/Stationfall/Item/Duffy/RedButton.cs
@@ -1,0 +1,54 @@
+using Model.AIGeneration;
+
+namespace Stationfall.Item.Duffy;
+
+/// <summary>
+///     The emergency beacon button below the truck's viewport (ship.zil RED-BUTTON-F). It does nothing
+///     at all until the flight is over — and the joke is that by the time pressing it is permitted, the
+///     recording it plays is no comfort whatsoever.
+/// </summary>
+public class RedButton : ItemBase, ICanBeExamined
+{
+    public override string[] NounsForMatching =>
+        ["red button", "button", "beacon", "emergency beacon", "distress beacon"];
+
+    public string ExaminationDescription =>
+        "A red button set into the console below the viewport, labelled EMERGENCY MESSAGE BEACON in " +
+        "lettering considerably calmer than the situation it exists for. ";
+
+    public override string NeverPickedUpDescription(ILocation currentLocation)
+    {
+        return string.Empty;
+    }
+
+    public override string CannotBeTakenDescription => "The button is part of the console. ";
+
+    public override async Task<InteractionResult?> RespondToSimpleInteraction(SimpleIntent action,
+        IContext context, IGenerationClient client, IItemProcessorFactory itemProcessorFactory)
+    {
+        if (!action.MatchNounAndAdjective(NounsForMatching))
+            return new NoNounMatchInteractionResult();
+
+        if (action.MatchVerb(["push", "press", "hit", "punch", "activate", "turn on"]))
+            return new PositiveInteractionResult(Press());
+
+        return await base.RespondToSimpleInteraction(action, context, client, itemProcessorFactory);
+    }
+
+    /// <summary>
+    ///     Gated on the flight being over rather than on having arrived safely: the original checks only
+    ///     that the trip has finished (ship.zil RED-BUTTON-F against SPACETRUCK-COUNTER 5), which is
+    ///     what lets a player stranded at the end of a wrong course actually reach the beacon — and get
+    ///     that recording for an answer.
+    /// </summary>
+    private static string Press()
+    {
+        if (!Repository.GetLocation<Spacetruck>().FlightHasEnded)
+            return "You're not in trouble! Misuse of the emergency message beacon is a court-martial " +
+                   "offense. ";
+
+        return "A recording answers, in the unhurried tone of someone reading from a card: \"At the " +
+               "conclusion of this recording, your emergency message will be sent. In the meantime, " +
+               "please remain calm. Nothing can go wrong... go wrong... go wrong... go wrong...\" ";
+    }
+}

--- a/Stationfall/Item/Duffy/RobotBin.cs
+++ b/Stationfall/Item/Duffy/RobotBin.cs
@@ -1,0 +1,53 @@
+using Model.AIGeneration;
+
+namespace Stationfall.Item.Duffy;
+
+/// <summary>
+///     One of the three bins in the Robot Pool (ship.zil BIN-F). A bin is a window onto whichever robot
+///     is waiting in it: looking inside is how a player is meant to shop before committing to a
+///     requisition, and getting that choice wrong is one of the ways the opening can go badly.
+/// </summary>
+public abstract class RobotBin : ItemBase, ICanBeExamined
+{
+    /// <summary>
+    ///     Which bin this is, and therefore which robot stands in it.
+    /// </summary>
+    protected abstract int BinNumber { get; }
+
+    /// <summary>
+    ///     The robot waiting here, or null once it has been requisitioned and walked out.
+    /// </summary>
+    private ShipRobot? Occupant =>
+        Repository.GetItem<Rex>().BinNumber == BinNumber && !Repository.GetItem<Rex>().IsSelected
+            ? Repository.GetItem<Rex>()
+            : Repository.GetItem<Helen>().BinNumber == BinNumber && !Repository.GetItem<Helen>().IsSelected
+                ? Repository.GetItem<Helen>()
+                : Repository.GetItem<Floyd>().BinNumber == BinNumber && !Repository.GetItem<Floyd>().IsSelected
+                    ? Repository.GetItem<Floyd>()
+                    : null;
+
+    public string ExaminationDescription => Occupant?.InTheBinDescription ?? "The bin is empty. ";
+
+    public override string CannotBeTakenDescription => "The bin is part of the wall. ";
+
+    public override string NeverPickedUpDescription(ILocation currentLocation)
+    {
+        return string.Empty;
+    }
+
+    public override async Task<InteractionResult?> RespondToSimpleInteraction(SimpleIntent action,
+        IContext context, IGenerationClient client, IItemProcessorFactory itemProcessorFactory)
+    {
+        if (!action.MatchNounAndAdjective(NounsForMatching))
+            return new NoNounMatchInteractionResult();
+
+        if (action.MatchVerb(["look in", "look inside", "search", "examine", "inspect", "look at"]))
+            return new PositiveInteractionResult(ExaminationDescription);
+
+        // The original refuses to let you climb in or use a bin as storage, in as many words.
+        if (action.MatchVerb(["enter", "get in", "climb in", "sit in", "put", "put in"]))
+            return new PositiveInteractionResult("The bin is only for robots. ");
+
+        return await base.RespondToSimpleInteraction(action, context, client, itemProcessorFactory);
+    }
+}

--- a/Stationfall/Item/Duffy/SecondBin.cs
+++ b/Stationfall/Item/Duffy/SecondBin.cs
@@ -1,0 +1,9 @@
+namespace Stationfall.Item.Duffy;
+
+/// <summary>The middle bin in the Robot Pool. See <see cref="RobotBin" />.</summary>
+public class SecondBin : RobotBin
+{
+    protected override int BinNumber => 2;
+
+    public override string[] NounsForMatching => ["second bin", "bin two", "bin 2", "two bin"];
+}

--- a/Stationfall/Item/Duffy/SpacetruckCabHatch.cs
+++ b/Stationfall/Item/Duffy/SpacetruckCabHatch.cs
@@ -1,0 +1,7 @@
+namespace Stationfall.Item.Duffy;
+
+/// <summary>
+///     The hatch as seen from inside the cab. Reports and changes the same flag as
+///     <see cref="SpacetruckHatch" />; see <see cref="SpacetruckHatchBase" />.
+/// </summary>
+public class SpacetruckCabHatch : SpacetruckHatchBase;

--- a/Stationfall/Item/Duffy/SpacetruckHatch.cs
+++ b/Stationfall/Item/Duffy/SpacetruckHatch.cs
@@ -1,104 +1,25 @@
+using Newtonsoft.Json;
+
 namespace Stationfall.Item.Duffy;
 
 /// <summary>
-///     The spacetruck's hatch. It must be shut before launch — the original vents the cabin and kills a
-///     player who leaves it open (ship.zil:1164-1166) — and it cannot be opened at all in deep space
-///     (ship.zil:1042-1048).
+///     The hatch as seen from the Cargo Bay, and the object that owns the one open/closed flag every
+///     other view of the hatch reads. See <see cref="SpacetruckHatchBase" /> for why there are three.
 /// </summary>
-public class SpacetruckHatch : OpenAndCloseContainerBase, ICanBeExamined
+public class SpacetruckHatch : SpacetruckHatchBase
 {
-    public override string[] NounsForMatching => ["hatch", "spacetruck hatch", "truck hatch", "door"];
-
-    public override bool IsTransparent => true;
-
-    public string ExaminationDescription =>
-        $"A broad loading hatch in the side of the spacetruck. It is {(IsOpen ? "open" : "closed")}. ";
-
-    public override string NowOpen(ILocation currentLocation)
-    {
-        return "The hatch swings open. ";
-    }
-
-    public override string NowClosed(ILocation currentLocation)
-    {
-        return "The hatch swings shut and seals with a pneumatic sigh. ";
-    }
-
     /// <summary>
-    ///     Once the truck is under way there is nothing outside but vacuum, so the hatch stays shut
-    ///     until it docks (ship.zil:1042-1048).
+    ///     The single stored flag. Named for what it is — the raw state, as opposed to any room's view
+    ///     of it — and kept public so it serializes under the name saved games already use.
     /// </summary>
-    public override string? CannotBeOpenedDescription(IContext context)
+    [UsedImplicitly]
+    [JsonProperty("IsOpen")]
+    public bool StoredIsOpen { get; set; }
+
+    [JsonIgnore]
+    protected override bool RawIsOpen
     {
-        return Repository.GetLocation<Spacetruck>().IsInFlight
-            ? "You can't open the hatch in deep space! "
-            : null;
-    }
-
-    /// <summary>
-    ///     Handles open/close/examine of the hatch from a room where the item itself is out of scope
-    ///     (inside the truck, and the docking bay). Matches on the verb plus any noun the hatch
-    ///     advertises, so the phrasings the item claims to answer to all work. Returns null when the
-    ///     input isn't about the hatch, so the caller can fall through.
-    /// </summary>
-    public static string? TryHandleRawCommand(string? normalizedInput, IContext context, ILocation location)
-    {
-        if (string.IsNullOrWhiteSpace(normalizedInput))
-            return null;
-
-        var hatch = Repository.GetItem<SpacetruckHatch>();
-
-        string[] closeVerbs = ["close", "shut", "seal"];
-        string[] openVerbs = ["open", "unseal"];
-        string[] examineVerbs = ["examine", "look at", "inspect", "check", "x"];
-
-        var noun = MatchedNoun(normalizedInput, closeVerbs.Concat(openVerbs).Concat(examineVerbs), hatch);
-
-        if (noun is null)
-            return null;
-
-        var verb = normalizedInput[..^noun.Length].Trim();
-
-        if (examineVerbs.Contains(verb))
-            return hatch.ExaminationDescription;
-
-        if (closeVerbs.Contains(verb))
-        {
-            if (!hatch.IsOpen)
-                return "It is already closed. ";
-
-            hatch.IsOpen = false;
-            return hatch.NowClosed(location);
-        }
-
-        var refusal = hatch.CannotBeOpenedDescription(context);
-
-        if (refusal is not null)
-            return refusal;
-
-        if (hatch.IsOpen)
-            return "It is already open. ";
-
-        hatch.IsOpen = true;
-        return hatch.NowOpen(location);
-    }
-
-    /// <summary>
-    ///     Returns the hatch noun the input ends with, when the input also starts with one of the
-    ///     given verbs.
-    /// </summary>
-    private static string? MatchedNoun(string input, IEnumerable<string> verbs, SpacetruckHatch hatch)
-    {
-        var verbList = verbs.ToArray();
-
-        return hatch.NounsForMatching
-            .Where(candidate => input.EndsWith(candidate, StringComparison.InvariantCultureIgnoreCase))
-            .OrderByDescending(candidate => candidate.Length)
-            .FirstOrDefault(candidate =>
-                verbList.Contains(input[..^candidate.Length].Trim(), StringComparer.InvariantCultureIgnoreCase));
-    }
-
-    public override void Init()
-    {
+        get => StoredIsOpen;
+        set => StoredIsOpen = value;
     }
 }

--- a/Stationfall/Item/Duffy/SpacetruckHatchBase.cs
+++ b/Stationfall/Item/Duffy/SpacetruckHatchBase.cs
@@ -1,0 +1,85 @@
+using Newtonsoft.Json;
+
+namespace Stationfall.Item.Duffy;
+
+/// <summary>
+///     The spacetruck's hatch <i>as it stands in one particular room</i> — seen from the cargo bay,
+///     from inside the cab, or from the docking bay. It must be shut before launch (the original vents
+///     the cabin and kills a player who leaves it open, ship.zil:1164-1166) and cannot be opened at all
+///     in deep space (ship.zil:1042-1048).
+///     <para>
+///         There is one hatch in the fiction but three objects here, because one object cannot honestly
+///         be in three places: a single instance seeded into three rooms has its
+///         <see cref="ItemBase.CurrentLocation" /> overwritten by whichever <c>Init()</c> runs last, and
+///         every scope check built on that then rejects it in the other two. Splitting identity is what
+///         makes <c>CurrentLocation</c> true again. State is deliberately <i>not</i> split with it —
+///         see <see cref="IsOpen" />.
+///     </para>
+///     <para>
+///         This is what retires the raw-string interception the truck and the docking bay used to need.
+///         They matched verb-plus-noun against the input by hand precisely because the hatch object was
+///         out of scope there; with a real object in each room the ordinary processors work, and every
+///         verb they support — not just the two that were hand-coded — works from all three rooms.
+///     </para>
+/// </summary>
+public abstract class SpacetruckHatchBase : OpenAndCloseContainerBase, ICanBeExamined
+{
+    /// <summary>
+    ///     The object holding the one open/closed flag: the cargo bay's hatch, which is where the flag
+    ///     lived before the split, so saved games keep pointing at it.
+    /// </summary>
+    protected virtual SpacetruckHatchBase FlagHolder => Repository.GetItem<SpacetruckHatch>();
+
+    public override string[] NounsForMatching => ["hatch", "spacetruck hatch", "truck hatch", "door"];
+
+    public override bool IsTransparent => true;
+
+    public string ExaminationDescription =>
+        $"A broad loading hatch in the side of the spacetruck. It is {(IsOpen ? "open" : "closed")}. ";
+
+    // No backing field and nothing to serialize here: the flag belongs to the holder, which is
+    // serialized in its own right. This must be Newtonsoft's JsonIgnore, not System.Text.Json's - saves
+    // go through JsonConvert (GameEngine.SaveGame), which ignores the STJ attribute entirely and would
+    // write each room's copy into the blob, then push it back through the setter on restore.
+    [JsonIgnore]
+    public override bool IsOpen
+    {
+        get => FlagHolder.RawIsOpen;
+        set => FlagHolder.RawIsOpen = value;
+    }
+
+    /// <summary>
+    ///     The flag itself, reached only through <see cref="IsOpen" />. Overridden by the holder to be
+    ///     a real stored property; every other hatch inherits this and never uses it.
+    /// </summary>
+    protected virtual bool RawIsOpen
+    {
+        get => false;
+        set { }
+    }
+
+    public override string NowOpen(ILocation currentLocation)
+    {
+        return "The hatch swings open. ";
+    }
+
+    public override string NowClosed(ILocation currentLocation)
+    {
+        return "The hatch swings shut and seals with a pneumatic sigh. ";
+    }
+
+    /// <summary>
+    ///     Once the truck is under way there is nothing outside but vacuum, so the hatch stays shut
+    ///     until it docks (ship.zil:1042-1048).
+    /// </summary>
+    public override string? CannotBeOpenedDescription(IContext context)
+    {
+        return Repository.GetLocation<Spacetruck>().IsInFlight
+            ? "You can't open the hatch in deep space! "
+            : null;
+    }
+
+    public override void Init()
+    {
+    }
+}

--- a/Stationfall/Item/Duffy/Thermos.cs
+++ b/Stationfall/Item/Duffy/Thermos.cs
@@ -1,3 +1,5 @@
+using Model.AIGeneration;
+
 namespace Stationfall.Item.Duffy;
 
 /// <summary>
@@ -25,6 +27,56 @@ public class Thermos : OpenAndCloseContainerBase, ICanBeTakenAndDropped, ICanBeE
     public override string NeverPickedUpDescription(ILocation currentLocation)
     {
         return OnTheGroundDescription(currentLocation);
+    }
+
+    public override async Task<InteractionResult?> RespondToSimpleInteraction(SimpleIntent action,
+        IContext context, IGenerationClient client, IItemProcessorFactory itemProcessorFactory)
+    {
+        // NB: no early return when the noun isn't ours. ContainerBase's implementation offers the
+        // action to the items INSIDE this one before considering itself, so returning NoNounMatch here
+        // would cut the soup off from every verb it has - it would simply stop existing to the parser.
+        if (action.MatchNounAndAdjective(NounsForMatching))
+        {
+            var soup = Repository.GetItem<BlueSoup>();
+
+            // Emptying the Thermos means emptying what is in it, which is worth doing deliberately:
+            // the soup is gone for good, and the bottle matters later.
+            if (action.MatchVerb(["pour", "empty", "pour out", "dump"]) && Items.Contains(soup))
+            {
+                RemoveItem(soup);
+                soup.CurrentLocation = null;
+
+                return new PositiveInteractionResult(
+                    "You pour the soup out. It spreads across the deck in a wide blue disc, and the " +
+                    "smell of blueberries fills the place. ");
+            }
+
+            if (action.MatchVerb(["look in", "look inside", "reach in", "reach into"]))
+                return new PositiveInteractionResult(
+                    Items.Contains(soup) ? soup.ExaminationDescription : "The Thermos is empty. ");
+        }
+
+        return await base.RespondToSimpleInteraction(action, context, client, itemProcessorFactory);
+    }
+
+    /// <summary>
+    ///     Nothing goes into the Thermos. Far downstream the bottle matters for what it can be made to
+    ///     hold, so the refusal is worded to leave that possibility open rather than to close the idea
+    ///     off entirely.
+    /// </summary>
+    public override async Task<InteractionResult?> RespondToMultiNounInteraction(MultiNounIntent action,
+        IContext context)
+    {
+        var isPuttingSomethingIn =
+            action.MatchVerb(["put", "place", "insert", "drop"]) &&
+            action.MatchNounTwo(NounsForMatching) &&
+            action.Preposition is "in" or "into" or "inside";
+
+        if (isPuttingSomethingIn)
+            return new PositiveInteractionResult(
+                $"The neck of the Thermos is too narrow for the {action.NounOne}. ");
+
+        return await base.RespondToMultiNounInteraction(action, context);
     }
 
     public override void Init()

--- a/Stationfall/Item/Duffy/ThirdBin.cs
+++ b/Stationfall/Item/Duffy/ThirdBin.cs
@@ -1,0 +1,9 @@
+namespace Stationfall.Item.Duffy;
+
+/// <summary>The rightmost bin in the Robot Pool. See <see cref="RobotBin" />.</summary>
+public class ThirdBin : RobotBin
+{
+    protected override int BinNumber => 3;
+
+    public override string[] NounsForMatching => ["third bin", "bin three", "bin 3", "three bin"];
+}

--- a/Stationfall/Location/Duffy/DeckTwelve.cs
+++ b/Stationfall/Location/Duffy/DeckTwelve.cs
@@ -14,14 +14,6 @@ public class DeckTwelve : LocationBase
 
     public override string[] NounsForMatching => ["deck 12", "deck twelve"];
 
-    protected override IReadOnlyList<SceneryItem> Scenery =>
-    [
-        new(["door", "port door", "closed door", "sealed door"],
-            "A heavy door leading to the rest of the Duffy. It is firmly closed, and there is a slot " +
-            "set into the bulkhead beside it. ",
-            "The door is part of the ship. ")
-    ];
-
     protected override Dictionary<Direction, MovementParameters> Map(IContext context)
     {
         return new Dictionary<Direction, MovementParameters>
@@ -50,5 +42,6 @@ public class DeckTwelve : LocationBase
     public override void Init()
     {
         StartWithItem<DeckTwelveSlot>();
+        StartWithItem<PortDoor>();
     }
 }

--- a/Stationfall/Location/Duffy/DockingBayTwo.cs
+++ b/Stationfall/Location/Duffy/DockingBayTwo.cs
@@ -42,22 +42,6 @@ public class DockingBayTwo : LocationBase
         };
     }
 
-    /// <summary>
-    ///     The hatch item lives in the Cargo Bay, so it is out of scope here too; route open/close/
-    ///     examine to it so a player can climb back into the docked truck.
-    /// </summary>
-    public override Task<InteractionResult> RespondToSpecificLocationInteraction(string? input, IContext context,
-        IGenerationClient client)
-    {
-        var normalized = input?.ToLowerInvariant().Replace("the ", "").Trim();
-        var hatchResponse = SpacetruckHatch.TryHandleRawCommand(normalized, context, this);
-
-        if (hatchResponse is not null)
-            return Task.FromResult<InteractionResult>(new PositiveInteractionResult(hatchResponse));
-
-        return base.RespondToSpecificLocationInteraction(input, context, client);
-    }
-
     protected override string GetContextBasedDescription(IContext context)
     {
         return "A cramped docking bay, its walls crowded with mooring clamps and fuel couplings. Your " +
@@ -67,5 +51,6 @@ public class DockingBayTwo : LocationBase
 
     public override void Init()
     {
+        StartWithItem<DockingBayHatch>();
     }
 }

--- a/Stationfall/Location/Duffy/FormStorageRoom.cs
+++ b/Stationfall/Location/Duffy/FormStorageRoom.cs
@@ -28,5 +28,6 @@ public class FormStorageRoom : LocationBase
     public override void Init()
     {
         StartWithItem<Pallets>();
+        StartWithItem<BoxedForms>();
     }
 }

--- a/Stationfall/Location/Duffy/RobotPool.cs
+++ b/Stationfall/Location/Duffy/RobotPool.cs
@@ -26,7 +26,14 @@ public class RobotPool : LocationBase
     [
         new(["keypad", "keys", "console", "equipment", "selection equipment"],
             "A numeric keypad beside the slot, for typing the bin number of the robot you want. ",
-            "The keypad is bolted to the console. ")
+            "The keypad is bolted to the console. "),
+        // The original answers a bare "bin" by asking which one (ship.zil BIN-F). Scenery is the right
+        // shape for that: the three real bins are matched first, so this only catches the ambiguous
+        // case that has nothing to act on.
+        new(["bin", "bins"],
+            "Three numbered bins are set into the wall. You'll have to say which one you mean — the " +
+            "first, the second or the third. ",
+            "The bins are set into the wall. ")
     ];
 
     protected override Dictionary<Direction, MovementParameters> Map(IContext context)
@@ -126,6 +133,9 @@ public class RobotPool : LocationBase
     public override void Init()
     {
         StartWithItem<RobotPoolSlot>();
+        StartWithItem<FirstBin>();
+        StartWithItem<SecondBin>();
+        StartWithItem<ThirdBin>();
         StartWithItem<Rex>();
         StartWithItem<Helen>();
         StartWithItem<Floyd>();

--- a/Stationfall/Location/Duffy/Spacetruck.cs
+++ b/Stationfall/Location/Duffy/Spacetruck.cs
@@ -20,6 +20,11 @@ public class Spacetruck : LocationBase, ITurnBasedActor
     private const int NotLaunched = -1;
 
     /// <summary>
+    ///     The last step of the launch sequence: arrival, one way or the other.
+    /// </summary>
+    private const int FinalFlightStep = 5;
+
+    /// <summary>
     ///     Set once the activation form has been accepted; the keypad is inert until then.
     /// </summary>
     [UsedImplicitly]
@@ -67,6 +72,14 @@ public class Spacetruck : LocationBase, ITurnBasedActor
     /// </summary>
     public bool IsInFlight => LaunchCounter >= 0 && !HasDocked;
 
+    /// <summary>
+    ///     Whether the trip has run its course. Deliberately not the same as <see cref="HasDocked" />:
+    ///     the counter reaches its last step whether you arrived at the station or came to a dead stop
+    ///     in empty space, and some things aboard — the emergency beacon especially — care only that
+    ///     the flying has stopped.
+    /// </summary>
+    public bool FlightHasEnded => LaunchCounter >= FinalFlightStep;
+
     private bool CourseIsCorrect => CoursePicked != 0 && CoursePicked == RightCourse;
 
     public override string Name => "Spacetruck";
@@ -81,17 +94,15 @@ public class Spacetruck : LocationBase, ITurnBasedActor
         new(["viewport", "window"],
             "A broad viewport above the console. ",
             "The viewport is part of the truck. "),
-        new(["radio", "sb radio", "space band radio"],
-            "A space-band radio. Its microphone is missing, so you can listen but never answer. ",
-            "The radio is built into the console. "),
-        new(["red button", "button", "beacon"],
-            "A red button that fires the emergency distress beacon. ",
-            "The button is part of the console. ")
+        new(["dashboard", "instruments", "instrument panel"],
+            "A spartan instrument panel: a course display, a fuel gauge, and a great deal of blank " +
+            "metal where a more expensive truck would have something useful. ",
+            "The panel is part of the truck. ")
     ];
 
     protected override Dictionary<Direction, MovementParameters> Map(IContext context)
     {
-        var hatch = Repository.GetItem<SpacetruckHatch>();
+        var hatch = Repository.GetItem<SpacetruckCabHatch>();
 
         // Before launch the hatch leads back into the cargo bay; after docking, out into the station.
         ILocation destination = HasDocked
@@ -140,16 +151,6 @@ public class Spacetruck : LocationBase, ITurnBasedActor
             return Task.FromResult<InteractionResult>(new PositiveInteractionResult(seat.GetIn(context)));
         }
 
-        // The hatch item lives in the Cargo Bay (where you first open it), so it isn't in scope from
-        // inside the truck. Handle it here rather than seeding one shared instance into two rooms,
-        // which would leave its CurrentLocation pointing at whichever room initialized last. Matching
-        // is on verb + any of the hatch's own nouns, so every phrasing the item advertises works —
-        // shutting the hatch is required before launch, and a silent miss is fatal.
-        var hatchResponse = SpacetruckHatch.TryHandleRawCommand(normalized, context, this);
-
-        if (hatchResponse is not null)
-            return Task.FromResult<InteractionResult>(new PositiveInteractionResult(hatchResponse));
-
         switch (normalized)
         {
             case "stand":
@@ -159,19 +160,6 @@ public class Spacetruck : LocationBase, ITurnBasedActor
                     context.CurrentLocation.SubLocation is SeatBase seat
                         ? seat.GetOut(context)
                         : "You're already standing. "));
-
-            case "push red button":
-            case "press red button":
-            case "push button":
-            case "press button":
-                // Once docked, the beacon actually plays its recording (RED-BUTTON-F, ship.zil:1136).
-                return Task.FromResult<InteractionResult>(new PositiveInteractionResult(
-                    HasDocked
-                        ? "A recording answers: \"At the conclusion of this message your emergency " +
-                          "signal will be transmitted. In the meantime, please remain calm. Nothing " +
-                          "can go wrong... go wrong... go wrong...\" "
-                        : "You're not in trouble! Misuse of the emergency beacon is a court-martial " +
-                          "offense. "));
         }
 
         return base.RespondToSpecificLocationInteraction(input, context, client);
@@ -433,5 +421,8 @@ public class Spacetruck : LocationBase, ITurnBasedActor
         StartWithItem<PilotSeat>();
         StartWithItem<CopilotSeat>();
         StartWithItem<SurvivalKit>();
+        StartWithItem<SpacetruckCabHatch>();
+        StartWithItem<Radio>();
+        StartWithItem<RedButton>();
     }
 }

--- a/Stationfall/Location/Duffy/Spacetruck.cs
+++ b/Stationfall/Location/Duffy/Spacetruck.cs
@@ -170,6 +170,19 @@ public class Spacetruck : LocationBase, ITurnBasedActor
     ///     "occupied" after you leave, which both satisfies the launch interlock for a player who is
     ///     standing in the cargo bay and lets them dodge the failed-to-strap-in death.
     /// </summary>
+    /// <summary>
+    ///     The Thermos only starts losing heat once you are aboard with it (ship.zil SPACETRUCK-F queues
+    ///     the cooling interrupt on first entry, not at the start of the game) - so a player who dawdles
+    ///     on the ship does not find cold soup waiting for them.
+    /// </summary>
+    public override Task<string> AfterEnterLocation(IContext context, ILocation previousLocation,
+        IGenerationClient generationClient)
+    {
+        Repository.GetItem<BlueSoup>().StartCooling(context);
+
+        return base.AfterEnterLocation(context, previousLocation, generationClient);
+    }
+
     public override void OnLeaveLocation(IContext context, ILocation newLocation, ILocation previousLocation)
     {
         SubLocation = null;

--- a/Stationfall/Survival/SleepEngine.cs
+++ b/Stationfall/Survival/SleepEngine.cs
@@ -101,6 +101,11 @@ public static class SleepEngine
                                                        ? HungerNotifications.FamishedMorningTicks
                                                        : HungerNotifications.RestedMorningTicks);
 
+        // A night's sleep costs the soup too - all of it if the Thermos was left open
+        // (globals.zil:1150-1155).
+        var soup = Repository.GetItem<BlueSoup>();
+        soup.Cool(Repository.GetItem<Thermos>().IsOpen ? soup.Warmth : BlueSoup.DegreesLostOvernight);
+
         DropEverythingNotWorn(context);
 
         var message = $"***** NOVEM {context.Day + 3}, 11349 *****\n\n";

--- a/UnitTests/IntentMappings/stationfall-mappings.json
+++ b/UnitTests/IntentMappings/stationfall-mappings.json
@@ -1,0 +1,23 @@
+{
+  "version": "1.0",
+  "gameName": "stationfall",
+  "extends": "base",
+
+  // Phrasings the hand-rolled TestParser cannot reach on its own: it has no "shut" verb, and its
+  // verb+noun fallback only handles two-word commands, so every multi-word noun needs naming here.
+  // These used to "work" only because the Spacetruck and Docking Bay intercepted raw input strings
+  // before the parser ever saw them. That interception is gone now that the hatch is a real object in
+  // each room, so the phrasings the hatch advertises have to be genuinely parseable instead.
+  "simpleIntents": [
+    { "inputs": ["shut hatch", "shut the hatch"], "verb": "close", "noun": "hatch" },
+    { "inputs": ["shut door", "shut the door"], "verb": "close", "noun": "door" },
+    { "inputs": ["close spacetruck hatch", "close the spacetruck hatch"], "verb": "close", "noun": "spacetruck hatch" },
+    { "inputs": ["close truck hatch", "close the truck hatch"], "verb": "close", "noun": "truck hatch" },
+    { "inputs": ["shut spacetruck hatch"], "verb": "close", "noun": "spacetruck hatch" },
+    { "inputs": ["shut truck hatch"], "verb": "close", "noun": "truck hatch" },
+    { "inputs": ["open spacetruck hatch", "open the spacetruck hatch"], "verb": "open", "noun": "spacetruck hatch" },
+    { "inputs": ["open truck hatch", "open the truck hatch"], "verb": "open", "noun": "truck hatch" },
+    { "inputs": ["examine spacetruck hatch"], "verb": "examine", "noun": "spacetruck hatch" },
+    { "inputs": ["examine truck hatch"], "verb": "examine", "noun": "truck hatch" }
+  ]
+}

--- a/UnitTests/IntentMappings/stationfall-mappings.json
+++ b/UnitTests/IntentMappings/stationfall-mappings.json
@@ -18,6 +18,27 @@
     { "inputs": ["open spacetruck hatch", "open the spacetruck hatch"], "verb": "open", "noun": "spacetruck hatch" },
     { "inputs": ["open truck hatch", "open the truck hatch"], "verb": "open", "noun": "truck hatch" },
     { "inputs": ["examine spacetruck hatch"], "verb": "examine", "noun": "spacetruck hatch" },
-    { "inputs": ["examine truck hatch"], "verb": "examine", "noun": "truck hatch" }
+    { "inputs": ["examine truck hatch"], "verb": "examine", "noun": "truck hatch" },
+
+    // Multi-word nouns for the Duffy's fittings. The TestParser's verb+noun fallback is two words
+    // only, so anything with an adjective in front of it has to be named here.
+    { "inputs": ["turn on radio", "turn the radio on", "switch on radio"], "verb": "turn on", "noun": "radio" },
+    { "inputs": ["turn off radio", "turn the radio off", "switch off radio"], "verb": "turn off", "noun": "radio" },
+    { "inputs": ["listen to radio", "listen to the radio"], "verb": "listen", "noun": "radio" },
+    { "inputs": ["push red button", "press red button", "push the red button", "press the red button"], "verb": "push", "noun": "red button" },
+    { "inputs": ["examine red button"], "verb": "examine", "noun": "red button" },
+    { "inputs": ["look in first bin", "look inside first bin", "examine first bin"], "verb": "look in", "noun": "first bin" },
+    { "inputs": ["look in second bin", "look inside second bin", "examine second bin"], "verb": "look in", "noun": "second bin" },
+    { "inputs": ["look in third bin", "look inside third bin", "examine third bin"], "verb": "look in", "noun": "third bin" },
+    { "inputs": ["enter first bin", "get in first bin", "climb in first bin"], "verb": "enter", "noun": "first bin" },
+    { "inputs": ["examine boxed forms", "examine forms"], "verb": "examine", "noun": "forms" },
+    { "inputs": ["tear forms", "tear the forms"], "verb": "tear", "noun": "forms" },
+    { "inputs": ["examine port door"], "verb": "examine", "noun": "port door" },
+    { "inputs": ["open port door"], "verb": "open", "noun": "port door" },
+    { "inputs": ["look in thermos", "look inside thermos", "reach in thermos"], "verb": "look in", "noun": "thermos" },
+    { "inputs": ["pour out thermos", "pour the thermos out"], "verb": "pour", "noun": "thermos" },
+    { "inputs": ["examine blue soup"], "verb": "examine", "noun": "blue soup" },
+    { "inputs": ["take gray goo", "take the gray goo"], "verb": "take", "noun": "gray goo" },
+    { "inputs": ["drop gray goo"], "verb": "drop", "noun": "gray goo" }
   ]
 }

--- a/UnitTests/TestParser.cs
+++ b/UnitTests/TestParser.cs
@@ -47,8 +47,11 @@ public class TestParser : IntentParser
 
         _allNouns = _allNouns.Union(specialNouns).ToArray();
 
-        // Initialize the JSON-based resolver for O(1) lookups
-        _resolver = IntentMappingResolver.ForGame("base");
+        // Initialize the JSON-based resolver for O(1) lookups. This must follow the game, not be
+        // pinned to "base": the loader already supports a per-game overlay that extends base
+        // (IntentMappingLoader.LoadConfigurationInternal), and hardcoding "base" here meant no game
+        // could ever use one. Games without an overlay fall back to base, so this is inert for them.
+        _resolver = IntentMappingResolver.ForGame(gameName);
     }
 
     public override Task<IntentBase> DetermineComplexIntentType(string? input, string locationDescription,


### PR DESCRIPTION
## Heads up before you read the diff

The repo owner has never played Stationfall and is building this port in order to play it. **This PR body is spoiler-free; the diff is not.** `Stationfall/**` and `Stationfall.Tests/**` name rooms and objects by necessity. See [`Docs/Stationfall-Port-Plan.md`](Docs/Stationfall-Port-Plan.md) for spoiler-free status.

Scoped to the opening's **rooms and objects**. The companion and the other robots are deliberately untouched and come later.

## The problem

Phase 2 built the opening's puzzle chain and left the furniture thin. What a player pokes at on the way through was mostly props. Three kinds of gap:

**Scenery pretending to be objects.** The radio, the emergency beacon, the port door, the robot-pool bins and the boxed forms were examine-only text with no verbs. You could look at the radio but not switch it on; look at the door but not try to open it.

**Room code pretending to be objects.** The truck's hatch existed only in the cargo bay, so from inside the cab and from the docking bay it was faked by matching raw input strings against a hand-written verb list. It is now a real object in each of the three rooms it appears in, sharing one open/closed flag — the pattern `CLAUDE.md` prescribes and the Planetfall elevator doors already use. This is not tidying: one object cannot honestly be in three places, and the interception existed only to paper over the scope failures that caused. Every verb now works from all three rooms rather than the two that were hand-coded, and `CurrentLocation` is true again.

**A mechanic missing entirely.** The soup has a temperature that falls the whole time you carry it — four times faster with the lid off, plus a fixed cost per night slept. Nothing hangs on it mechanically; it exists so that the one comfort the Patrol issued you visibly stops being one.

## Bugs this turned up

**A real one, mine.** `Thermos` overrode `RespondToSimpleInteraction` and early-returned `NoNounMatch` for nouns that weren't its own. `ContainerBase` offers the action to the items **inside** it before considering itself, so that override silently deleted the soup from the parser — it answered to nothing at all. Pinned with a regression test that names the trap, because any future container override can reintroduce it.

**Shared test infrastructure.** `TestParser` hardcoded `IntentMappingResolver.ForGame("base")` and ignored the `gameName` it was constructed with, so the per-game overlay the loader has always supported was unreachable by every game. Now follows the game; games without an overlay fall back to base, so it is inert for them. Verified against all four other suites.

Dropping the hatch interception also exposed that four phrasings the hatch advertises were never actually parseable — they only worked because the interception ran before the parser saw them. They are now real mappings in a Stationfall overlay rather than a hidden special case.

## Tests

| Suite | Result |
|---|---|
| Stationfall | 109 (was 85) |
| Planetfall | 3960 |
| UnitTests | 1182 |
| ZorkOne | 1782 |
| EscapeRoom | 9 |
| Console | 16 |

## Explicitly not done

The opening is not finished. Still outstanding: the companion and the other robots; one scripted ambient event; global scenery (`examine walls` / `floor` / `ceiling` / `air` / `me`), which the original has everywhere and this engine has no equivalent for; and the original's footnote verb.

🤖 Generated with [Claude Code](https://claude.com/claude-code)