### PR TITLE
Read the OpenAI key from Secrets Manager when the env var is absent

### DIFF
--- a/EscapeRoom-Lambda/src/EscapeRoom-Lambda/LambdaEntryPoint.cs
+++ b/EscapeRoom-Lambda/src/EscapeRoom-Lambda/LambdaEntryPoint.cs
@@ -1,4 +1,5 @@
 using Amazon.Lambda.AspNetCoreServer;
+using GameEngine.Web;
 
 namespace EscapeRoom_Lambda;
 
@@ -29,6 +30,11 @@ public class LambdaEntryPoint :
     /// <param name="builder">The IWebHostBuilder to configure.</param>
     protected override void Init(IWebHostBuilder builder)
     {
+        // Must happen before the host builds the OpenAI client. OPEN_AI_KEY is not declared in any
+        // serverless.template, so a freshly created stack has no such env var and every request 502s
+        // during startup; this falls back to Secrets Manager. See OpenAiKeyResolver.
+        OpenAiKeyResolver.EnsureKeyAvailableAtStartup();
+
         builder
             .UseStartup<Startup>();
     }

--- a/GameEngine/Web/OpenAiKeyResolver.cs
+++ b/GameEngine/Web/OpenAiKeyResolver.cs
@@ -1,0 +1,81 @@
+using Microsoft.Extensions.Logging;
+using Model.Interface;
+using SecretsManager;
+
+namespace GameEngine.Web;
+
+/// <summary>
+///     Resolves the OpenAI API key that <c>OpenAIClientBase</c> reads out of the environment.
+///
+///     The trap this closes: <c>OPEN_AI_KEY</c> has never appeared in any <c>serverless.template</c>. It
+///     was applied by hand to the Zork and Planetfall Lambdas and persisted only because CloudFormation
+///     does not manage properties a template never declares. So the deploy of a brand-new game stack
+///     reports success, the stack is valid, and every request then 502s during host startup with
+///     "Missing environment variable OPEN_AI_KEY" — which is exactly what StationfallStack did on
+///     release 2.0.9. Nothing in the repo recorded that the dependency existed.
+///
+///     The env var stays the first source, so the functions that already carry it (and local dev, and
+///     the console app) are untouched and spend no Secrets Manager call per cold start. When it is
+///     absent we fall back to the <see cref="SecretName" /> secret, which is real infrastructure the
+///     account already owns and the deploy role can read — the same mechanism
+///     <c>IInfocomGame.SystemPromptSecretKey</c> already uses for the per-game system prompt.
+///
+///     Deliberately non-throwing: a missing or unreadable secret leaves the environment untouched so the
+///     operator still gets the client's explicit "Missing environment variable OPEN_AI_KEY", rather than
+///     an opaque failure raised from inside DI registration.
+/// </summary>
+public static class OpenAiKeyResolver
+{
+    public const string EnvironmentVariableName = "OPEN_AI_KEY";
+    public const string SecretName = "OpenAiApiKey";
+
+    /// <summary>
+    ///     Ensures <see cref="EnvironmentVariableName" /> holds a usable key, fetching it from Secrets
+    ///     Manager if the environment does not already supply one.
+    /// </summary>
+    /// <returns><c>true</c> if a non-blank key is now in the environment.</returns>
+    public static async Task<bool> EnsureKeyAvailable(ISecretsManager secretsManager, ILogger? logger = null)
+    {
+        if (!string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(EnvironmentVariableName)))
+            return true;
+
+        try
+        {
+            var secret = await secretsManager.GetSecret(SecretName);
+
+            // A blank secret is not a key. Leave the environment alone rather than handing the OpenAI
+            // client whitespace, which would fail later and further from the cause.
+            if (string.IsNullOrWhiteSpace(secret))
+            {
+                logger?.LogError("Secret {SecretName} is empty; OpenAI generation will be unavailable.",
+                    SecretName);
+                return false;
+            }
+
+            Environment.SetEnvironmentVariable(EnvironmentVariableName, secret);
+            logger?.LogInformation("Resolved the OpenAI key from secret {SecretName}.", SecretName);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            logger?.LogError(ex, "Could not read secret {SecretName}; OpenAI generation will be unavailable.",
+                SecretName);
+            return false;
+        }
+    }
+
+    /// <summary>
+    ///     Cold-start entry point for the Lambda hosts, which cannot await. Blocking is safe and
+    ///     deliberate here: it runs once on the Lambda init thread, where there is no synchronization
+    ///     context to deadlock against, and it must complete before the host builds the OpenAI client.
+    ///
+    ///     Called from each LambdaEntryPoint rather than from ServicesHelper on purpose. A side effect
+    ///     buried in DI registration would run inside every Startup unit test and turn them into real
+    ///     network calls; LambdaEntryPoint is production-only (its own tests never instantiate it), so
+    ///     the unit suite stays offline and deterministic.
+    /// </summary>
+    public static void EnsureKeyAvailableAtStartup(ILogger? logger = null)
+    {
+        EnsureKeyAvailable(new AmazonSecretsManager(), logger).GetAwaiter().GetResult();
+    }
+}

--- a/Lambda/src/Lambda/LambdaEntryPoint.cs
+++ b/Lambda/src/Lambda/LambdaEntryPoint.cs
@@ -1,4 +1,5 @@
 using Amazon.Lambda.AspNetCoreServer;
+using GameEngine.Web;
 
 namespace Lambda;
 
@@ -28,6 +29,11 @@ public class LambdaEntryPoint :
     /// <param name="builder">The IWebHostBuilder to configure.</param>
     protected override void Init(IWebHostBuilder builder)
     {
+        // Must happen before the host builds the OpenAI client. OPEN_AI_KEY is not declared in any
+        // serverless.template, so a freshly created stack has no such env var and every request 502s
+        // during startup; this falls back to Secrets Manager. See OpenAiKeyResolver.
+        OpenAiKeyResolver.EnsureKeyAvailableAtStartup();
+
         builder
             .UseStartup<Startup>();
     }

--- a/Planetfall-Lambda/src/Planetfall-Lambda/LambdaEntryPoint.cs
+++ b/Planetfall-Lambda/src/Planetfall-Lambda/LambdaEntryPoint.cs
@@ -1,4 +1,5 @@
 using Amazon.Lambda.AspNetCoreServer;
+using GameEngine.Web;
 
 namespace Planetfall_Lambda;
 
@@ -29,6 +30,11 @@ public class LambdaEntryPoint :
     /// <param name="builder">The IWebHostBuilder to configure.</param>
     protected override void Init(IWebHostBuilder builder)
     {
+        // Must happen before the host builds the OpenAI client. OPEN_AI_KEY is not declared in any
+        // serverless.template, so a freshly created stack has no such env var and every request 502s
+        // during startup; this falls back to Secrets Manager. See OpenAiKeyResolver.
+        OpenAiKeyResolver.EnsureKeyAvailableAtStartup();
+
         builder
             .UseStartup<Startup>();
     }

--- a/Stationfall-Lambda/src/Stationfall-Lambda/LambdaEntryPoint.cs
+++ b/Stationfall-Lambda/src/Stationfall-Lambda/LambdaEntryPoint.cs
@@ -1,4 +1,5 @@
 using Amazon.Lambda.AspNetCoreServer;
+using GameEngine.Web;
 
 namespace Stationfall_Lambda;
 
@@ -29,6 +30,11 @@ public class LambdaEntryPoint :
     /// <param name="builder">The IWebHostBuilder to configure.</param>
     protected override void Init(IWebHostBuilder builder)
     {
+        // Must happen before the host builds the OpenAI client. OPEN_AI_KEY is not declared in any
+        // serverless.template, so a freshly created stack has no such env var and every request 502s
+        // during startup; this falls back to Secrets Manager. See OpenAiKeyResolver.
+        OpenAiKeyResolver.EnsureKeyAvailableAtStartup();
+
         builder
             .UseStartup<Startup>();
     }

--- a/Stationfall-Lambda/src/Stationfall-Lambda/Readme.md
+++ b/Stationfall-Lambda/src/Stationfall-Lambda/Readme.md
@@ -97,3 +97,9 @@ account (`576431164672`, us-east-1):
 * the DynamoDB tables `stationfall_session` and `stationfall_savegame`, whose key schemas match the
   other games' (`session_id` hash; `id` hash + `session_id` range with a `session_id-index` GSI).
   Both have deletion protection enabled, as Planetfall's do.
+* the OpenAI API key. This one bit on the first deploy: `OPEN_AI_KEY` is read from the environment by
+  `OpenAIClientBase`, but is declared in no `serverless.template` — it had been applied by hand to the
+  Zork and Planetfall functions and survived only because CloudFormation does not manage properties a
+  template never declares. A new stack therefore deployed "successfully" and then 502'd on every
+  request. `OpenAiKeyResolver` now falls back to the `OpenAiApiKey` secret when the env var is absent,
+  so no new stack needs the manual step; the env var still wins when present.

--- a/UnitTests/Engine/OpenAiKeyResolverTests.cs
+++ b/UnitTests/Engine/OpenAiKeyResolverTests.cs
@@ -1,0 +1,108 @@
+using GameEngine.Web;
+using Microsoft.Extensions.Logging;
+using Model.Interface;
+
+namespace UnitTests.Engine;
+
+/// <summary>
+///     The OPEN_AI_KEY env var was never declared in any serverless.template — it was set by hand on the
+///     Zork and Planetfall Lambdas and survived only because CloudFormation does not manage properties a
+///     template never declares. A brand-new game stack therefore deploys "successfully" and then 502s on
+///     every request with "Missing environment variable OPEN_AI_KEY" (StationfallStack, release 2.0.9).
+///     These cover the fallback that removes the manual step: env var wins when present, Secrets Manager
+///     fills the gap when it isn't.
+/// </summary>
+[TestFixture]
+public class OpenAiKeyResolverTests
+{
+    [SetUp]
+    public void Setup()
+    {
+        // The env var is process-global state; snapshot it so a test can never leak into its neighbours
+        // (or into the rest of the suite, which builds real clients).
+        _originalKey = Environment.GetEnvironmentVariable(OpenAiKeyResolver.EnvironmentVariableName);
+        _secretsManager = new Mock<ISecretsManager>();
+        _logger = new Mock<ILogger>();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        Environment.SetEnvironmentVariable(OpenAiKeyResolver.EnvironmentVariableName, _originalKey);
+    }
+
+    private string? _originalKey;
+    private Mock<ISecretsManager> _secretsManager;
+    private Mock<ILogger> _logger;
+
+    [Test]
+    public async Task Should_KeepTheEnvironmentVariable_When_ItIsAlreadySet()
+    {
+        // Zork and Planetfall run with the key already on the function. The fallback must not disturb
+        // them, and must not spend a Secrets Manager call on every cold start.
+        Environment.SetEnvironmentVariable(OpenAiKeyResolver.EnvironmentVariableName, "sk-existing-key");
+
+        var resolved = await OpenAiKeyResolver.EnsureKeyAvailable(_secretsManager.Object, _logger.Object);
+
+        resolved.Should().BeTrue();
+        Environment.GetEnvironmentVariable(OpenAiKeyResolver.EnvironmentVariableName).Should().Be("sk-existing-key");
+        _secretsManager.Verify(s => s.GetSecret(It.IsAny<string>()), Times.Never);
+    }
+
+    [Test]
+    public async Task Should_FetchFromSecretsManager_When_EnvironmentVariableIsMissing()
+    {
+        // The Stationfall case: a fresh stack with no hand-applied env var.
+        Environment.SetEnvironmentVariable(OpenAiKeyResolver.EnvironmentVariableName, null);
+        _secretsManager.Setup(s => s.GetSecret(OpenAiKeyResolver.SecretName)).ReturnsAsync("sk-from-secrets");
+
+        var resolved = await OpenAiKeyResolver.EnsureKeyAvailable(_secretsManager.Object, _logger.Object);
+
+        resolved.Should().BeTrue();
+        Environment.GetEnvironmentVariable(OpenAiKeyResolver.EnvironmentVariableName).Should().Be("sk-from-secrets");
+        _secretsManager.Verify(s => s.GetSecret(OpenAiKeyResolver.SecretName), Times.Once);
+    }
+
+    [Test]
+    public async Task Should_ReportUnresolved_When_SecretIsEmpty()
+    {
+        // An empty secret is not a key. Treat it as unresolved so the client's existing, explicit
+        // "Missing environment variable OPEN_AI_KEY" throw is what the operator sees.
+        Environment.SetEnvironmentVariable(OpenAiKeyResolver.EnvironmentVariableName, null);
+        _secretsManager.Setup(s => s.GetSecret(OpenAiKeyResolver.SecretName)).ReturnsAsync("   ");
+
+        var resolved = await OpenAiKeyResolver.EnsureKeyAvailable(_secretsManager.Object, _logger.Object);
+
+        resolved.Should().BeFalse();
+        Environment.GetEnvironmentVariable(OpenAiKeyResolver.EnvironmentVariableName).Should().BeNullOrEmpty();
+    }
+
+    [Test]
+    public async Task Should_NotThrow_When_SecretsManagerFails()
+    {
+        // A Secrets Manager outage (or a missing secret) must not replace the clear downstream error
+        // with an opaque startup crash from inside DI registration.
+        Environment.SetEnvironmentVariable(OpenAiKeyResolver.EnvironmentVariableName, null);
+        _secretsManager.Setup(s => s.GetSecret(OpenAiKeyResolver.SecretName))
+            .ThrowsAsync(new InvalidOperationException("secret not found"));
+
+        var resolved = await OpenAiKeyResolver.EnsureKeyAvailable(_secretsManager.Object, _logger.Object);
+
+        resolved.Should().BeFalse();
+        Environment.GetEnvironmentVariable(OpenAiKeyResolver.EnvironmentVariableName).Should().BeNullOrEmpty();
+    }
+
+    [Test]
+    public async Task Should_TreatWhitespaceEnvironmentVariable_AsMissing()
+    {
+        // A blank env var is the same failure as no env var; fall back rather than hand the OpenAI
+        // client a whitespace key that fails later and further away.
+        Environment.SetEnvironmentVariable(OpenAiKeyResolver.EnvironmentVariableName, "  ");
+        _secretsManager.Setup(s => s.GetSecret(OpenAiKeyResolver.SecretName)).ReturnsAsync("sk-from-secrets");
+
+        var resolved = await OpenAiKeyResolver.EnsureKeyAvailable(_secretsManager.Object, _logger.Object);
+
+        resolved.Should().BeTrue();
+        Environment.GetEnvironmentVariable(OpenAiKeyResolver.EnvironmentVariableName).Should().Be("sk-from-secrets");
+    }
+}


### PR DESCRIPTION
## The trap

`OPEN_AI_KEY` is read from the environment by `OpenAIClientBase`, but it is **declared in no `serverless.template`**. It had been applied by hand to the Zork and Planetfall functions, and persisted only because CloudFormation does not manage properties a template never declares.

So a brand-new game stack deploys *successfully* — valid stack, green workflow — and then 502s on every request, crashing during host startup:

```
System.Exception: Missing environment variable OPEN_AI_KEY
  at ZorkAI.OpenAI.OpenAIClientBase..ctor(...)
  at GameEngine.GameEngine`2..ctor(...)
```

That is exactly what `StationfallStack` did on release 2.0.9. The deploy cannot catch it — the stack is valid; only a real request fails. And nothing in the repo recorded that the dependency existed, so copying Planetfall's template faithfully still produced a broken function.

## The fix

`OpenAiKeyResolver` keeps the **env var as the first source**, so the functions that already carry it — plus local dev and the console app — are untouched and spend no Secrets Manager call per cold start. When it's absent, it falls back to the `OpenAiApiKey` secret, the same mechanism `IInfocomGame.SystemPromptSecretKey` already uses for the per-game system prompt.

Deliberately **non-throwing**: a missing or unreadable secret leaves the environment alone, so the operator still gets the client's explicit `Missing environment variable OPEN_AI_KEY` rather than an opaque failure raised from inside startup.

## Where it's called, and why not the obvious place

Called from each `LambdaEntryPoint.Init` rather than from `ServicesHelper.ConfigureCommonServices`.

`ServicesHelper` is the tempting seam — every game funnels through it, including Zork, which has no hosted-service initializer at all. But a side effect during DI registration runs inside all three Lambda `StartupTests` and turns them into real network calls. I measured it: **3s vs 61ms** for those 20 tests. That violates the repo's determinism rule, so it went to `LambdaEntryPoint`, which is production-only — its own tests explicitly never instantiate it.

## Tests

TDD per the repo rule. The two fallback tests first failed on the assertion `Expected resolved to be True, but found False` against a stub with today's env-var-only behaviour — the production failure reproduced as a unit test — then passed with the resolver in place. The other three are guards that must keep holding: env var wins and Secrets Manager is never called; a blank secret is not a key; a Secrets Manager outage does not throw.

All suites green, run with `AWS_PROFILE`/`AWS_REGION`/`OPEN_AI_KEY` unset:

| Suite | Result |
|---|---|
| UnitTests | 1219 passed, 0 failed |
| ZorkOne.Tests | 1782 passed |
| Planetfall.Tests | 4015 passed |
| Stationfall.Tests | 121 passed |
| EscapeRoom.Tests | 9 passed |
| Console.Tests | 16 passed |

## Before this helps anything

The `OpenAiApiKey` secret has to exist in Secrets Manager (us-east-1). I have not created it — that means handling the API key, which is yours to do:

```
aws secretsmanager create-secret --name OpenAiApiKey --secret-string '<the key>' --region us-east-1 --profile delve
```

Until it exists this change is inert and the env var path is unchanged, so **the two live games are unaffected either way**. Stationfall stays 502 until either that secret exists and the stack redeploys, or its env var is set directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)