### PR TITLE
Surface the companion Lambda's own error instead of masking it as an NRE (#562)

### DIFF
--- a/ChatLambda/ChatWithCompanion.cs
+++ b/ChatLambda/ChatWithCompanion.cs
@@ -90,10 +90,23 @@ public abstract class ChatWithCompanion
             if (lambdaResponse == null)
                 throw new Exception("Failed to deserialize Lambda response");
 
+            // The AWS invocation can succeed (outer HTTP 200) while the Lambda itself reports a
+            // failure in its OWN envelope - e.g. {"statusCode":500,"body":"{\"error\":\"Error code:
+            // 404\"}"} when its upstream OpenAI call fails. Surface that verbatim instead of
+            // pressing on to dereference a body that never carried a result: the old code did the
+            // latter and threw a NullReferenceException, which masked the real cause and reached the
+            // player as the generic "Floyd doesn't understand" fallback (issue #562).
+            if (lambdaResponse.StatusCode is < 200 or >= 300)
+                throw new Exception(
+                    $"{AssistantName} Lambda reported status {lambdaResponse.StatusCode}: {lambdaResponse.Body}");
+
             // Parse the body content (which is a JSON string)
             var bodyContent = JsonSerializer.Deserialize<BodyContent>(lambdaResponse.Body);
 
-            if (bodyContent?.Results.Response == null)
+            // Null-safe through Results as well: an error or otherwise degenerate body deserializes
+            // to a BodyContent whose Results is null, so the '?.' has to guard THAT hop, not just
+            // bodyContent - guarding only the first hop was the NullReferenceException above.
+            if (bodyContent?.Results?.Response == null)
                 throw new Exception("Failed to extract message from Lambda response");
 
             // Map the internal metadata to the public metadata type
@@ -120,7 +133,7 @@ public abstract class ChatWithCompanion
 
     private record BodyContent(
         [property: JsonPropertyName("results")]
-        Results Results
+        Results? Results
     );
 
     [UsedImplicitly]

--- a/Planetfall.Tests/FloydTests.cs
+++ b/Planetfall.Tests/FloydTests.cs
@@ -2965,4 +2965,42 @@ public class FloydTests : EngineTestsBase
     }
 
     #endregion
+
+    #region Small Door Phrasings (issue #562 follow-up)
+
+    /// <summary>
+    /// The Floyd Lambda has no room context, so it cannot know that the Repair Room's little opening
+    /// lies north: "go through the little door" comes back as GoSomewhere with direction
+    /// "little door", not "north". This layer DOES know the room, so it is the right place to accept
+    /// the phrasings a player naturally uses for the opening they can see in front of them.
+    /// </summary>
+    private static Mock<IChatWithFloyd> FloydAnsweringGoSomewhere(string spoken, string direction)
+    {
+        var mock = new Mock<IChatWithFloyd>();
+        mock.Setup(s => s.AskFloydAsync(spoken)).ReturnsAsync(new CompanionResponse(
+            "Floyd's response",
+            new CompanionMetadata("GoSomewhere", new Dictionary<string, object> { { "direction", direction } })));
+        return mock;
+    }
+
+    [TestCase("go through the little door", "little door")]
+    [TestCase("go through the door", "door")]
+    [TestCase("squeeze through the opening", "opening")]
+    [TestCase("go into the small opening", "small opening")]
+    public async Task SmallDoor_DoorAndOpeningPhrasings_RunTheExplorationLikeNorth(string spoken, string direction)
+    {
+        var target = GetTarget();
+        StartHere<RepairRoom>();
+        var floyd = GetItem<Floyd>();
+        floyd.IsOn = true;
+        floyd.ChatWithFloyd = FloydAnsweringGoSomewhere(spoken, direction).Object;
+        GetLocation<RepairRoom>().ItemPlacedHere(floyd);
+
+        var response = await target.GetResponse($"floyd, {spoken}");
+
+        response.Should().Contain("squeezes through");
+        floyd.HasEverGoneThroughTheLittleDoor.Should().BeTrue();
+    }
+
+    #endregion
 }

--- a/Planetfall.Tests/FloydTests.cs
+++ b/Planetfall.Tests/FloydTests.cs
@@ -2954,6 +2954,8 @@ public class FloydTests : EngineTestsBase
         StartHere<RepairRoom>();
         var floyd = GetItem<Floyd>();
         floyd.IsOn = true;
+        // The canonical precondition: Floyd has been through the little door and found the board.
+        floyd.HasEverGoneThroughTheLittleDoor = true;
         floyd.ChatWithFloyd = FloydAnsweringPickUpBoard().Object;
         GetLocation<RepairRoom>().ItemPlacedHere(floyd);
 
@@ -2962,6 +2964,30 @@ public class FloydTests : EngineTestsBase
         response.Should().Contain("If you say so");
         target.Context.Items.Should().Contain(GetItem<ShinyFromitzBoard>());
         floyd.HasGottenTheFromitzBoard.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// The board is not in play until Floyd has been through the little door and found it. In the
+    /// original, asking him to fetch it before then gets a puzzled "What fromitz board?" - the board
+    /// is INVISIBLE until discovered (comptwo.zabstr:68; compone.zil:1904). The port granted it
+    /// immediately, letting a player skip the discovery sequence entirely.
+    /// </summary>
+    [Test]
+    public async Task FromitzBoardRetrieval_BeforeFloydHasGoneThroughTheDoor_HeDoesNotKnowWhatBoardYouMean()
+    {
+        var target = GetTarget();
+        StartHere<RepairRoom>();
+        var floyd = GetItem<Floyd>();
+        floyd.IsOn = true;
+        floyd.HasEverGoneThroughTheLittleDoor = false;
+        floyd.ChatWithFloyd = FloydAnsweringPickUpBoard().Object;
+        GetLocation<RepairRoom>().ItemPlacedHere(floyd);
+
+        var response = await target.GetResponse("floyd, take board");
+
+        response.Should().Contain("What fromitz board?");
+        target.Context.Items.Should().NotContain(GetItem<ShinyFromitzBoard>());
+        floyd.HasGottenTheFromitzBoard.Should().BeFalse();
     }
 
     #endregion

--- a/Planetfall.Tests/SleepEngineTests.cs
+++ b/Planetfall.Tests/SleepEngineTests.cs
@@ -845,11 +845,26 @@ public class SleepEngineTests : EngineTestsBase
         pfContext.Day = 1;
         pfContext.SleepNotifications.QueueFallAsleep(pfContext.CurrentTime);
 
-        var result = SleepEngine.ProcessFallAsleep(pfContext);
+        // HasEverBeenOn (required for this scenario) also arms the 13% Floyd DREAM, whose text names
+        // him - nothing to do with the greeting under test, but enough to trip NotContain("Floyd")
+        // about one run in eight. Pin the static chooser (RollDice(100) > 60 skips every dream) so
+        // the turn is deterministic, and restore the real chooser afterward - per CLAUDE.md's
+        // mock-IRandomChooser rule, and exactly as the sibling tests in this fixture do.
+        var mockChooser = new Mock<IRandomChooser>();
+        mockChooser.Setup(c => c.RollDice(100)).Returns(90);
+        SleepEngine.Chooser = mockChooser.Object;
+        try
+        {
+            var result = SleepEngine.ProcessFallAsleep(pfContext);
 
-        result.Should().NotContain("lazy bones");
-        result.Should().NotContain("Let's explore around some more");
-        result.Should().NotContain("Floyd");
+            result.Should().NotContain("lazy bones");
+            result.Should().NotContain("Let's explore around some more");
+            result.Should().NotContain("Floyd");
+        }
+        finally
+        {
+            SleepEngine.Chooser = new GameEngine.RandomChooser();
+        }
     }
 
     // The other half of the same guard, and the half that corrupts state rather than just tone: the

--- a/Planetfall/Item/Kalamontee/Mech/FloydPart/FloydConstants.cs
+++ b/Planetfall/Item/Kalamontee/Mech/FloydPart/FloydConstants.cs
@@ -146,6 +146,13 @@ public static class FloydConstants
     internal const string AlreadyGotTheFromitzBoard =
         "Floyd looks half-bored and half-annoyed. \"Floyd already did that. How about some leap-frogger?\"";
 
+    /// <summary>
+    /// Asked to fetch the board before he has been through the little door and found it. The board
+    /// is not in play yet - INVISIBLE until discovered in the original (comptwo.zabstr:68) - so he
+    /// has no idea what you mean (compone.zil:1904).
+    /// </summary>
+    internal const string WhatFromitzBoard = "\"Huh?\" asks Floyd. \"What fromitz board?\"";
+
     internal const string GoNorth =
         "Floyd squeezes through the opening and is gone for quite a while. You hear thudding noises and squeals " +
         "of enjoyment. After a while the noise stops, and Floyd emerges, looking downcast. \"Floyd found a rubber " +

--- a/Planetfall/Item/Kalamontee/Mech/FloydPart/FloydLocationBehaviors.cs
+++ b/Planetfall/Item/Kalamontee/Mech/FloydPart/FloydLocationBehaviors.cs
@@ -6,6 +6,19 @@ namespace Planetfall.Item.Kalamontee.Mech.FloydPart;
 
 public class FloydLocationBehaviors(Floyd floyd)
 {
+    /// <summary>
+    /// The ways a player names the Repair Room's little opening. The Floyd Lambda has no room
+    /// context, so "go through the little door" comes back as GoSomewhere with direction
+    /// "little door", not "north" - only this layer knows the opening lies north, so only this
+    /// layer can accept the phrasings for the thing the player can actually see (issue #562
+    /// follow-up). "n" is accepted as defense in depth: the prompt normalizes abbreviations, but a
+    /// model that doesn't (gpt-5.4 was measured emitting "n") must not silently break the puzzle.
+    /// </summary>
+    private static readonly HashSet<string> SmallDoorDirections = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "north", "n", "door", "little door", "small door", "opening", "small opening", "little opening"
+    };
+
     public string? HandleSpecificInteraction(CompanionResponse companionResponse, IContext context)
     {
         // For now, the only custom interaction is when Floyd is in the Repair Room
@@ -18,7 +31,8 @@ public class FloydLocationBehaviors(Floyd floyd)
             return HandleFromitzBoardRetrieval(context);
 
         if (companionResponse.Metadata?.AssistantType == "GoSomewhere" &&
-            companionResponse.Metadata.Parameters?.FirstOrDefault().Value?.ToString() == "north")
+            SmallDoorDirections.Contains(
+                companionResponse.Metadata.Parameters?.FirstOrDefault().Value?.ToString()?.Trim() ?? ""))
             return HandleSmallDoorExploration(context);
 
         return null;

--- a/Planetfall/Item/Kalamontee/Mech/FloydPart/FloydLocationBehaviors.cs
+++ b/Planetfall/Item/Kalamontee/Mech/FloydPart/FloydLocationBehaviors.cs
@@ -48,6 +48,14 @@ public class FloydLocationBehaviors(Floyd floyd)
         if (floyd.HasGottenTheFromitzBoard)
             return FloydConstants.AlreadyGotTheFromitzBoard;
 
+        // The board is not in play until Floyd has been through the little door and found it: the
+        // original keeps it INVISIBLE until then (comptwo.zabstr:68) and answers "What fromitz
+        // board?" (compone.zil:1904). Granting it regardless let a player skip the discovery
+        // sequence entirely. Checked AFTER the already-got guard, mirroring the original's order, so
+        // a save that somehow holds the board without the flag still gets "already did that".
+        if (!floyd.HasEverGoneThroughTheLittleDoor)
+            return FloydConstants.WhatFromitzBoard;
+
         context.ItemPlacedHere<ShinyFromitzBoard>();
         floyd.HasGottenTheFromitzBoard = true;
         return FloydConstants.GetTheFromitzBoard;

--- a/UnitTests/LambdaChat/ChatWithFloydTests.cs
+++ b/UnitTests/LambdaChat/ChatWithFloydTests.cs
@@ -246,6 +246,43 @@ public class ChatWithFloydTests
     }
 
     [Test]
+    public void AskFloydAsync_WhenLambdaEnvelopeReportsError_SurfacesThatError_NotANullReference()
+    {
+        // The AWS invocation itself succeeds (outer HTTP 200), but the Lambda's OWN envelope
+        // reports a failure. This is exactly what prod returned after OpenAI retired the Assistants
+        // API that the Floyd Lambda is built on (see issue #562):
+        //   {"statusCode":500,"body":"{\"error\":\"Error code: 404\"}"}
+        // The old code never inspected the inner statusCode and pressed on to dereference a body
+        // that carried no "results" - `bodyContent?.Results.Response` guards bodyContent but NOT
+        // Results - throwing a NullReferenceException. That masked the real cause and surfaced to
+        // the player as the generic "Floyd doesn't understand" fallback. The client must instead
+        // surface the actual error so an outage is diagnosable.
+        var responseJson = """
+        {
+          "statusCode": 500,
+          "body": "{\"error\": \"Error code: 404\"}"
+        }
+        """;
+
+        var invokeResponse = new InvokeResponse
+        {
+            StatusCode = 200,
+            Payload = new MemoryStream(Encoding.UTF8.GetBytes(responseJson))
+        };
+
+        _mockLambdaClient
+            .Setup(x => x.InvokeAsync(It.IsAny<InvokeRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(invokeResponse);
+
+        var target = new ChatWithFloyd(_mockLambdaClient.Object);
+
+        var ex = Assert.ThrowsAsync<Exception>(async () => await target.AskFloydAsync("floyd, take board"));
+        ex!.Message.Should().Contain("500");
+        ex.Message.Should().Contain("Error code: 404");
+        ex.Message.Should().NotContain("Object reference");
+    }
+
+    [Test]
     public async Task AskFloydAsync_SendsCorrectRequestPayload()
     {
         // Arrange


### PR DESCRIPTION
Refs #562.

## The actual root cause of #562
#562 reports every `floyd, <verb>` command silently no-op'ing and attributes it to a regressed companion-command parser/router. The engine routing was never broken — 139 `FloydTests` pass, including three that drive `floyd, take board` end-to-end into the fromitz-board grant. The narrator-OFF no-ops in the report are the intended generation kill-switch (`ConversationHandler.cs:69`).

What actually happened: OpenAI **sunset the Assistants API on 2026-08-26**, and the Floyd companion Lambda (`arsindelve/Floyd`) was built entirely on it. Every call now returns the Lambda's own error envelope, `{"statusCode":500,"body":"{\"error\":\"Error code: 404\"}"}`. That Lambda has been migrated to Chat Completions in arsindelve/Floyd#12 and **deployed** — Floyd's commands work in prod again.

## 1. Surface the Lambda's own error instead of masking it as an NRE
`ChatWithCompanion.AskCompanionAsync` never inspected the Lambda's inner `statusCode` and pressed on to dereference a body that carried no `results` — `bodyContent?.Results.Response` guards `bodyContent` but **not** `Results` — so it threw a `NullReferenceException`. That masked the real error and reached the player as the generic "Floyd tilts his head… doesn't seem to understand" fallback, which is exactly why the outage read as a parser bug.

- Check the inner `statusCode` and surface its body verbatim (`"floyd Lambda reported status 500: {…Error code: 404}"`).
- Make the `Results` hop null-safe as defense in depth.
- Reproducing test (`AskFloydAsync_WhenLambdaEnvelopeReportsError_SurfacesThatError_NotANullReference`) — red on the NRE message, green after. `UnitTests` 1214 ✓.

## 2. Accept door/opening phrasings for the Repair Room's little door
The Lambda has no room context, so `"go through the little door"` arrives as `GoSomewhere` with direction `"little door"`, not `"north"`, and `HandleSmallDoorExploration` never fired — a player who said the natural thing instead of the walkthrough's `go north` got only a redirect. This layer *does* know the room, so it now accepts `north | n | door | little door | small door | opening | small opening | little opening`. (`n` is defense in depth — gpt-5.4 was measured emitting the abbreviation.) The Lambda-side counterpart (squeezing/crawling through a door or opening classifies as movement) is arsindelve/Floyd `5f85e20`, already deployed. The ZIL corroborates the phrasing: the original's door routine hangs off `<VERB? THROUGH>`.

- Reproducing tests for four phrasings — red on `Expected … to contain "squeezes through"`, green after.

## 3. Don't hand over the fromitz board before Floyd has found it (ZIL fidelity)
In the original, `floyd, take board` *before* `floyd, go north` gets `"Huh?" asks Floyd. "What fromitz board?"` (`compone.zil:1904`) — the board is `INVISIBLE` until the door sequence reveals it (`comptwo.zabstr:68`). The port granted it immediately, letting a player skip the discovery scene. The grant is now gated on `HasEverGoneThroughTheLittleDoor`, checked *after* the already-got guard to mirror the original's three-way order (already fetched → "already did that"; reported → "if you say so"; else → "what board?"), so a pre-fix save that holds the board without the flag still gets "already did that."

- Reproducing test — red on the full grant text, green after.

## 4. Make the dead-Floyd wake-up test deterministic
`WakeUp_FloydIsDead_DoesNotGreetThePlayer` left the static `SleepEngine.Chooser` on the real `RandomChooser`. The scenario requires `HasEverBeenOn`, which also arms the 13% Floyd *dream* whose text names him, so `NotContain("Floyd")` tripped about one run in eight on a dream unrelated to the greeting under test (it surfaced as 1/4014 in two of five full-suite runs while verifying this PR). Now pins the chooser to a mock that skips every dream and restores it in a `finally`, exactly as the fixture's sibling tests already do. The dream itself is untouched — dreaming of a dead friend is right.

- Verified 10/10 runs of the previously flaky test; `Planetfall.Tests` 4015 ✓.

Verified against the ZIL while here: the board's `(ADJECTIVE SHINY GOOD SEVENTEEN CENTIMETER FROMITZ)` (`comptwo.zabstr:67`) confirms bare `shiny` in `ShinyFromitzBoard`'s noun list is canonical and should stay; the Lambda prompt is what guards against emitting a bare adjective.

🤖 Generated with [Claude Code](https://claude.com/claude-code)