### PR TITLE
Format SessionHandler.ts so web-lint passes on main

### DIFF
--- a/shared-web-types/src/utils/SessionHandler.ts
+++ b/shared-web-types/src/utils/SessionHandler.ts
@@ -40,14 +40,21 @@ export class SessionHandler {
     }
 
     private consumeTransferredSessionId(): string | null {
-        if (typeof window === 'undefined' || !window.location.hash.startsWith('#session=')) return null;
+        if (typeof window === 'undefined' || !window.location.hash.startsWith('#session='))
+            return null;
 
-        const transferredSessionId = new URLSearchParams(window.location.hash.slice(1)).get('session');
+        const transferredSessionId = new URLSearchParams(window.location.hash.slice(1)).get(
+            'session',
+        );
         if (!transferredSessionId || !/^[A-Za-z0-9]{15}$/.test(transferredSessionId)) return null;
 
         // The fragment is never sent to a web server. Remove it immediately after adoption so
         // copying the address bar cannot accidentally share control of a guest game session.
-        window.history.replaceState(null, '', `${window.location.pathname}${window.location.search}`);
+        window.history.replaceState(
+            null,
+            '',
+            `${window.location.pathname}${window.location.search}`,
+        );
         return transferredSessionId;
     }
 }


### PR DESCRIPTION
## Summary

Restores the `web-lint` check, which has been red on `main` since 307c9e0 (#561 "Accept transferred guest game sessions", 2026-09-02). It was last green on 263d79e (2026-08-22).

The failing step is "Prettier formatting check" (`npm run format:check`), and it reports exactly one file:

```
[warn] shared-web-types/src/utils/SessionHandler.ts
[warn] Code style issues found in the above file. Run Prettier with --write to fix.
```

## Change

This PR is the output of `npx prettier --write shared-web-types/src/utils/SessionHandler.ts` using the repo's own Prettier config and toolchain (`npm ci --legacy-peer-deps`, same as CI). Prettier wrapped three over-long lines in `consumeTransferredSessionId()` and added its configured trailing commas. **Formatting only, no logic change** — the before/after are byte-identical once whitespace and trailing commas are stripped.

## Verification

- `npm run format:check` on `main` locally reproduces the CI failure on this one file.
- After the change, `npm run format:check` passes: "All matched files use Prettier code style!"
- `git diff` reviewed: 1 file, 10 insertions / 3 deletions, all line wrapping.

## Context

Noticed while merging #564 (C#-only changes for #562), which inherited the red check from `main` and was merged with `--admin` over it. Nothing in #564 touches web-client files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
