### PR TITLE
Make the Duffy's three robots characters you can talk to

### DIFF
--- a/Docs/Stationfall-Port-Plan.md
+++ b/Docs/Stationfall-Port-Plan.md
@@ -50,7 +50,7 @@ Measured against the original, not from memory. Update this table as phases land
 | Region objects | 20 | 116 |
 | Background daemons | ~4 | 32 |
 | **Reachable score** | **8** | **80** |
-| Tests | 109 | — |
+| Tests | 121 | — |
 
 Landed so far:
 
@@ -63,6 +63,8 @@ Landed so far:
 - **Opening content pass** — the fittings of the opening rooms, as opposed to their puzzle chain:
   the things a player pokes at on the way through. Phase 2 built the chain and left much of the
   furniture as examine-only scenery or as strings matched in a room's input handler.
+- **The opening's robots** — the three of them as characters: addressable by name, each with its own
+  register, with the companion's opening beats and the consequences of choosing wrongly.
 
 For scale: Planetfall in this engine is 127 location files and 142 item files. Stationfall is the
 bigger game.
@@ -83,8 +85,15 @@ round-trip the new state.
 ### Phase 4 — Engine capabilities that do not exist yet
 Blocking work for Phases 5–6, no score movement:
 
-- **Commanding an NPC** (`<name>, <command>`). The engine has no intent for this at all; Planetfall
-  approximates its equivalent with bespoke per-scene code. Needs a real intent plus routing.
+- **Commanding an NPC** (`<name>, <command>`). Correcting an earlier overstatement here: the engine
+  *can* route speech to a character addressed by name — `ICanBeTalkedTo` and `ConversationHandler`
+  do that, including for absent characters. What it cannot do is have a character *act on* a
+  command. That is the real gap.
+  Related, and found the hard way: `ConversationHandler.FindTargetCharacter` treats **any** of a
+  character's nouns appearing **anywhere** in the input as addressing them. A character holding a
+  generic noun therefore swallows ordinary commands that merely contain the word. Worked around
+  per-character for now by not claiming generic nouns; the engine-level fix wants its own change,
+  since it would alter Planetfall's matching too.
 - **The companion, into `StellarPatrol`.** He is literally the same character in both games and
   Planetfall's implementation runs to ~1800 lines across nine files. The persona prompts, the canned
   social responses, following the player between rooms and carrying things are all common. What is

--- a/Stationfall.Tests/DuffyRobotTests.cs
+++ b/Stationfall.Tests/DuffyRobotTests.cs
@@ -1,0 +1,163 @@
+using FluentAssertions;
+using GameEngine;
+using Stationfall.Item.Duffy;
+
+namespace Stationfall.Tests;
+
+/// <summary>
+///     The three robots as characters rather than as a keypad choice: what they say, what they let you
+///     do, and how the companion behaves while he is campaigning for the job.
+/// </summary>
+[TestFixture]
+public class DuffyRobotTests : EngineTestsBase
+{
+    private GameEngine<StationfallGame, StationfallContext> _target = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _target = GetTarget();
+    }
+
+    private async Task GoToRobotPool()
+    {
+        await _target.GetResponse("east");
+        await _target.GetResponse("north");
+    }
+
+    private async Task SelectFloyd()
+    {
+        await GoToRobotPool();
+        await _target.GetResponse("put authorization in slot");
+        await _target.GetResponse("type 3");
+    }
+
+    [TestFixture]
+    public class TheirVoices : DuffyRobotTests
+    {
+        [Test]
+        public async Task EachRobotGreetsYouInItsOwnRegister()
+        {
+            await GoToRobotPool();
+
+            (await _target.GetResponse("floyd, hello")).Should().Contain("bounces");
+            (await _target.GetResponse("rex, hello")).Should().Contain("Hey");
+            (await _target.GetResponse("helen, hello")).Should().Contain("Likewise");
+        }
+
+        [Test]
+        public async Task RexWillNotFollowSomeoneHeIsNotAssignedTo()
+        {
+            await GoToRobotPool();
+
+            (await _target.GetResponse("rex, follow me")).Should().Contain("Ain't been assigned");
+        }
+
+        [Test]
+        public async Task HelenIsInterestedInExactlyOneSubject()
+        {
+            await GoToRobotPool();
+
+            (await _target.GetResponse("helen, what do you think of the ship")).Should()
+                .Contain("sorting forms");
+        }
+    }
+
+    [TestFixture]
+    public class ChoosingOne : DuffyRobotTests
+    {
+        [Test]
+        public async Task AskingForARobotDirectly_PointsYouAtTheEquipment()
+        {
+            await GoToRobotPool();
+
+            (await _target.GetResponse("pick floyd")).Should().Contain("automated robot selection");
+        }
+
+        [Test]
+        public async Task OnceYouHaveChosen_TheOthersAreOutOfReach()
+        {
+            await SelectFloyd();
+
+            (await _target.GetResponse("take rex")).Should().Contain("can't reach");
+        }
+
+        [Test]
+        public async Task EachRobotCanStillBeExaminedByName()
+        {
+            // Floyd gave up the bare noun "robot" to stop the conversation handler hijacking commands
+            // that merely contain the word (see TheRequiredFormCommand_IsNotHijackedIntoAConversation).
+            // Naming any of them must still work.
+            await GoToRobotPool();
+
+            (await _target.GetResponse("examine floyd")).Should().Contain("Floyd");
+            (await _target.GetResponse("examine rex")).Should().Contain("Rex");
+            (await _target.GetResponse("examine helen")).Should().Contain("Helen");
+        }
+
+        [Test]
+        public async Task TheRequiredFormCommand_IsNotHijackedIntoAConversation()
+        {
+            await GoToRobotPool();
+
+            var response = await _target.GetResponse("put robot use authorization form in slot");
+
+            response.Should().Contain("Authorization approved",
+                "the command names a robot noun, but it is a command, not a conversation");
+        }
+    }
+
+    [TestFixture]
+    public class TheCompanion : DuffyRobotTests
+    {
+        [Test]
+        public async Task IsRecognisedTheFirstTimeYouSeeHim()
+        {
+            var response = await _target.GetResponse("east");
+            response.Should().NotContain("Resida");
+
+            response = await _target.GetResponse("north");
+
+            response.Should().Contain("Resida", "the reunion is the point of the room");
+            Repository.GetItem<Floyd>().HasBeenSeen.Should().BeTrue();
+        }
+
+        [Test]
+        public async Task IsOnlyRecognisedOnce()
+        {
+            await GoToRobotPool();
+
+            (await _target.GetResponse("wait")).Should().NotContain("Resida");
+        }
+
+        [Test]
+        public async Task CampaignsForTheJobWhileNobodyHasBeenChosen()
+        {
+            await GoToRobotPool();
+
+            (await _target.GetResponse("wait")).Should().Contain("pick Floyd");
+        }
+
+        [Test]
+        public async Task LooksDejected_IfYouChooseSomeoneElse()
+        {
+            await GoToRobotPool();
+            await _target.GetResponse("put authorization in slot");
+            await _target.GetResponse("type 1");
+
+            (await _target.GetResponse("examine floyd")).Should().Contain("looks at his feet");
+        }
+
+        [Test]
+        public async Task StopsCampaigningOnceYouHaveLeftTheRoom()
+        {
+            await GoToRobotPool();
+            await _target.GetResponse("wait");
+
+            await _target.GetResponse("south");
+
+            // He is still in his bin; he must not go on begging from an empty room.
+            (await _target.GetResponse("wait")).Should().NotContain("pick Floyd");
+        }
+    }
+}

--- a/Stationfall/Item/Duffy/Floyd.cs
+++ b/Stationfall/Item/Duffy/Floyd.cs
@@ -3,28 +3,102 @@ using Model.AIGeneration;
 namespace Stationfall.Item.Duffy;
 
 /// <summary>
-///     Floyd — the multiple-purpose robot from Planetfall, waiting in bin three and desperately hoping
-///     to be picked (ship.zil:279-289). He is the only correct choice: he is also the only robot who
-///     will climb into the spacetruck's second seat, which the autopilot requires before it will accept
-///     a course.
-///     TODO (Phase 3): Floyd's full companion AI — idle chatter, wandering, conversation via
-///     ICanBeTalkedTo, and the pyramid's corruption of him — is still to be ported. This is the
-///     Duffy-scoped Floyd: he can be chosen, he follows, and he takes the copilot seat.
+///     Floyd, waiting in bin three (ship.zil FLOYD-F, DESCRIBE-FLOYD, interrupts.zil I-FLOYD). He is the
+///     only right answer at the selection keypad, and the game does not tell you so — it just lets him
+///     campaign for the job while the other two stand there.
+///     TODO: Floyd's AI-driven conversation, and the rest of his behaviour beyond the ship, come with
+///     the station. This is the Duffy-scoped Floyd: he can be recognised, chosen, talked to, and
+///     followed around, and he reacts to the couple of things aboard worth reacting to.
 /// </summary>
 public class Floyd : ShipRobot
 {
+    /// <summary>
+    ///     One-shot: he only strains to see over the dashboard once (interrupts.zil PILOT-SEAT-COMMENT).
+    /// </summary>
+    [UsedImplicitly]
+    public bool HasComplainedAboutTheSeat { get; set; }
+
     public override int BinNumber => 3;
 
-    public override string[] NounsForMatching => ["floyd", "robot", "multiple purpose robot"];
+    // Deliberately does NOT claim the bare noun "robot", though the original's Floyd does. The
+    // conversation handler treats any of a character's nouns appearing anywhere in the input as
+    // addressing them, so a Floyd who answered to "robot" hijacked "put robot use authorization form
+    // in slot" - a required command - into a conversation. Rex and Helen were already qualified;
+    // Floyd now matches the same way, and the bare word is disambiguated by the room.
+    public override string[] NounsForMatching =>
+        ["floyd", "multiple purpose robot", "short robot", "third robot"];
 
-    public override string InTheBinDescription =>
-        "Bin number three holds a short robot with a hopeful expression stenciled more or less " +
-        "permanently onto his face. He notices you looking and waves both arms. ";
+    public override string InTheBinDescription => HasBeenSeen
+        ? "Bin number three holds a short robot with a hopeful expression stencilled more or less " +
+          "permanently onto his face. He notices you looking and waves both arms. "
+        : "You can't get a good look at the robot in the third bin — he's hunched in the corner with " +
+          "his back to you, apparently playing marbles. ";
 
-    public override string ExaminationDescription =>
-        "Floyd is a squat, multiple-purpose robot in a scuffed boron-titanium finish, with an " +
-        "expression of relentless good cheer. He is, by a wide margin, the friendliest thing aboard " +
-        "this ship. ";
+    /// <summary>
+    ///     How he reads depends entirely on where he stands in the selection: hopeful, chosen, or
+    ///     passed over. The dejected case is the one worth getting right.
+    /// </summary>
+    public override string ExaminationDescription
+    {
+        get
+        {
+            if (!HasBeenSeen)
+                return InTheBinDescription;
+
+            if (Repository.GetLocation<RobotPool>() == CurrentLocation && !IsSelected)
+                return AnyRobotPicked
+                    ? "Floyd sits down in bin three and looks at his feet. "
+                    : "Floyd is hopping about in bin number three with entirely unconcealed hope. ";
+
+            return "Floyd is a squat, multiple-purpose robot in a scuffed boron-titanium finish, with " +
+                   "an expression of relentless good cheer. He is, by a wide margin, the friendliest " +
+                   "thing aboard this ship. ";
+        }
+    }
+
+    protected override string GreetingResponse => "\"Hi!\" Floyd grins and bounces on the spot. ";
+
+    protected override string FollowResponse => "\"Okay!\" ";
+
+    protected override string CatchAllResponse =>
+        "\"Enough talking!\" says Floyd. \"Let's play Hider-and-Seeker!\" ";
+
+    /// <summary>
+    ///     The opening's three Floyd beats: being recognised, campaigning for the job, and — once you
+    ///     are both strapped in and moving — discovering that the seat does not fit him.
+    /// </summary>
+    public override async Task<string> Act(IContext context, IGenerationClient client)
+    {
+        if (context.CurrentLocation == CurrentLocation)
+        {
+            if (!HasBeenSeen)
+            {
+                HasBeenSeen = true;
+
+                return "\nThe third robot looks up from his marbles, scrambles to his feet and starts " +
+                       "waving both arms at once. It's Floyd — your companion from Resida. You've seen " +
+                       "him only a handful of times since he took his own assignment with the Patrol, " +
+                       "five years ago now, and he does not appear to have changed in any respect " +
+                       "whatsoever. ";
+            }
+
+            if (!IsSelected && !AnyRobotPicked)
+                return "\nFloyd jumps up and down. \"Oh boy oh boy oh boy pick Floyd pick Floyd pick " +
+                       "Floyd!\" ";
+
+            if (!HasComplainedAboutTheSeat && IsSelected &&
+                context.CurrentLocation is Spacetruck { IsInFlight: true } &&
+                context.CurrentLocation.SubLocation is SeatBase)
+            {
+                HasComplainedAboutTheSeat = true;
+
+                return "\nFloyd strains to see over the top of the dashboard. \"Boy, seats are low! " +
+                       "Floyd could sure use a phone book!\" ";
+            }
+        }
+
+        return await base.Act(context, client);
+    }
 
     protected override string FollowThePlayer(IContext context)
     {

--- a/Stationfall/Item/Duffy/Helen.cs
+++ b/Stationfall/Item/Duffy/Helen.cs
@@ -66,6 +66,14 @@ public class Helen : ShipRobot, ICanBeGivenThings
         return await base.RespondToMultiNounInteraction(action, context);
     }
 
+    protected override string GreetingResponse => "\"Likewise, I'm sure.\" ";
+
+    protected override string FollowResponse =>
+        "\"I'm to remain with whichever human I've been assigned. That's the procedure.\" ";
+
+    protected override string CatchAllResponse =>
+        "That has nothing to do with sorting forms, and Helen loses interest in you visibly. ";
+
     protected override string FollowThePlayer(IContext context)
     {
         MoveToPlayer(context);

--- a/Stationfall/Item/Duffy/Rex.cs
+++ b/Stationfall/Item/Duffy/Rex.cs
@@ -21,6 +21,15 @@ public class Rex : ShipRobot
         "Rex is an enormous lifting robot. He regards you with the blank, patient incomprehension of " +
         "sixteen tons of machinery that has never once had an idea. ";
 
+    protected override string GreetingResponse => "\"Yeah. Hey.\" ";
+
+    protected override string FollowResponse =>
+        IsSelected
+            ? "\"I go where they puts me, an' they put me with youse.\" "
+            : "\"Can't. Ain't been assigned ta youse.\" ";
+
+    protected override string CatchAllResponse => "Rex looks at you without the least sign of comprehension. ";
+
     protected override string FollowThePlayer(IContext context)
     {
         MoveToPlayer(context);

--- a/Stationfall/Item/Duffy/ShipRobot.cs
+++ b/Stationfall/Item/Duffy/ShipRobot.cs
@@ -7,7 +7,7 @@ namespace Stationfall.Item.Duffy;
 ///     requisitioned, via the selection keypad (verbs.zil ROBOT-TYPE): bin 1 is Rex, bin 2 is Helen,
 ///     bin 3 is Floyd. The chosen robot then trails the player around the ship.
 /// </summary>
-public abstract class ShipRobot : ContainerBase, ICanBeExamined, ITurnBasedActor
+public abstract class ShipRobot : ContainerBase, ICanBeExamined, ITurnBasedActor, ICanBeTalkedTo
 {
     /// <summary>
     ///     Which bin this robot occupies, and therefore the number that selects it on the keypad.
@@ -24,6 +24,64 @@ public abstract class ShipRobot : ContainerBase, ICanBeExamined, ITurnBasedActor
     ///     Shown when the player looks in this robot's bin, before selection.
     /// </summary>
     public abstract string InTheBinDescription { get; }
+
+    /// <summary>
+    ///     True once the player has laid eyes on this robot properly — the original's TOUCHBIT. Only
+    ///     the companion does anything with it, but it belongs here because it is set by simply being
+    ///     in the room with them.
+    /// </summary>
+    [UsedImplicitly]
+    public bool HasBeenSeen { get; set; }
+
+    /// <summary>
+    ///     Whether any of the three has been requisitioned yet.
+    /// </summary>
+    protected static bool AnyRobotPicked =>
+        Repository.GetItem<Rex>().IsSelected || Repository.GetItem<Helen>().IsSelected ||
+        Repository.GetItem<Floyd>().IsSelected;
+
+    /// <summary>
+    ///     A robot in its bin is behind the pool's barrier: you can look, and that is all. Once one has
+    ///     been requisitioned the others stay out of reach for good.
+    /// </summary>
+    protected bool IsWithinReach => IsSelected;
+
+    /// <summary>
+    ///     What this robot says to a greeting. Each of the three has its own voice, and that is most of
+    ///     what distinguishes them before you have to choose.
+    /// </summary>
+    protected abstract string GreetingResponse { get; }
+
+    /// <summary>
+    ///     What it says when asked to come along.
+    /// </summary>
+    protected abstract string FollowResponse { get; }
+
+    /// <summary>
+    ///     What it says to anything else. The catch-all is characterful rather than a shrug: it is the
+    ///     clearest signal of what each robot is and isn't good for.
+    /// </summary>
+    protected abstract string CatchAllResponse { get; }
+
+    /// <summary>
+    ///     Addressing a robot by name. Recognized openings get the original's canned lines; everything
+    ///     else falls to the robot's own catch-all rather than to the narrator, because these three are
+    ///     characters with fixed registers, not improvisers.
+    /// </summary>
+    public Task<string> OnBeingTalkedTo(string text, IContext context, IGenerationClient client)
+    {
+        var said = text.ToLowerInvariant();
+
+        if (said.Contains("hello") || said.Contains("hi ") || said.Trim() is "hi" or "hey" ||
+            said.Contains("greetings"))
+            return Task.FromResult(GreetingResponse);
+
+        if (said.Contains("follow") || said.Contains("come with") || said.Contains("come along") ||
+            said.Contains("walk"))
+            return Task.FromResult(FollowResponse);
+
+        return Task.FromResult(CatchAllResponse);
+    }
 
     public abstract string ExaminationDescription { get; }
 
@@ -75,6 +133,44 @@ public abstract class ShipRobot : ContainerBase, ICanBeExamined, ITurnBasedActor
     public override string GenericDescription(ILocation? currentLocation)
     {
         return Name;
+    }
+
+    public override async Task<InteractionResult?> RespondToSimpleInteraction(SimpleIntent action,
+        IContext context, IGenerationClient client, IItemProcessorFactory itemProcessorFactory)
+    {
+        // NB: no early return on a noun miss. ContainerBase offers the action to whatever this robot is
+        // carrying before considering itself, and short-circuiting here would hide those items from
+        // every verb - the same trap the Thermos fell into.
+        if (action.MatchNounAndAdjective(NounsForMatching))
+        {
+            // You cannot requisition a robot by asking for it; that is what the equipment is for, and
+            // saying so is what points the player at the keypad.
+            if (action.MatchVerb(["pick", "choose", "select", "requisition", "hire"]))
+                return new PositiveInteractionResult(PickResponse());
+
+            // Only physical contact is blocked. The original gates on TOUCHING?, not on visibility -
+            // and it matters: the passed-over robot's reaction is meant to be seen, so refusing to let
+            // the player look at them would hide the one thing choosing has consequences for.
+            var isPhysical = action.MatchVerb([
+                "take", "get", "grab", "touch", "push", "pull", "move", "kick", "shake", "hit", "kiss",
+                "attack", "kill", "turn on", "turn off", "open", "close", "hug", "tickle"
+            ]);
+
+            if (isPhysical && !IsWithinReach && AnyRobotPicked)
+                return new PositiveInteractionResult($"You can't reach {Name} from here. ");
+        }
+
+        return await base.RespondToSimpleInteraction(action, context, client, itemProcessorFactory);
+    }
+
+    private string PickResponse()
+    {
+        if (IsSelected)
+            return $"You already picked {Name}. ";
+
+        return AnyRobotPicked
+            ? $"You've already made your choice, and it wasn't {Name}. "
+            : "Use the automated robot selection equipment. ";
     }
 
     public override void Init()

--- a/Stationfall/Location/Duffy/RobotPool.cs
+++ b/Stationfall/Location/Duffy/RobotPool.cs
@@ -130,6 +130,31 @@ public class RobotPool : LocationBase
                "are a slot, for your form, and a keypad, for your selection. You can exit aft. ";
     }
 
+    /// <summary>
+    ///     Floyd only campaigns while you are standing in front of him, so he runs as an actor for
+    ///     exactly as long as you are in the room (ship.zil ROBOT-POOL-F queues his interrupt on entry
+    ///     and drops it again on the way out unless he was the one chosen).
+    /// </summary>
+    public override Task<string> AfterEnterLocation(IContext context, ILocation previousLocation,
+        IGenerationClient generationClient)
+    {
+        context.RegisterActor(Repository.GetItem<Floyd>());
+
+        return base.AfterEnterLocation(context, previousLocation, generationClient);
+    }
+
+    public override void OnLeaveLocation(IContext context, ILocation newLocation, ILocation previousLocation)
+    {
+        var floyd = Repository.GetItem<Floyd>();
+
+        // If he wasn't picked he stays behind in his bin, and must stop acting - otherwise he would go
+        // on begging from an empty room for the rest of the game.
+        if (!floyd.IsSelected)
+            context.RemoveActor(floyd);
+
+        base.OnLeaveLocation(context, newLocation, previousLocation);
+    }
+
     public override void Init()
     {
         StartWithItem<RobotPoolSlot>();

--- a/UnitTests/IntentMappings/stationfall-mappings.json
+++ b/UnitTests/IntentMappings/stationfall-mappings.json
@@ -39,6 +39,12 @@
     { "inputs": ["pour out thermos", "pour the thermos out"], "verb": "pour", "noun": "thermos" },
     { "inputs": ["examine blue soup"], "verb": "examine", "noun": "blue soup" },
     { "inputs": ["take gray goo", "take the gray goo"], "verb": "take", "noun": "gray goo" },
-    { "inputs": ["drop gray goo"], "verb": "drop", "noun": "gray goo" }
+    { "inputs": ["drop gray goo"], "verb": "drop", "noun": "gray goo" },
+    { "inputs": ["pick floyd", "choose floyd"], "verb": "pick", "noun": "floyd" },
+    { "inputs": ["pick rex", "choose rex"], "verb": "pick", "noun": "rex" },
+    { "inputs": ["examine floyd", "look at floyd"], "verb": "examine", "noun": "floyd" },
+    { "inputs": ["examine rex"], "verb": "examine", "noun": "rex" },
+    { "inputs": ["examine helen"], "verb": "examine", "noun": "helen" },
+    { "inputs": ["take rex"], "verb": "take", "noun": "rex" }
   ]
 }


### PR DESCRIPTION
## Heads up before you read the diff

The repo owner has never played Stationfall and is building this port in order to play it. **This PR body is spoiler-free; the diff is not.** See [`Docs/Stationfall-Port-Plan.md`](Docs/Stationfall-Port-Plan.md) for spoiler-free status.

## What this does

The three robots in the opening were a keypad choice with a description attached. They are characters now: each answers to its own name in its own register, asking for one by name points you at the selection equipment instead of doing nothing, and once you have chosen, the other two are out of reach.

The companion gets the opening's actual beats — being recognised, campaigning for the job, and, if you pick one of the others, sitting down and looking at his feet.

**These are canned responses, not AI.** `ICanBeTalkedTo` routes the address; `OnBeingTalkedTo` returns fixed lines chosen by keyword. That is right for two of the three — the original gives them a deliberately tiny fixed repertoire, and that limitation is the characterisation. It is *not* the end state for the companion, who should get the same AI-driven voice Planetfall's has. That is a separate change, and it is the point at which `QuirkyCompanion` should move into the shared `StellarPatrol` library — there is no sense abstracting it from one implementation.

## The bug this turned up

Making the robots talkable took the Stationfall suite from 7 seconds to 47. That was the symptom of something worse.

`ConversationHandler.FindTargetCharacter` treats **any** of a character's nouns appearing **anywhere** in the input as addressing that character. The companion claimed the bare noun `"robot"`, so `"put robot use authorization form in slot"` — a *required* command — was being pulled out of the parser and handed to him as conversation. It still happened to work, purely by luck of the fall-through.

He no longer claims generic nouns, which is how the other two were already written. There is a test that runs that exact command and asserts it stays a command.

**The engine-level greediness is deliberately left alone.** It is the real defect, but fixing it changes how Planetfall matches too, so it wants its own change rather than riding along in a content commit. It is written up in the plan.

## A correction to the plan

The plan claimed the engine had no way to address an NPC at all. It does — `ICanBeTalkedTo` and `ConversationHandler`, including handling characters who are not present. The actual gap is narrower: a character cannot *act on* a command. The plan says that now.

Reaching a robot is gated on physical contact rather than on visibility, matching the original: the passed-over companion's reaction is meant to be seen, and refusing to let the player look at him would hide the one thing that choosing has consequences for.

## Tests

| Suite | Result |
|---|---|
| Stationfall | 121 (was 109) |
| Planetfall | 3960 |
| UnitTests | 1182 |
| ZorkOne | 1782 |
| EscapeRoom | 9 |
| Console | 16 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)