### PR TITLE
Accept transferred guest game sessions

### DIFF
--- a/shared-web-types/src/utils/SessionHandler.ts
+++ b/shared-web-types/src/utils/SessionHandler.ts
@@ -2,6 +2,12 @@ export class SessionHandler {
     getSessionId(): [string, boolean] {
         let firstTime: boolean = false;
 
+        const transferredSessionId = this.consumeTransferredSessionId();
+        if (transferredSessionId) {
+            localStorage.setItem('SessionId', transferredSessionId);
+            return [transferredSessionId, false];
+        }
+
         if (!localStorage.getItem('SessionId')) {
             firstTime = true;
             localStorage.setItem('SessionId', this.generateRandomString());
@@ -31,5 +37,17 @@ export class SessionHandler {
         }
 
         return randomString;
+    }
+
+    private consumeTransferredSessionId(): string | null {
+        if (typeof window === 'undefined' || !window.location.hash.startsWith('#session=')) return null;
+
+        const transferredSessionId = new URLSearchParams(window.location.hash.slice(1)).get('session');
+        if (!transferredSessionId || !/^[A-Za-z0-9]{15}$/.test(transferredSessionId)) return null;
+
+        // The fragment is never sent to a web server. Remove it immediately after adoption so
+        // copying the address bar cannot accidentally share control of a guest game session.
+        window.history.replaceState(null, '', `${window.location.pathname}${window.location.search}`);
+        return transferredSessionId;
     }
 }

--- a/zorkweb.client/src/__tests__/SessionHandoff.test.ts
+++ b/zorkweb.client/src/__tests__/SessionHandoff.test.ts
@@ -1,0 +1,29 @@
+import {SessionHandler} from '../../../shared-web-types/src/utils/SessionHandler';
+
+describe('Unopened Worlds session handoff', () => {
+    beforeEach(() => {
+        localStorage.clear();
+        window.history.replaceState(null, '', '/');
+    });
+
+    test('adopts a valid guest session from the URL fragment and removes it from the address bar', () => {
+        window.history.replaceState(null, '', '/#session=AbCdEf123456789');
+
+        const [sessionId, firstTime] = new SessionHandler().getSessionId();
+
+        expect(sessionId).toBe('AbCdEf123456789');
+        expect(firstTime).toBe(false);
+        expect(localStorage.getItem('SessionId')).toBe('AbCdEf123456789');
+        expect(window.location.hash).toBe('');
+    });
+
+    test('ignores malformed handoff fragments', () => {
+        window.history.replaceState(null, '', '/#session=not-valid!');
+
+        const [sessionId, firstTime] = new SessionHandler().getSessionId();
+
+        expect(sessionId).toHaveLength(15);
+        expect(sessionId).not.toBe('not-valid!');
+        expect(firstTime).toBe(true);
+    });
+});


### PR DESCRIPTION
## Summary
- adopt guest Zork sessions transferred from Unopened Worlds
- pass the existing session into the full NewZork experience
- clear the transfer fragment immediately after adoption
- cover valid and malformed handoff fragments

## Verification
- targeted Jest test: 2 passed
- production Zork web client build succeeded