### PR TITLE
Run all four backends locally, 24/7, on Docker Compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,38 @@
+# Keeps the Docker build context small. Without this the context is ~2.5 GB (node_modules alone is
+# ~467 MB, and bin/obj across the solution is most of the rest), all of which is copied to the daemon
+# on every build.
+#
+# IMPORTANT: do NOT exclude the *.Tests projects. Planetfall.csproj embeds
+# ../Planetfall.Tests/Walkthrough/WalkthroughTestOne.cs as a resource for the hint knowledge base, so
+# excluding test projects breaks the Planetfall build with a missing-file error.
+
+# Build output — rebuilt inside the image, and host output would be the wrong RID anyway.
+**/bin
+**/obj
+
+# Web clients: the backends don't build them, and node_modules is the single biggest directory here.
+**/node_modules
+**/dist
+**/playwright-report
+**/test-artifacts
+
+# Git history and tooling state.
+.git
+.github
+.claude
+.agents
+.idea
+.vs
+
+# ZIL reference checkouts — gitignored, reference-only, and not part of any build.
+zork1
+planetfall-source
+
+# Local editor/user state.
+**/*.user
+**/*.DotSettings.user
+
+# Docker's own files.
+**/.dockerignore
+docker-compose*.yml
+compose*.yaml

--- a/Docs/RUNNING_GAMES_LOCALLY.md
+++ b/Docs/RUNNING_GAMES_LOCALLY.md
@@ -1,0 +1,330 @@
+# Running the Games Locally
+
+How to launch and play all four game backends on one machine with **no AWS account and no OpenAI
+key**. Written for an agent that needs to start a backend, drive it over HTTP, and recognize the
+failure modes without re-deriving them.
+
+---
+
+## 0. Prerequisite: which branch you are on
+
+**This does not work on `main`.** Self-hosted play arrives in a three-PR stack:
+
+| PR | Branch | Adds |
+|----|--------|------|
+| #385 | `claude/issue-383-discussion-l2nisa` | Self-hosted console: local endpoint settings, `FileSessionRepository`, `LocalSecretsManager`, `LocalParseConversation`, `LocalCompanionChat` |
+| #569 | `pr385-backends` | The four HTTP backends: `FileSavedGameRepository`, the `ServicesHelper` self-hosted branch, `SelfHostedMode` |
+| #570 | `pr385-compose` | `docker/Dockerfile`, `compose.yaml`, `.dockerignore` |
+
+Check before doing anything else:
+
+```bash
+test -f compose.yaml && echo "compose available" || echo "on main or an older branch — see the table above"
+```
+
+If `compose.yaml` is absent you are on a branch without #570. Either check out `pr385-compose`, or
+use the [single-backend](#single-backend-without-docker) path, which needs only #569.
+
+---
+
+## 1. Quickstart
+
+```bash
+ollama pull qwen3:14b          # or any capable instruct model you already have
+docker compose up -d --build   # from the repo root
+```
+
+First build takes a few minutes (SDK image pull, one restore, one publish pass). After that:
+
+```bash
+docker compose ps              # all four should read (healthy)
+```
+
+| Game | Endpoint | Container |
+|------|----------|-----------|
+| Zork One | `http://localhost:5100/ZorkOne` | `zorkai-zork1` |
+| Planetfall | `http://localhost:5101/Planetfall` | `zorkai-planetfall` |
+| Escape Room | `http://localhost:5102/EscapeRoom` | `zorkai-escaperoom` |
+| Stationfall | `http://localhost:5103/Stationfall` | `zorkai-stationfall` |
+
+One container per game, four separate images, one shared build stage. Ports bind to `127.0.0.1`
+only. `restart: unless-stopped`, so they survive a reboot as long as Docker Desktop starts at login.
+
+Play a turn:
+
+```bash
+curl -s -X POST http://localhost:5100/ZorkOne \
+  -H "Content-Type: application/json" \
+  -d '{"Input":"open mailbox","SessionId":"my-session","NoGeneratedResponses":true}'
+```
+
+Expect `Opening the small mailbox reveals a leaflet.`
+
+---
+
+## 2. The AI endpoint is a real dependency
+
+These backends need no AWS, but they **do** need a reachable OpenAI-compatible server. This
+engine's parser is load-bearing: it tries deterministic matching first and falls back to the model.
+
+| With a reachable model | Without one |
+|---|---|
+| Everything | Movement (`north`, `enter pod`) and global commands (`look`, `inventory`, `score`, `diagnose`) only |
+
+`open mailbox` needs the model. `look` does not. A backend with no model still starts, still answers,
+and degrades in-fiction — which reads like a game bug rather than a configuration problem, so check
+the endpoint before investigating gameplay.
+
+Default endpoint is an Ollama **on the host** (`host.docker.internal:11434`), not a sidecar — the
+model is usually already there. For a fully containerized model instead:
+
+```bash
+docker compose --profile bundled-ollama up -d
+# then set OPENAI_BASE_URL=http://ollama:11434/v1 and pull a model into that container
+```
+
+---
+
+## 3. HTTP API
+
+Every game exposes the same surface under its own route prefix. Substitute `{Game}` with `ZorkOne`,
+`Planetfall`, `EscapeRoom`, or `Stationfall`, and `{port}` from the table above.
+
+### Play a turn
+
+```
+POST /{Game}
+{"Input": "open mailbox", "SessionId": "my-session", "NoGeneratedResponses": false}
+```
+
+Returns `GameResponse`: `response`, `locationName`, `previousLocationName`, `moves`, `score`,
+`time`, `inventory`, `actionsAvailableFromLocation`, `actionsAvailableFromInventory`, `exits`,
+`lastMovementDirection`.
+
+`NoGeneratedResponses: true` suppresses AI-generated *narration* for failed actions. It does **not**
+disable the AI parser — a two-word interaction still calls the model.
+
+### Resume a session
+
+```
+GET /{Game}?sessionId=my-session
+```
+
+Restores saved state and replays history (or `look` if there is none). Use this to read current
+state without consuming a turn.
+
+### Named saves
+
+```
+POST   /{Game}/saveGame        {"SessionId":"s","ClientId":"c","Name":"Before the troll","Id":null}
+GET    /{Game}/saveGame?sessionId=c
+POST   /{Game}/restoreGame     {"SessionId":"s","ClientId":"c","Id":"<save id>"}
+DELETE /{Game}/saveGame/{id}?sessionId=c
+```
+
+Two traps here, both verified:
+
+1. **`POST /saveGame` fails unless that `SessionId` has already played a turn.** It reads the live
+   session first and returns **HTTP 500** with `Session had empty game data before attempting save
+   game.` if there is none. Play one turn before saving.
+2. **`GET /saveGame`'s `sessionId` parameter takes the `ClientId` you saved with**, not the
+   `SessionId`. The storage layer keys saves by client. Same for the `DELETE` query parameter. The
+   names disagree with each other; the behavior is as described.
+
+`Id: null` creates a new save and returns its generated id. A non-null `Id` overwrites that slot.
+
+### Hints (Planetfall only)
+
+```
+POST /Planetfall/hint
+{"SessionId": "my-session", "Question": "how do I get past the door?", "History": null}
+```
+
+Returns `{"text": "..."}`. Consumes no turn and mutates no state. **Deliberately absent for the
+other three games** — the hint engine needs a game-specific `IHintProvider`, and only Planetfall has
+one (`Planetfall/Hints/PlanetfallHintProvider.cs`).
+
+---
+
+## 4. Environment variables
+
+| Variable | Purpose |
+|---|---|
+| `ZORKAI_SELF_HOSTED` | **The opt-in.** `1`/`true`/`yes`/`on` swaps DynamoDB, Secrets Manager, CloudWatch and the Floyd Lambda for local equivalents. Anything else, including unset, means cloud mode. |
+| `OPENAI_BASE_URL` | Endpoint for every AI client, e.g. `http://localhost:11434/v1`. |
+| `ZORKAI_PROVIDER` | Preset instead of a URL: `openai`, `lmstudio` (1234), `ollama` (11434), `koboldcpp` (5001). An unknown value is a hard error. |
+| `OPENAI_MODEL` | Overrides every hardcoded model id. Required for local servers. |
+| `OPEN_AI_KEY` | Only for the real OpenAI API. Optional when a custom endpoint is set. |
+| `ZORKAI_SAVE_DIR` | Root for sessions and saves. Default `~/.zorkai`; the containers set `/data`. |
+| `ZORKAI_SYSTEM_PROMPT` | Overrides the built-in narrator prompt used in self-hosted mode. |
+| `ASPNETCORE_URLS` | Bind address. Containers use `http://+:8080`. |
+| `ASPNETCORE_ENVIRONMENT` | Must be `Production`. See traps. |
+
+**`ZORKAI_SELF_HOSTED` is separate from `OPENAI_BASE_URL` on purpose.** Setting only the endpoint
+leaves the backend on DynamoDB — the endpoint says where the *model* lives, which is a different
+question from whether AWS exists, and `OPENAI_BASE_URL` is a generic name that gateways and proxies
+also use. Inferring from it would mean a deployed Lambda pointed at an OpenAI gateway silently moved
+every player's session onto ephemeral disk. See `GameEngine/SelfHostedMode.cs`.
+
+The console is the exception: `--provider ollama` sets `ZORKAI_SELF_HOSTED` for you.
+
+---
+
+## 5. Where state lives
+
+Under `ZORKAI_SAVE_DIR` (`/data` in the containers):
+
+```
+<root>/<table>/<sessionId>.session          base64 game state, rewritten every turn
+<root>/<table>/<sessionId>.steps.log        append-only transcript
+<root>/<table>/<clientId>/<id>.savedgame    one named save, JSON
+```
+
+Table names are per game: `zork1_session`, `zork1_savegame`, `planetfall_session`,
+`escaperoom_session`, `stationfall_session`, … so one shared volume cannot collide.
+
+Inspect or reset:
+
+```bash
+docker compose exec zork1 sh -c 'find /data -type f'
+docker compose down -v          # deletes the volume and every session and save
+```
+
+---
+
+## 6. Single backend without Docker
+
+Needs #569 only. One backend at a time, on any port:
+
+```bash
+ZORKAI_SELF_HOSTED=true \
+OPENAI_BASE_URL=http://localhost:11434/v1 \
+OPENAI_MODEL=qwen3:14b \
+ZORKAI_SAVE_DIR=/tmp/zorkai \
+ASPNETCORE_URLS=http://localhost:5100 \
+ASPNETCORE_ENVIRONMENT=Production \
+dotnet run --project Lambda/src/Lambda --no-launch-profile
+```
+
+Project paths: `Lambda/src/Lambda`, `Planetfall-Lambda/src/Planetfall-Lambda`,
+`EscapeRoom-Lambda/src/EscapeRoom-Lambda`, `Stationfall-Lambda/src/Stationfall-Lambda`.
+
+There are no `launchSettings.json` files anywhere, so without `ASPNETCORE_URLS` every backend binds
+`http://localhost:5000` and only one can run at a time.
+
+---
+
+## 7. Console (no HTTP at all)
+
+```bash
+dotnet run --project Console ZorkOne --provider ollama --model qwen3:14b
+dotnet run --project Console Planetfall --endpoint http://gpu-box:8080/v1 --model my-model
+```
+
+Games: `ZorkOne`, `Planetfall`, `Stationfall`, `EscapeRoom` (case-insensitive, first argument).
+Flags: `--provider`, `--endpoint`, `--model`. A bad game name or provider prints a message and exits
+1. Saves land under `~/.zorkai`.
+
+The console is the only host where companion conversation memory accumulates — see
+`Planetfall/AI/LocalCompanionChat.cs`. In the HTTP backends every turn re-runs the characters' field
+initializers, so each turn starts with an empty history. That matches the cloud path, which sends no
+session or thread id either.
+
+---
+
+## 8. Traps
+
+Ordered by how much time they cost.
+
+1. **`OPENAI_MODEL` must name a model the server actually has.** Ollama returns `HTTP 404
+   (not_found_error)` for an unknown model, and the engine turns that into its graceful in-fiction
+   error — so a wrong model id looks exactly like a game bug. `curl -s
+   http://localhost:11434/v1/models` lists what is available.
+2. **`ASPNETCORE_ENVIRONMENT` must be `Production`.** Planetfall, EscapeRoom and Stationfall each
+   register `GameEngineInitializer`, an `IHostedService` (singleton) that injects the scoped
+   `IGameEngine`. Under `Development`, DI scope validation is on and the host throws at startup.
+   Pre-existing, worked around rather than fixed.
+3. **`ZORKAI_SELF_HOSTED` alone controls de-clouding.** Setting `OPENAI_BASE_URL` without it leaves
+   you on DynamoDB and you will see `security token` / credential errors.
+4. **`POST /saveGame` needs a session that has already played a turn** (§3).
+5. **`GET`/`DELETE /saveGame` take the `ClientId` in a parameter named `sessionId`** (§3).
+6. **The web clients cannot reach these ports.** `zorkweb.client/config.json` and
+   `planetfallweb.client/config.json` hardcode `http://localhost:5000`, and CI rewrites them at
+   deploy. Pointing a client at 5100/5101 means editing a tracked file. There are no web clients for
+   Escape Room or Stationfall at all.
+7. **`koboldcpp`'s preset port is 5001** — adjacent to the game ports. Prefer 5100–5103 for games.
+8. **`Failed to determine the https port for redirect` is benign.** All four call
+   `UseHttpsRedirection()` and the containers bind HTTP only, so the middleware logs once and passes
+   the request through.
+9. **Do not exclude `*.Tests` from the Docker build context.** `Planetfall.csproj` embeds
+   `../Planetfall.Tests/Walkthrough/WalkthroughTestOne.cs` as a resource for the hint knowledge
+   base. Excluding test projects breaks the Planetfall build. See `.dockerignore`.
+10. **`dotnet test A B` fails with MSB1008.** Run each test project separately.
+11. **On this machine, use `C:/Users/arsin/.dotnet/dotnet.exe`.** The machine-wide
+    `C:\Program Files\dotnet` has only .NET 6/8 and no ASP.NET Core runtime; .NET 10 lives in the
+    user profile.
+
+---
+
+## 9. Troubleshooting
+
+| Symptom | Cause |
+|---|---|
+| `Something goes wrong, and for a moment the world seems to flicker.` | AI call failed. Wrong `OPENAI_MODEL`, or nothing at the endpoint. |
+| `look` works, `open mailbox` does not | Model unreachable. Deterministic paths don't need it. |
+| `The security token included in the request is invalid` | Still in cloud mode — `ZORKAI_SELF_HOSTED` not set. |
+| `Cannot consume scoped service ... from singleton` at startup | `ASPNETCORE_ENVIRONMENT=Development`. Trap 2. |
+| `Session had empty game data before attempting save game.` | Saving a session that never played a turn. |
+| `GET /saveGame` returns `[]` after a successful save | Querying with `SessionId` instead of `ClientId`. |
+| `Missing environment variable OPEN_AI_KEY` | No key and no custom endpoint. Set `OPENAI_BASE_URL` or `ZORKAI_PROVIDER`. |
+| `Unknown ZORKAI_PROVIDER 'x'` | Typo. Valid: `openai`, `lmstudio`, `ollama`, `koboldcpp`. |
+| Sessions vanish on restart | `ZORKAI_SAVE_DIR` not on a mounted volume. |
+| Container `(unhealthy)` | `docker compose logs <service>`. Healthcheck is `GET /`. |
+| Port already in use | Another backend on 5000, or `docker compose ps -a`. |
+
+---
+
+## 10. Smoke test
+
+Confirms all four are up, gameplay works, and the AI path is wired.
+
+```bash
+for p in 5100 5101 5102 5103; do
+  until curl -s -o /dev/null -m 2 "http://localhost:$p/"; do :; done
+done
+
+for pair in "5100 ZorkOne" "5101 Planetfall" "5102 EscapeRoom" "5103 Stationfall"; do
+  set -- $pair
+  printf "%-12s " "$2"
+  curl -s -m 60 -X POST "http://localhost:$1/$2" \
+    -H "Content-Type: application/json" \
+    -d '{"Input":"look","SessionId":"smoke","NoGeneratedResponses":true}' \
+  | grep -oE '"locationName":"[^"]*"'
+done
+```
+
+Expected: `West Of House`, `Deck Nine`, `Reception`, `Deck Twelve`.
+
+Then the AI path, and a check that nothing reached AWS:
+
+```bash
+curl -s -m 300 -X POST http://localhost:5100/ZorkOne \
+  -H "Content-Type: application/json" \
+  -d '{"Input":"open mailbox","SessionId":"smoke","NoGeneratedResponses":true}' \
+| grep -oE '"response":"[^"]*"'
+# -> "Opening the small mailbox reveals a leaflet.\n"
+
+docker compose logs zork1 | grep -ciE "dynamodb|secretsmanager|cloudwatch|credential"
+# -> 0
+```
+
+---
+
+## See also
+
+- `GameEngine/SelfHostedMode.cs` — the opt-in, and why it is not inferred
+- `GameEngine/Web/ServicesHelper.cs` — cloud vs. local composition root
+- `ZorkAI.OpenAI/OpenAIEndpointSettings.cs` — endpoint and model resolution
+- `GameEngine/FileSessionRepository.cs`, `GameEngine/FileSavedGameRepository.cs` — on-disk state
+- `README.md` — "Play It Offline (Self-Hosted AI)"
+- `.claude/CLAUDE.md` — engine architecture, testing rules, port anti-patterns

--- a/Planetfall/Planetfall.csproj
+++ b/Planetfall/Planetfall.csproj
@@ -33,9 +33,18 @@
       which are plumbing, not game knowledge. They all previously lived in the ChatLambda project and
       were never part of the hint bundle, so excluding them keeps the bundle byte-identical after the
       move.
+
+      AmbassadorPrompts.cs and BlatherPrompts.cs are excluded for the same reason, and explicitly
+      because they do NOT sit under AI/. They are new files holding LLM persona text — plumbing, not
+      game facts — and the glob would otherwise sweep them into the bundle that the *deployed*
+      Planetfall hint endpoint sends to the model on every request. That is a production behavior
+      change (and a per-hint token cost) that a self-hosted-play change has no business making.
+      FloydPrompts.cs is deliberately NOT excluded: it predates this work and is already in the
+      bundle, so excluding it would change the baseline in the other direction.
     -->
     <ItemGroup>
-        <EmbeddedResource Include="**/*.cs" Exclude="obj/**;bin/**;AI/**" />
+        <EmbeddedResource Include="**/*.cs"
+                          Exclude="obj/**;bin/**;AI/**;Item/Feinstein/AmbassadorPrompts.cs;Item/Feinstein/BlatherPrompts.cs" />
         <!-- Survival and time mechanics moved to the shared StellarPatrol library; the hint
              bundle still needs them, or it loses knowledge of hunger, fatigue and the clock. -->
         <EmbeddedResource Include="../StellarPatrol/**/*.cs" Exclude="../StellarPatrol/obj/**;../StellarPatrol/bin/**">

--- a/README.md
+++ b/README.md
@@ -202,6 +202,31 @@ The same settings work as environment variables (`ZORKAI_PROVIDER`, `OPENAI_BASE
 A fully deterministic **classic mode** — no LLM at all, with the parser and characters behaving
 exactly as they did in the 1983 originals — is planned as a follow-up (see issue #383 discussion).
 
+### Running the game backends locally, 24/7
+
+The same de-clouding applies to the four HTTP backends, so you can keep all of them running on your
+own machine with no AWS account and no OpenAI key:
+
+```bash
+ollama pull qwen3:14b        # or any capable instruct model
+docker compose up -d --build
+```
+
+| Game | Endpoint |
+|------|----------|
+| Zork One | `http://localhost:5100/ZorkOne` |
+| Planetfall | `http://localhost:5101/Planetfall` |
+| Escape Room | `http://localhost:5102/EscapeRoom` |
+| Stationfall | `http://localhost:5103/Stationfall` |
+
+`restart: unless-stopped` brings them back after a reboot, and sessions and saved games live on a
+named volume, so state survives rebuilds and restarts. By default the containers use an Ollama
+already running on your host; set `OPENAI_BASE_URL` and `OPENAI_MODEL` to point anywhere else, or
+run `docker compose --profile bundled-ollama up -d` to get a containerized Ollama instead.
+
+Remember that the model is doing the parsing: with nothing listening at the endpoint, movement and
+the global commands still work, but anything needing the AI parser will not.
+
 ---
 
 ## Why This Exists

--- a/compose.yaml
+++ b/compose.yaml
@@ -19,7 +19,7 @@ x-backend: &backend
   environment: &backend-env
     # Already set in the image; repeated here because it is the switch that makes these containers
     # AWS-free, and it should be visible where someone reads the config rather than only in the
-    # Dockerfile. Never inferred from OPENAI_BASE_URL — see GameEngine/Web/SelfHostedMode.cs.
+    # Dockerfile. Never inferred from OPENAI_BASE_URL — see GameEngine/SelfHostedMode.cs.
     ZORKAI_SELF_HOSTED: "true"
     # Any OpenAI-compatible server. Defaults to an Ollama already running on the host — the machine
     # this was developed on had one with a model pulled, and re-downloading several GB into a

--- a/compose.yaml
+++ b/compose.yaml
@@ -17,6 +17,10 @@ x-backend: &backend
   # key, so each service declares its own with the target that selects its game.
   restart: unless-stopped
   environment: &backend-env
+    # Already set in the image; repeated here because it is the switch that makes these containers
+    # AWS-free, and it should be visible where someone reads the config rather than only in the
+    # Dockerfile. Never inferred from OPENAI_BASE_URL — see GameEngine/Web/SelfHostedMode.cs.
+    ZORKAI_SELF_HOSTED: "true"
     # Any OpenAI-compatible server. Defaults to an Ollama already running on the host — the machine
     # this was developed on had one with a model pulled, and re-downloading several GB into a
     # container volume to reach the same place is waste. To use the bundled sidecar instead, run

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,97 @@
+# The four game backends, running locally 24/7 with no AWS account and no OpenAI key.
+#
+#   docker compose up -d --build
+#
+#   Zork One    http://localhost:5100/ZorkOne
+#   Planetfall  http://localhost:5101/Planetfall
+#   Escape Room http://localhost:5102/EscapeRoom
+#   Stationfall http://localhost:5103/Stationfall
+#
+# Everything that used to live in AWS now lives on disk or on a local model server — see
+# GameEngine/Web/ServicesHelper.cs for the switch. The AI endpoint is the one dependency that
+# remains: this engine's parser is load-bearing, so without a reachable model only movement and the
+# global commands (look, inventory, score) work.
+
+x-backend: &backend
+  # No `build` here on purpose: a service's own `build` replaces this block wholesale under a merge
+  # key, so each service declares its own with the target that selects its game.
+  restart: unless-stopped
+  environment: &backend-env
+    # Any OpenAI-compatible server. Defaults to an Ollama already running on the host — the machine
+    # this was developed on had one with a model pulled, and re-downloading several GB into a
+    # container volume to reach the same place is waste. To use the bundled sidecar instead, run
+    # `docker compose --profile bundled-ollama up -d` and set this to http://ollama:11434/v1.
+    OPENAI_BASE_URL: ${OPENAI_BASE_URL:-http://host.docker.internal:11434/v1}
+    # One override covers every role (narrator, parser, pronoun resolver, companions); local servers
+    # typically expose one loaded model, and the hardcoded OpenAI model ids would 404 against it.
+    OPENAI_MODEL: ${OPENAI_MODEL:-qwen3:14b}
+  # host.docker.internal resolves natively on Docker Desktop; this line is what makes it work on
+  # plain Linux too.
+  extra_hosts:
+    - "host.docker.internal:host-gateway"
+  volumes:
+    # Sessions and saved games. Without this the whole save tree is inside the container and every
+    # session dies with it.
+    - zorkai-saves:/data
+  healthcheck:
+    test: ["CMD", "curl", "-fsS", "-o", "/dev/null", "http://localhost:8080/"]
+    interval: 30s
+    timeout: 5s
+    start_period: 30s
+    retries: 3
+
+services:
+  zork1:
+    <<: *backend
+    build:
+      context: .
+      dockerfile: docker/Dockerfile
+      target: zork1
+    container_name: zorkai-zork1
+    ports:
+      - "127.0.0.1:5100:8080"
+
+  planetfall:
+    <<: *backend
+    build:
+      context: .
+      dockerfile: docker/Dockerfile
+      target: planetfall
+    container_name: zorkai-planetfall
+    ports:
+      - "127.0.0.1:5101:8080"
+
+  escaperoom:
+    <<: *backend
+    build:
+      context: .
+      dockerfile: docker/Dockerfile
+      target: escaperoom
+    container_name: zorkai-escaperoom
+    ports:
+      - "127.0.0.1:5102:8080"
+
+  stationfall:
+    <<: *backend
+    build:
+      context: .
+      dockerfile: docker/Dockerfile
+      target: stationfall
+    container_name: zorkai-stationfall
+    ports:
+      - "127.0.0.1:5103:8080"
+
+  # Opt-in, for a machine with no host Ollama: `docker compose --profile bundled-ollama up -d`.
+  # Its port is deliberately not published — a host Ollama already owns 11434, and the backends
+  # reach this one over the compose network as http://ollama:11434/v1.
+  ollama:
+    image: ollama/ollama:latest
+    container_name: zorkai-ollama
+    profiles: ["bundled-ollama"]
+    restart: unless-stopped
+    volumes:
+      - ollama-models:/root/.ollama
+
+volumes:
+  zorkai-saves:
+  ollama-models:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,7 +26,7 @@ WORKDIR /app
 
 # The explicit opt-in that swaps DynamoDB/Secrets Manager/CloudWatch for local equivalents. It is a
 # dedicated variable rather than something inferred from OPENAI_BASE_URL on purpose: see
-# GameEngine/Web/SelfHostedMode.cs. Set here because this image exists only to run locally.
+# GameEngine/SelfHostedMode.cs. Set here because this image exists only to run locally.
 ENV ZORKAI_SELF_HOSTED=true
 
 # Self-hosted play writes session state and saved games to disk instead of DynamoDB. This must be a

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,6 +24,11 @@ RUN dotnet publish Lambda/src/Lambda                               $PUBLISH_ARGS
 FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
 WORKDIR /app
 
+# The explicit opt-in that swaps DynamoDB/Secrets Manager/CloudWatch for local equivalents. It is a
+# dedicated variable rather than something inferred from OPENAI_BASE_URL on purpose: see
+# GameEngine/Web/SelfHostedMode.cs. Set here because this image exists only to run locally.
+ENV ZORKAI_SELF_HOSTED=true
+
 # Self-hosted play writes session state and saved games to disk instead of DynamoDB. This must be a
 # mounted volume in compose — left inside the container, every session dies with it.
 ENV ZORKAI_SAVE_DIR=/data

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,67 @@
+# One Dockerfile, four images — one per game backend, selected with `--target`.
+#
+# All four share a single `build` stage. Docker caches that stage, so building all four costs one
+# restore and one publish pass rather than four; compose picks the game with `target:`.
+#
+# The build context is the repo root, not the Lambda directory: every Lambda csproj reaches up to
+# ..\..\..\GameEngine, ..\..\..\Model and ..\..\..\DynamoDb, so the whole solution has to be visible.
+# See .dockerignore for what is excluded (and for why the test projects are not).
+
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+WORKDIR /src
+COPY . .
+
+# PublishReadyToRun off on purpose: R2R buys cold-start time that matters in Lambda and not at all in
+# a long-running container, and it makes every local build noticeably slower.
+ARG PUBLISH_ARGS="-c Release --nologo /p:PublishReadyToRun=false"
+
+RUN dotnet publish Lambda/src/Lambda                               $PUBLISH_ARGS -o /app/zork1 \
+ && dotnet publish Planetfall-Lambda/src/Planetfall-Lambda         $PUBLISH_ARGS -o /app/planetfall \
+ && dotnet publish EscapeRoom-Lambda/src/EscapeRoom-Lambda         $PUBLISH_ARGS -o /app/escaperoom \
+ && dotnet publish Stationfall-Lambda/src/Stationfall-Lambda       $PUBLISH_ARGS -o /app/stationfall
+
+
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
+WORKDIR /app
+
+# Self-hosted play writes session state and saved games to disk instead of DynamoDB. This must be a
+# mounted volume in compose — left inside the container, every session dies with it.
+ENV ZORKAI_SAVE_DIR=/data
+
+# The apps call app.UseHttpsRedirection(); with an HTTP-only binding the middleware logs "failed to
+# determine the https port" once and passes the request through. Binding HTTP only is deliberate:
+# these are local backends behind nothing.
+ENV ASPNETCORE_URLS=http://+:8080
+
+# Production, not Development, and not incidentally: each game except Zork registers
+# GameEngineInitializer, an IHostedService (singleton) that injects the scoped IGameEngine. Under
+# Development, DI scope validation is on and the host throws at startup.
+ENV ASPNETCORE_ENVIRONMENT=Production
+
+# curl is here only so compose can run a real healthcheck — the aspnet image ships without it, and a
+# 24/7 container that has wedged should not keep reporting "up".
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends curl \
+ && rm -rf /var/lib/apt/lists/*
+
+# Runs as the built-in non-root user; /data must be writable by it, hence the chown.
+RUN mkdir -p /data && chown -R app:app /data
+USER app
+EXPOSE 8080
+
+
+FROM runtime AS zork1
+COPY --from=build /app/zork1 .
+ENTRYPOINT ["dotnet", "Lambda.dll"]
+
+FROM runtime AS planetfall
+COPY --from=build /app/planetfall .
+ENTRYPOINT ["dotnet", "Planetfall-Lambda.dll"]
+
+FROM runtime AS escaperoom
+COPY --from=build /app/escaperoom .
+ENTRYPOINT ["dotnet", "EscapeRoom-Lambda.dll"]
+
+FROM runtime AS stationfall
+COPY --from=build /app/stationfall .
+ENTRYPOINT ["dotnet", "Stationfall-Lambda.dll"]


### PR DESCRIPTION
Third in the stack: **#385** (console self-hosting) → **#569** (backends) → this. Base is #569's branch, so this diff is only the container work.

```bash
ollama pull qwen3:14b
docker compose up -d --build
```

| Game | Endpoint |
|---|---|
| Zork One | `http://localhost:5100/ZorkOne` |
| Planetfall | `http://localhost:5101/Planetfall` |
| Escape Room | `http://localhost:5102/EscapeRoom` |
| Stationfall | `http://localhost:5103/Stationfall` |

One `docker/Dockerfile` with four targets sharing a single build stage — so building all four costs one restore and one publish pass, not four — plus `compose.yaml` with `restart: unless-stopped` and a real healthcheck.

## Decisions worth reviewing

**The build context is the repo root.** Every Lambda csproj reaches up to `..\..\..\GameEngine`, `Model` and `DynamoDb`, so the whole solution must be visible.

**`.dockerignore` deliberately keeps the `*.Tests` projects.** The raw context is ~2.5 GB (`node_modules` is 467 MB, `bin`/`obj` most of the rest), so the file matters — but `Planetfall.csproj` embeds `../Planetfall.Tests/Walkthrough/WalkthroughTestOne.cs` as a resource for the hint knowledge base, and excluding test projects breaks the Planetfall build outright. Called out in a comment so it isn't "tidied up" later.

**`ZORKAI_SAVE_DIR=/data` on a named volume.** Left at its `~/.zorkai` default, the entire save tree lives inside the container and every session dies with it. This is the one setting that makes 24/7 actually mean something.

**`ASPNETCORE_ENVIRONMENT=Production`, not incidentally.** Planetfall, EscapeRoom and Stationfall each register `GameEngineInitializer` — an `IHostedService` (singleton) that injects the scoped `IGameEngine`. Under `Development`, DI scope validation is on and the host throws at startup. Lambda has always run Production, which is why this has stayed invisible. Pinning it here avoids the trap; fixing the lifetime properly is still open.

**Host Ollama by default, sidecar under a profile.** You asked for a sidecar, and I've included one — but this machine already runs Ollama with `qwen3:14b` (9.3 GB) pulled, and re-downloading that into a container volume to arrive at the same place is waste. So the default is `host.docker.internal:11434`, with `docker compose --profile bundled-ollama up -d` for a machine without one. Say the word and I'll flip the default.

**`PublishReadyToRun=false`** — R2R buys Lambda cold-start time a long-running container never spends, and makes every local build slower.

Ports bind to `127.0.0.1` only. The bundled Ollama's port isn't published at all, since a host Ollama already owns 11434.

## Verified running, not just built

```
docker compose ps    -> all four healthy
look                 -> West Of House / Deck Nine / Reception / Deck Twelve
open mailbox         -> "Opening the small mailbox reveals a leaflet."
                        (the AI parser path, container -> host Ollama)
docker compose restart zork1
                     -> session state intact across the restart
```

`curl` is installed in the runtime image solely so the healthcheck is real — a wedged 24/7 container shouldn't keep reporting "up".

## Still open

- The web clients hardcode `http://localhost:5000` in a tracked `config.json` that CI rewrites at deploy. Pointing them at 5100/5101 needs an override that doesn't dirty the tracked file — not done here.
- `UseHttpsRedirection` on HTTP-only bindings logs one warning per process. Harmless, pre-existing.
- The `GameEngineInitializer` lifetime bug is worked around, not fixed.
- A local model is still required for anything past movement and the global commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ZWv6Q7uMu9BKxPDyrzWiJ