### PR TITLE
Measure completeness instead of asserting it, then close the opening's gaps

### DIFF
--- a/Docs/Stationfall-Port-Plan.md
+++ b/Docs/Stationfall-Port-Plan.md
@@ -71,6 +71,31 @@ bigger game.
 
 ---
 
+## The completeness bar (depth before breadth)
+
+The goal is not a game that reaches the end. It is a game whose **early parts are finished**, so the
+owner can start playing while later parts are still being built.
+
+That makes incompleteness dangerous rather than merely absent. This engine narrates with an LLM when
+nothing handles the player's input, so an unimplemented object does not go quiet — it produces a
+confident, plausible, invented answer. A player cannot tell improvised behaviour from ported
+behaviour. An unfinished region does not feel unfinished; it feels like a different game.
+
+So "finished" is a measurement, not a judgement. A region is finished when:
+
+1. Every noun the room's own prose puts in front of the player has an authored answer.
+2. Every verb the original's action routine handles for an object is handled.
+3. Every death, refusal and score trigger reachable in the region fires.
+4. **`CompletenessSweepTests` records zero narrator fall-throughs for the region.**
+
+Point (4) is the enforceable one. `GameEngine/Diagnostics/LeakRecordingGenerationClient` wraps the
+generation client and records every occasion the game had no answer of its own. Drive a region, and
+the recorded leaks *are* the to-do list.
+
+**First measurement of the opening: 53 fall-throughs** — 49 of them from nouns *every* room should
+answer for (walls, floor, ceiling, air, me, hands), which the engine has no equivalent for at all,
+and 4 room-specific. That single systemic gap is therefore the highest-value fix in the project.
+
 ## Phases
 
 ### Phase 3 — Survival and time systems

--- a/Docs/Stationfall-Port-Plan.md
+++ b/Docs/Stationfall-Port-Plan.md
@@ -92,9 +92,16 @@ Point (4) is the enforceable one. `GameEngine/Diagnostics/LeakRecordingGeneratio
 generation client and records every occasion the game had no answer of its own. Drive a region, and
 the recorded leaks *are* the to-do list.
 
-**First measurement of the opening: 53 fall-throughs** — 49 of them from nouns *every* room should
-answer for (walls, floor, ceiling, air, me, hands), which the engine has no equivalent for at all,
-and 4 room-specific. That single systemic gap is therefore the highest-value fix in the project.
+**The opening now measures zero**, and `TheOpeningLeavesNothingToTheNarrator` keeps it there. The
+first measurement was 53, of which 49 came from nouns *every* room should answer for — walls, floor,
+ceiling, air, the player's own body — which the engine had no equivalent for at all. `IInfocomGame`
+now declares `GlobalScenery`, checked after a room's own, so one system closed 92% of the gap and did
+it for Zork and Planetfall too.
+
+Note what the sweep covers today: `examine` on the nouns each room's prose puts in front of the
+player. That is the floor, not the ceiling. The next passes should widen it to the full verb set the
+original answers for, then to the objects rather than just the rooms — and each widening should be
+expected to find new gaps. A zero here means "nothing known is missing", never "nothing is missing".
 
 ## Phases
 

--- a/GameEngine/Diagnostics/LeakRecordingGenerationClient.cs
+++ b/GameEngine/Diagnostics/LeakRecordingGenerationClient.cs
@@ -1,0 +1,119 @@
+using CloudWatch;
+using CloudWatch.Model;
+using Model.AIGeneration;
+using Model.AIGeneration.Requests;
+using Model.Interface;
+
+namespace GameEngine.Diagnostics;
+
+/// <summary>
+///     Wraps a generation client and records every time the game fell through to the narrator.
+///     <para>
+///         This exists to make "is this part of the game finished?" a measurement rather than a
+///         judgement. When an object or a verb has not been implemented, the engine does not go quiet —
+///         it asks the narrator to improvise, and the narrator obliges with something plausible and
+///         wrong. A player cannot tell invented behaviour from ported behaviour, which makes an
+///         unfinished region actively misleading rather than merely incomplete.
+///     </para>
+///     <para>
+///         Point this at a region, drive it, and the recorded leaks <i>are</i> the to-do list. A region
+///         is finished when the list is empty for everything the original answers for.
+///     </para>
+///     <para>
+///         Not every leak is a defect: a few requests are legitimate narration (save and restore
+///         flavour, winning the game). <see cref="IsCompletenessLeak" /> separates those out.
+///     </para>
+/// </summary>
+public class LeakRecordingGenerationClient(IGenerationClient inner, Func<(string Input, string Location)> stamp)
+    : IGenerationClient
+{
+    private readonly List<NarrationLeak> _leaks = [];
+
+    /// <summary>
+    ///     Every fallback recorded so far, in order.
+    /// </summary>
+    public IReadOnlyList<NarrationLeak> Leaks => _leaks;
+
+    /// <summary>
+    ///     Only the fallbacks that indicate missing content. Narration the game legitimately delegates —
+    ///     save/restore flavour text, the victory message, verbosity acknowledgements — is not a gap.
+    /// </summary>
+    public IReadOnlyList<NarrationLeak> CompletenessLeaks =>
+        _leaks.Where(l => IsCompletenessLeak(l.RequestType)).ToList();
+
+    /// <summary>
+    ///     Request types that represent the game delegating on purpose rather than falling short.
+    /// </summary>
+    private static readonly string[] Legitimate =
+    [
+        nameof(AfterSaveGameRequest), nameof(BeforeSaveGameRequest), nameof(AfterRestoreGameRequest),
+        nameof(BeforeRestoreGameRequest), nameof(RestoreFailedFileNotFoundGameRequest),
+        nameof(RestoreFailedUnknownReasonGameRequest), nameof(SaveFailedUnknownReasonGameRequest),
+        nameof(WonTheGameRequest), nameof(EngineErrorRequest),
+        nameof(MaximumVerbosityRequest), nameof(MediumVerbosityRequest), nameof(MinimumVerbosityRequest),
+        nameof(MultipleCommandsRequest), nameof(CompanionRequest)
+    ];
+
+    public static bool IsCompletenessLeak(string requestType)
+    {
+        return !Legitimate.Contains(requestType);
+    }
+
+    public void Clear()
+    {
+        _leaks.Clear();
+    }
+
+    public Task<string> GenerateNarration(Request request, string systemPromptAddendum)
+    {
+        Record(request);
+        return inner.GenerateNarration(request, systemPromptAddendum);
+    }
+
+    public Task<string> GenerateCompanionSpeech(CompanionRequest request)
+    {
+        Record(request);
+        return inner.GenerateCompanionSpeech(request);
+    }
+
+    private void Record(Request request)
+    {
+        var (input, location) = stamp();
+        _leaks.Add(new NarrationLeak(input, location, request.GetType().Name, request.UserMessage));
+    }
+
+    public Action? OnGenerate
+    {
+        get => inner.OnGenerate;
+        set => inner.OnGenerate = value;
+    }
+
+    public bool IsDisabled
+    {
+        get => inner.IsDisabled;
+        set => inner.IsDisabled = value;
+    }
+
+    public string SystemPrompt
+    {
+        set => inner.SystemPrompt = value;
+    }
+
+    public List<(string, string, bool)> LastFiveInputOutputs
+    {
+        get => inner.LastFiveInputOutputs;
+        set => inner.LastFiveInputOutputs = value;
+    }
+
+    public Guid TurnCorrelationId
+    {
+        get => inner.TurnCorrelationId;
+        set => inner.TurnCorrelationId = value;
+    }
+
+    public ICloudWatchLogger<GenerationLog>? CloudWatchLogger
+    {
+        get => inner.CloudWatchLogger;
+        set => inner.CloudWatchLogger = value;
+    }
+}

--- a/GameEngine/Diagnostics/NarrationLeak.cs
+++ b/GameEngine/Diagnostics/NarrationLeak.cs
@@ -1,0 +1,10 @@
+namespace GameEngine.Diagnostics;
+
+/// <summary>
+///     One occasion on which the game had no authored answer and asked the narrator to invent one.
+/// </summary>
+/// <param name="Input">What the player typed.</param>
+/// <param name="Location">Where they were standing.</param>
+/// <param name="RequestType">Which kind of fallback fired — the most useful thing to group by.</param>
+/// <param name="Prompt">The prompt handed to the narrator, which names the noun and verb involved.</param>
+public readonly record struct NarrationLeak(string Input, string Location, string RequestType, string? Prompt);

--- a/GameEngine/Location/LocationBase.cs
+++ b/GameEngine/Location/LocationBase.cs
@@ -345,7 +345,11 @@ public abstract class LocationBase : ILocation, ICanContainItems
         // Inert scenery (issue #315). Checked AFTER real items so a genuine object that shares a noun
         // always wins. Matching the noun makes the thing "present", so an unsupported verb yields a
         // NoVerbMatch ("you can't do that to it") — never the narrator's false "no such thing is here".
-        var scenery = Scenery.FirstOrDefault(s => action.MatchNounAndAdjective(s.Nouns));
+        // The room's own scenery first, then the game's global scenery - walls, floor, ceiling, the
+        // air, the player's own body - which answer everywhere. A room that has something particular
+        // to say about its walls therefore always wins over the generic reply.
+        var scenery = Scenery.FirstOrDefault(s => action.MatchNounAndAdjective(s.Nouns))
+                      ?? context.Game.GlobalScenery.FirstOrDefault(s => action.MatchNounAndAdjective(s.Nouns));
         if (scenery is not null)
         {
             if (action.MatchVerb(Verbs.ExamineVerbs))

--- a/GameEngine/Repository.cs
+++ b/GameEngine/Repository.cs
@@ -396,6 +396,25 @@ public static class Repository
             }
         }
 
+        // Global scenery lives on the game, not on any location, so it needs collecting separately -
+        // and it is precisely the set most likely to be typed in every room.
+        foreach (var type in assembly.GetTypes())
+        {
+            if (type is not { IsClass: true, IsGenericType: false, IsAbstract: false } ||
+                !typeof(IInfocomGame).IsAssignableFrom(type))
+                continue;
+
+            try
+            {
+                if (Activator.CreateInstance(type) is IInfocomGame game)
+                    nouns.AddRange(game.GlobalScenery.SelectMany(s => s.Nouns));
+            }
+            catch
+            {
+                // A game that cannot be constructed standalone contributes no global scenery nouns.
+            }
+        }
+
         return nouns.Distinct().ToArray();
     }
 

--- a/GameEngine/Repository.cs
+++ b/GameEngine/Repository.cs
@@ -360,6 +360,45 @@ public static class Repository
     /// omitted it. Callers already have the game name available (e.g. <c>context.Game.GameName</c>).
     /// </remarks>
     /// <returns></returns>
+    /// <summary>
+    ///     Every noun the game's locations advertise as scenery. These are not items, so
+    ///     <see cref="GetNouns" /> — which reflects over ItemBase — cannot see them, and anything built
+    ///     from that list alone is blind to every piece of scenery in the game. The deterministic test
+    ///     parser is built from that list, which is why scenery appeared to answer to nothing at all
+    ///     under test while working perfectly in play.
+    /// </summary>
+    public static string[] GetSceneryNouns(string gameName)
+    {
+        var assembly = Assembly.Load(gameName);
+        var nouns = new List<string>();
+
+        foreach (var type in assembly.GetTypes())
+        {
+            if (type is not { IsClass: true, IsGenericType: false, IsAbstract: false } ||
+                !type.IsSubclassOf(typeof(LocationBase)))
+                continue;
+
+            var property = type.GetProperty("Scenery",
+                BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.FlattenHierarchy);
+
+            if (property is null)
+                continue;
+
+            try
+            {
+                var instance = Activator.CreateInstance(type);
+                if (property.GetValue(instance) is IEnumerable<SceneryItem> scenery)
+                    nouns.AddRange(scenery.SelectMany(s => s.Nouns));
+            }
+            catch
+            {
+                // A location that cannot be constructed standalone simply contributes no scenery nouns.
+            }
+        }
+
+        return nouns.Distinct().ToArray();
+    }
+
     public static string[] GetNouns(string gameName)
     {
         lock (_allNouns)

--- a/Model/Interface/IInfocomGame.cs
+++ b/Model/Interface/IInfocomGame.cs
@@ -1,3 +1,4 @@
+using Model.Location;
 namespace Model.Interface;
 
 /// <summary>
@@ -80,6 +81,17 @@ public interface IInfocomGame
     /// Listing the types here also makes a not-yet-instantiated NPC "known" despite lazy loading.
     /// Defaults to none.
     /// </summary>
+    /// <summary>
+    ///     Scenery that answers in every room: walls, floor, ceiling, the air, the player's own body.
+    ///     The originals make these global objects, so the game recognises them anywhere and gives a
+    ///     stock reply. Without them every room silently defers those nouns to the AI narrator, which
+    ///     invents an answer the player cannot distinguish from a real one - the single largest source
+    ///     of improvised narration in this engine.
+    ///     Checked only after the room's own Scenery, so a room with something particular to say about
+    ///     its walls always wins.
+    /// </summary>
+    IReadOnlyList<SceneryItem> GlobalScenery => [];
+
     IReadOnlyList<Type> TalkableCharacterTypes => [];
 
     /// <summary>

--- a/Model/Location/SceneryItem.cs
+++ b/Model/Location/SceneryItem.cs
@@ -1,4 +1,4 @@
-namespace GameEngine.Location;
+namespace Model.Location;
 
 /// <summary>
 ///     A lightweight, inert piece of room scenery: a noun the room's prose mentions but which has

--- a/Planetfall.Tests/GlobalUsings.cs
+++ b/Planetfall.Tests/GlobalUsings.cs
@@ -4,3 +4,7 @@
 // rather than in Planetfall itself. Importing it globally keeps the ~17 test files that name
 // HungerLevel/TiredLevel unchanged.
 global using StellarPatrol;
+
+// SceneryItem moved from GameEngine.Location to Model.Location so the game interface can
+// declare global scenery; Model cannot reference GameEngine.
+global using Model.Location;

--- a/Stationfall.Tests/CompletenessSweepTests.cs
+++ b/Stationfall.Tests/CompletenessSweepTests.cs
@@ -1,0 +1,89 @@
+using FluentAssertions;
+using GameEngine;
+using GameEngine.Diagnostics;
+
+namespace Stationfall.Tests;
+
+/// <summary>
+///     Measures how finished the opening is, rather than asserting a guess about it.
+///     <para>
+///         Every command below is something a curious player would plainly try. Any of them that falls
+///         through to the narrator is a gap: the engine will improvise an answer that reads exactly like
+///         a real one, so an unfinished object is worse than a missing one — the player cannot tell.
+///     </para>
+/// </summary>
+[TestFixture]
+public class CompletenessSweepTests : EngineTestsBase
+{
+    /// <summary>
+    ///     Nouns every room in the original answers for, wherever you are standing.
+    /// </summary>
+    private static readonly string[] UniversalNouns =
+        ["walls", "wall", "floor", "ceiling", "air", "me", "hands"];
+
+    /// <summary>
+    ///     The route through the opening, with the nouns each room's own prose puts in front of the
+    ///     player. A player who reads the description and types one of these words back has done
+    ///     nothing unusual, and deserves an authored answer.
+    /// </summary>
+    private static readonly (string Travel, string[] Nouns)[] OpeningRooms =
+    [
+        ("", ["door", "slot", "corridor", "deck"]),
+        ("south", ["pallets", "boxes", "forms"]),
+        ("north", []),
+        ("east", ["entrance"]),
+        ("north", ["keypad", "slot", "first bin", "second bin", "third bin", "floyd", "rex", "helen"]),
+        ("south", []),
+        ("east", ["spacetruck", "hatch"])
+    ];
+
+    private async Task<List<NarrationLeak>> SweepTheOpening()
+    {
+        var target = GetTarget();
+
+        foreach (var (travel, nouns) in OpeningRooms)
+        {
+            if (!string.IsNullOrEmpty(travel))
+                await target.GetResponse(travel);
+
+            foreach (var noun in nouns.Concat(UniversalNouns))
+                await target.GetResponse($"examine {noun}");
+        }
+
+        return LeakRecorder.CompletenessLeaks.ToList();
+    }
+
+    [Test]
+    public async Task Report_WhatTheOpeningStillLeavesToTheNarrator()
+    {
+        var leaks = await SweepTheOpening();
+
+        var byNoun = leaks
+            .GroupBy(l => $"{l.Location} :: {l.Input}")
+            .OrderBy(g => g.Key)
+            .ToList();
+
+        TestContext.Out.WriteLine($"=== {leaks.Count} narrator fall-throughs across the opening ===");
+
+        var universal = leaks.Count(l => UniversalNouns.Any(n => l.Input.EndsWith(n, StringComparison.OrdinalIgnoreCase)));
+        TestContext.Out.WriteLine($"  {universal} from nouns every room should answer for (walls/floor/ceiling/air/me/hands)");
+        TestContext.Out.WriteLine($"  {leaks.Count - universal} from nouns specific to one room");
+        TestContext.Out.WriteLine("--- room-specific gaps ---");
+        foreach (var group in byNoun.Where(g => !UniversalNouns.Any(n => g.First().Input.EndsWith(n, StringComparison.OrdinalIgnoreCase))))
+            TestContext.Out.WriteLine($"  {group.Key}");
+
+        // Reporting only. The assertion that this must reach zero is the test below, which is the one
+        // that gates "the opening is finished".
+        Assert.Pass($"{leaks.Count} gaps recorded.");
+    }
+
+    [Test]
+    [Explicit("Gates the opening as complete. Made non-Explicit once the sweep reaches zero.")]
+    public async Task TheOpeningLeavesNothingToTheNarrator()
+    {
+        var leaks = await SweepTheOpening();
+
+        leaks.Should().BeEmpty(
+            "every noun the opening's own prose puts in front of the player must have an authored answer");
+    }
+}

--- a/Stationfall.Tests/CompletenessSweepTests.cs
+++ b/Stationfall.Tests/CompletenessSweepTests.cs
@@ -77,8 +77,12 @@ public class CompletenessSweepTests : EngineTestsBase
         Assert.Pass($"{leaks.Count} gaps recorded.");
     }
 
+    /// <summary>
+    ///     The gate. While this passes, nothing in the opening is being improvised by the narrator.
+    ///     A new object or room description that names something it does not answer for will fail here,
+    ///     which is the point: content and its coverage land together or not at all.
+    /// </summary>
     [Test]
-    [Explicit("Gates the opening as complete. Made non-Explicit once the sweep reaches zero.")]
     public async Task TheOpeningLeavesNothingToTheNarrator()
     {
         var leaks = await SweepTheOpening();

--- a/Stationfall.Tests/EngineTestsBase.cs
+++ b/Stationfall.Tests/EngineTestsBase.cs
@@ -2,6 +2,7 @@ using ChatLambda;
 using CloudWatch;
 using CloudWatch.Model;
 using GameEngine;
+using GameEngine.Diagnostics;
 using GameEngine.Item;
 using Model;
 using Model.AIGeneration;
@@ -32,6 +33,12 @@ public class EngineTestsBase
 
     protected Mock<IParseConversation> ParseConversationMock { get; private set; } = null!;
 
+    /// <summary>
+    ///     Records every narrator fall-through this engine produced. See
+    ///     <see cref="LeakRecordingGenerationClient" />.
+    /// </summary>
+    protected LeakRecordingGenerationClient LeakRecorder { get; private set; } = null!;
+
     protected GameEngine<StationfallGame, StationfallContext> GetTarget(IIntentParser? parser = null)
     {
         _client = new Mock<IGenerationClient>();
@@ -59,8 +66,16 @@ public class EngineTestsBase
         ParseConversationMock.Setup(x => x.ParseAsync(It.IsAny<string>()))
             .ReturnsAsync((false, ""));
 
+        // Wrap the generation client so every fall-through to the narrator is recorded. An
+        // unimplemented object does not go quiet in this engine - it gets improvised, plausibly and
+        // wrongly - so the recorded leaks are the only reliable measure of whether a region is done.
+        GameEngine<StationfallGame, StationfallContext>? built = null;
+        LeakRecorder = new LeakRecordingGenerationClient(
+            _client.Object,
+            () => (built?.Context.LastInput ?? "(none)", built?.Context.CurrentLocation.Name ?? "(none)"));
+
         var engine = new GameEngine<StationfallGame, StationfallContext>(
-            new ItemProcessorFactory(takeAndDropParser.Object), _parser, _client.Object,
+            new ItemProcessorFactory(takeAndDropParser.Object), _parser, LeakRecorder,
             Mock.Of<ISecretsManager>(), Mock.Of<ICloudWatchLogger<TurnLog>>(), ParseConversationMock.Object);
         engine.Context.Verbosity = Verbosity.Verbose;
 
@@ -69,6 +84,7 @@ public class EngineTestsBase
         Repository.GetLocation<DeckTwelve>().Init();
         engine.Context.Init();
 
+        built = engine;
         _storedEngine = engine;
         engine.Context.LastInput = null;
         engine.Context.LastResponse = null;

--- a/Stationfall/Item/Duffy/CargoBaySpacetruck.cs
+++ b/Stationfall/Item/Duffy/CargoBaySpacetruck.cs
@@ -1,0 +1,4 @@
+namespace Stationfall.Item.Duffy;
+
+/// <summary>The truck as it sits in the Cargo Bay. See <see cref="SpacetruckExteriorBase" />.</summary>
+public class CargoBaySpacetruck : SpacetruckExteriorBase;

--- a/Stationfall/Item/Duffy/DockingBaySpacetruck.cs
+++ b/Stationfall/Item/Duffy/DockingBaySpacetruck.cs
@@ -1,0 +1,4 @@
+namespace Stationfall.Item.Duffy;
+
+/// <summary>The truck as it sits in Docking Bay #2. See <see cref="SpacetruckExteriorBase" />.</summary>
+public class DockingBaySpacetruck : SpacetruckExteriorBase;

--- a/Stationfall/Item/Duffy/SpacetruckExteriorBase.cs
+++ b/Stationfall/Item/Duffy/SpacetruckExteriorBase.cs
@@ -1,0 +1,56 @@
+using Model.AIGeneration;
+
+namespace Stationfall.Item.Duffy;
+
+/// <summary>
+///     The spacetruck seen from outside — from the cargo bay before you leave, and from the docking bay
+///     after you arrive (ship.zil SPACETRUCK-OBJECT-F). The room's prose names it, so the player will
+///     type it, and it answers for the verbs you would expect to aim at a parked vehicle.
+///     Two objects rather than one, for the same reason the hatch is three: one object cannot honestly
+///     be in two rooms. It holds no state, so nothing is split by splitting it.
+/// </summary>
+public abstract class SpacetruckExteriorBase : ItemBase, ICanBeExamined
+{
+    public override string[] NounsForMatching => ["spacetruck", "truck", "spacecraft", "rig"];
+
+    public override string CannotBeTakenDescription => "It's a twelve-meter spacecraft. ";
+
+    public string ExaminationDescription
+    {
+        get
+        {
+            var open = Repository.GetItem<SpacetruckHatch>().IsOpen;
+
+            return "A twelve-meter rig, the largest Class Three spacecraft made — a working truck, " +
+                   $"scuffed and unglamorous. Its hatch is {(open ? "open" : "closed")}. ";
+        }
+    }
+
+    public override string NeverPickedUpDescription(ILocation currentLocation)
+    {
+        return string.Empty;
+    }
+
+    public override async Task<InteractionResult?> RespondToSimpleInteraction(SimpleIntent action,
+        IContext context, IGenerationClient client, IItemProcessorFactory itemProcessorFactory)
+    {
+        if (action.MatchNounAndAdjective(NounsForMatching))
+        {
+            // Opening "the truck" means opening its hatch; there is nothing else on it to open.
+            if (action.MatchVerb(["open", "close", "shut", "unseal"]))
+                return await Repository.GetItem<SpacetruckHatch>()
+                    .RespondToSimpleInteraction(action, context, client, itemProcessorFactory);
+
+            if (action.MatchVerb(["launch", "start", "drive", "fly", "turn on"]))
+                return new PositiveInteractionResult("You're not even in it! ");
+
+            if (action.MatchVerb(["enter", "board", "get in", "climb in"]))
+                return new PositiveInteractionResult(
+                    Repository.GetItem<SpacetruckHatch>().IsOpen
+                        ? "You'll have to go in. "
+                        : "The spacetruck's hatch is closed. ");
+        }
+
+        return await base.RespondToSimpleInteraction(action, context, client, itemProcessorFactory);
+    }
+}

--- a/Stationfall/Location/Duffy/CargoBay.cs
+++ b/Stationfall/Location/Duffy/CargoBay.cs
@@ -84,5 +84,6 @@ public class CargoBay : LocationBase
     public override void Init()
     {
         StartWithItem<SpacetruckHatch>();
+        StartWithItem<CargoBaySpacetruck>();
     }
 }

--- a/Stationfall/Location/Duffy/CargoBayEntrance.cs
+++ b/Stationfall/Location/Duffy/CargoBayEntrance.cs
@@ -12,6 +12,14 @@ public class CargoBayEntrance : LocationBase
 
     public override string[] NounsForMatching => ["cargo bay entrance", "entrance"];
 
+    protected override IReadOnlyList<SceneryItem> Scenery =>
+    [
+        new(["entrance", "cargo bay entrance", "opening"],
+            "The corridor ends in a broad cargo opening to starboard, wide enough to take a loaded " +
+            "pallet, and a smaller doorway forward. ",
+            "The entrance is part of the ship. ")
+    ];
+
     protected override Dictionary<Direction, MovementParameters> Map(IContext context)
     {
         return new Dictionary<Direction, MovementParameters>

--- a/Stationfall/Location/Duffy/DeckTwelve.cs
+++ b/Stationfall/Location/Duffy/DeckTwelve.cs
@@ -14,6 +14,14 @@ public class DeckTwelve : LocationBase
 
     public override string[] NounsForMatching => ["deck 12", "deck twelve"];
 
+    protected override IReadOnlyList<SceneryItem> Scenery =>
+    [
+        new(["corridor", "hallway", "passage"],
+            "The administrative corridor runs to starboard, lined with identical doors behind which " +
+            "identical people are filling in identical forms. ",
+            "The corridor is part of the ship. ")
+    ];
+
     protected override Dictionary<Direction, MovementParameters> Map(IContext context)
     {
         return new Dictionary<Direction, MovementParameters>

--- a/Stationfall/Location/Duffy/DockingBayTwo.cs
+++ b/Stationfall/Location/Duffy/DockingBayTwo.cs
@@ -52,5 +52,6 @@ public class DockingBayTwo : LocationBase
     public override void Init()
     {
         StartWithItem<DockingBayHatch>();
+        StartWithItem<DockingBaySpacetruck>();
     }
 }

--- a/Stationfall/StationfallGame.cs
+++ b/Stationfall/StationfallGame.cs
@@ -18,6 +18,42 @@ public class StationfallGame : IInfocomGame
 
     // TODO (Phase 3): Floyd returns in Stationfall — add typeof(Floyd) here once ported so
     // "Floyd, ..." is recognized even when he isn't in the room (see PlanetfallGame).
+    /// <summary>
+    ///     Nouns that answer in every room. The original makes these global objects, so it recognises
+    ///     them anywhere; without them each one silently becomes an improvised answer from the narrator,
+    ///     which is indistinguishable from a real one and therefore worse than nothing. A room with
+    ///     something particular to say about its own walls overrides these.
+    /// </summary>
+    public IReadOnlyList<SceneryItem> GlobalScenery =>
+    [
+        new(["wall", "walls", "bulkhead", "bulkheads"],
+            "Standard Patrol bulkhead: riveted plate, painted the regulation grey that the Patrol " +
+            "believes is restful. ",
+            "The bulkheads are structural, and you are not. "),
+        new(["floor", "ground", "deck", "deck plates", "plating"],
+            "Ridged metal decking, worn shiny down the middle where everyone walks. ",
+            "The deck stays where it is. "),
+        new(["ceiling", "roof", "overhead"],
+            "Ducting, cable runs, and a row of light panels, one of which is flickering in a way " +
+            "nobody has filed about. ",
+            "It's a good deal further up than you can reach. "),
+        new(["air", "atmosphere"],
+            "Recycled, faintly metallic, and a little too dry — the smell of every ship and station " +
+            "you have ever served on. ",
+            "You are, in fact, already breathing it. "),
+        new(["me", "myself", "self", "my body"],
+            "You are an Ensign Seventh Class in the Stellar Patrol, in a uniform you have kept " +
+            "regulation-neat for reasons that are becoming harder to articulate. ",
+            "You've got yourself already. "),
+        new(["hands", "hand", "fingers"],
+            "Two of them, the regulation number, and presently empty of anything interesting. ",
+            "They're attached. "),
+        new(["uniform patch", "insignia", "rank insignia"],
+            "The single dull chevron of an Ensign Seventh Class. You have been assured it gets " +
+            "better. ",
+            "It's stitched on. ")
+    ];
+
     public IReadOnlyList<Type> TalkableCharacterTypes => [];
 
     public string StartText => """

--- a/UnitTests/TestParser.cs
+++ b/UnitTests/TestParser.cs
@@ -45,7 +45,13 @@ public class TestParser : IntentParser
             "games", "tapes", "controls", "control panel", "light", "red light", "equipment", "rainbow"
         ];
 
-        _allNouns = _allNouns.Union(specialNouns).ToArray();
+        // Scenery nouns too. Without these the parser is blind to every noun a room advertises but
+        // does not back with an item, so scenery answers to nothing under test while working fine in
+        // play - which made a whole class of content look implemented when it had never been exercised.
+        _allNouns = _allNouns
+            .Union(specialNouns)
+            .Union(Repository.GetSceneryNouns(gameName))
+            .ToArray();
 
         // Initialize the JSON-based resolver for O(1) lookups. This must follow the game, not be
         // pinned to "base": the loader already supports a per-game overlay that extends base

--- a/UnitTests/ZorkSceneryInvariantTests.cs
+++ b/UnitTests/ZorkSceneryInvariantTests.cs
@@ -1,3 +1,4 @@
+using Model.Location;
 using System.Reflection;
 using GameEngine;
 using GameEngine.Item;

--- a/shared-web-types/src/utils/SessionHandler.ts
+++ b/shared-web-types/src/utils/SessionHandler.ts
@@ -40,14 +40,21 @@ export class SessionHandler {
     }
 
     private consumeTransferredSessionId(): string | null {
-        if (typeof window === 'undefined' || !window.location.hash.startsWith('#session=')) return null;
+        if (typeof window === 'undefined' || !window.location.hash.startsWith('#session='))
+            return null;
 
-        const transferredSessionId = new URLSearchParams(window.location.hash.slice(1)).get('session');
+        const transferredSessionId = new URLSearchParams(window.location.hash.slice(1)).get(
+            'session',
+        );
         if (!transferredSessionId || !/^[A-Za-z0-9]{15}$/.test(transferredSessionId)) return null;
 
         // The fragment is never sent to a web server. Remove it immediately after adoption so
         // copying the address bar cannot accidentally share control of a guest game session.
-        window.history.replaceState(null, '', `${window.location.pathname}${window.location.search}`);
+        window.history.replaceState(
+            null,
+            '',
+            `${window.location.pathname}${window.location.search}`,
+        );
         return transferredSessionId;
     }
 }


### PR DESCRIPTION
## Heads up before you read the diff

The repo owner has never played Stationfall and is building this port in order to play it. **This PR body is spoiler-free; the diff is not.** See [`Docs/Stationfall-Port-Plan.md`](Docs/Stationfall-Port-Plan.md) for spoiler-free status.

## Why

The goal for this port is depth before breadth — the early parts finished well enough to *play*, while later parts are still being built. That makes incompleteness dangerous rather than merely absent.

This engine narrates with an LLM whenever nothing handles the player's input. So an unimplemented object doesn't go quiet — it gets a confident, plausible, **invented** answer, and a player cannot tell improvised behaviour from ported behaviour. An unfinished region doesn't feel unfinished. It feels like a different game.

So this makes "is it finished?" a measurement.

## The detector

`LeakRecordingGenerationClient` wraps the generation client and records every occasion the game fell through to the narrator, separating those from the handful of places it legitimately delegates (save/restore flavour, the victory message). Drive a region, and the recorded leaks *are* the to-do list.

**First measurement of the opening: 53 fall-throughs.** 49 of them from a single missing capability. Not a split I would have guessed correctly — I'd have assumed the gaps were scattered across objects.

## Closing them

`IInfocomGame` now declares `GlobalScenery` — nouns that answer in every room: walls, floor, ceiling, the air, the player's own body. The originals make these global objects, so the game recognises them anywhere and gives a stock reply. This engine had no equivalent, so **every room in every game** quietly handed them to the narrator. A room's own `Scenery` is still checked first, so a room with something particular to say about its walls always wins. Zork and Planetfall gain the capability; only Stationfall populates it here.

The remaining four were content — including one worth naming: the spacetruck had **no object outside the truck at all**, despite two rooms' prose naming it. That was identified during an earlier pass and then simply not built. Nothing but the measurement would have caught it.

**53 → 0.** `TheOpeningLeavesNothingToTheNarrator` is a live gate now, not `[Explicit]`: a new object or room description that names something it doesn't answer for fails the build, so content and its coverage land together.

## Two things this turned up on the way

**Scenery has been shipping untested in every game.** The deterministic test parser builds its vocabulary by reflecting over items only, so it could not see a single noun a room advertises as scenery. Scenery answered to nothing under test while working fine in play. `Repository.GetSceneryNouns` now enumerates them (locations *and* global) and the parser includes them.

**`SceneryItem` moved** from `GameEngine.Location` to `Model.Location`. `Model` cannot reference `GameEngine`, and the game interface has to be able to declare scenery. It is a pure data record, so this is where it belonged anyway.

## What the zero does NOT mean

Recorded in the plan next to the number, so it can't be over-read: the sweep currently tests **`examine` only**, on **nouns the room's own prose raises**. That is the floor, not the ceiling. Widening it to the full verb set, and to objects rather than rooms, should be *expected* to find new gaps — and if a widening finds none, that is evidence the sweep is too narrow rather than that the game is done.

**Zero means nothing known is missing.**

## Tests

| Suite | Result |
|---|---|
| Stationfall | 123 |
| Planetfall | 4010 |
| UnitTests | 1213 |
| ZorkOne | 1782 |
| EscapeRoom | 9 |
| Console | 16 |

Verified after rebasing onto #560, so the gate is green against the robot work that landed after it was written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)