### PR TITLE
Fix #550: resolve the bedistor by its bare adjective "good"

### DIFF
--- a/Planetfall.Tests/CourseControlTests.cs
+++ b/Planetfall.Tests/CourseControlTests.cs
@@ -567,4 +567,33 @@ public class CourseControlTests : EngineTestsBase
         response.Should().Contain("smaller doorways to the north and south");
         response.Should().NotContain("north\n");
     }
+
+    [Test]
+    public async Task BareAdjectives_ResolveToTheirOwnBedistor_AndTheQualifiedPhrasingsStillWork()
+    {
+        // Issue #550 guard. "good" was added to GoodBedistor so a bare adjective resolves the way
+        // its sibling's "fused" already did. Pin BOTH directions - neither adjective may resolve
+        // the other sibling - and pin the printed name, which is the LONGEST noun: a short handle
+        // must never become the name the game prints (the trap from PR #542).
+        var target = GetTarget();
+        StartHere<CourseControl>();
+        GetItem<LargeMetalCube>().IsOpen = true; // fused sits in the open cube, in scope
+        Take<GoodBedistor>();
+        Take<Pliers>();
+
+        Repository.GetItemInScope("good", target.Context).Should().Be(GetItem<GoodBedistor>());
+        Repository.GetItemInScope("fused", target.Context).Should().Be(GetItem<FusedBedistor>());
+        Repository.GetItemInScope("good bedistor", target.Context).Should().Be(GetItem<GoodBedistor>());
+
+        GetItem<GoodBedistor>().NounsForMatching.MaxBy(n => n.Length).Should().Be("good ninety-ohm bedistor");
+        GetItem<GoodBedistor>().Name.Should().Be("good ninety-ohm bedistor");
+
+        // The phrasings that already worked in production must keep working alongside the new handle.
+        var response = await target.GetResponse("take fused with pliers");
+        response.Should().Contain("you manage to remove the fused bedistor");
+
+        response = await target.GetResponse("put good bedistor in cube");
+        response.Should().Contain("The warning lights go out");
+        GetItem<LargeMetalCube>().HasItem<GoodBedistor>().Should().BeTrue();
+    }
 }

--- a/Planetfall.Tests/LiveParserShapeTests.cs
+++ b/Planetfall.Tests/LiveParserShapeTests.cs
@@ -164,4 +164,41 @@ public class LiveParserShapeTests : EngineTestsBase
         response.Should().Contain("you manage to remove the fused bedistor");
         Context.HasItem<FusedBedistor>().Should().BeTrue();
     }
+
+    /// <summary>
+    ///     Issue #550, a residual of #538 that PR #540's preposition recovery does not cover: here the
+    ///     preposition survives, the multi-noun routing is healthy, and the cube handler is healthy —
+    ///     only the bare adjective fails to resolve. The original gives the good bedistor the
+    ///     bare-adjective handle its fused sibling has (<c>ADJECTIVE GOOD NINETY OHM</c>,
+    ///     planetfall-source/compone.zil:1419), which is exactly why "take fused with pliers" works in
+    ///     this port while "put good in cube" dropped the turn.
+    ///     <para>
+    ///         The walkthrough suite could not catch it: <c>base-mappings.json</c> pre-expanded
+    ///         "put good in cube" to nounOne "good bedistor" — an intent the parser never produces — so
+    ///         the bare noun was never exercised. That mapping is now faithful to the parser, which
+    ///         makes walkthrough step 262 a second guard; this test is the one that pins the real
+    ///         parser rather than a model of it.
+    ///     </para>
+    /// </summary>
+    [Test]
+    public async Task PutTheBedistorByItsBareAdjective_WithTheRealParser_StillFixesCourseControl()
+    {
+        var target = GetTarget(ParserReturning("""
+                                               <intent>act</intent>
+                                               <verb>put</verb>
+                                               <noun>good</noun>
+                                               <noun>cube</noun>
+                                               <preposition>in</preposition>
+                                               """));
+        StartHere<CourseControl>();
+        GetItem<LargeMetalCube>().IsOpen = true;
+        Take<FusedBedistor>(); // pried out of the socket and still in hand, as in the prod report
+        Take<GoodBedistor>();
+
+        var response = await target.GetResponse("put good in cube");
+
+        response.Should().Contain("The warning lights go out");
+        GetItem<LargeMetalCube>().HasItem<GoodBedistor>().Should().BeTrue();
+        GetLocation<CourseControl>().Fixed.Should().BeTrue();
+    }
 }

--- a/Planetfall/Item/Kalamontee/Mech/Bedistor.cs
+++ b/Planetfall/Item/Kalamontee/Mech/Bedistor.cs
@@ -16,7 +16,16 @@ public abstract class BedistorBase : ItemBase
 
 public class GoodBedistor : BedistorBase, ICanBeTakenAndDropped
 {
-    public override string[] NounsForMatching => ["good ninety-ohm bedistor", "bedistor", "ninety-ohm bedistor", "good bedistor", "ninety-ohm", "90-ohm bedistor", "90-ohm"];
+    // Issue #550: the bare adjective "good" must be a handle of its own, exactly as "fused" is on
+    // FusedBedistor - the original registers both as adjectives (ADJECTIVE GOOD NINETY OHM,
+    // compone.zil:1419) and the Infocom parser resolves an unambiguous adjective with no head noun.
+    // The containment fallback in HasMatchingNoun cannot cover for a missing entry here: it asks
+    // whether the player's PHRASE contains one of our nouns, so "good" on its own matches nothing
+    // unless it is itself registered. That made "put good in cube" a dropped turn - no handler at
+    // all, and narrator prose in place of the bedistor swap. Keep the full name FIRST (Name is
+    // NounsForMatching.First(), and the printed name is the LONGEST entry, so a short handle is
+    // safe to add).
+    public override string[] NounsForMatching => ["good ninety-ohm bedistor", "bedistor", "ninety-ohm bedistor", "good bedistor", "good", "ninety-ohm", "90-ohm bedistor", "90-ohm"];
 
     public string OnTheGroundDescription(ILocation? currentLocation)
     {

--- a/UnitTests/IntentMappings/base-mappings.json
+++ b/UnitTests/IntentMappings/base-mappings.json
@@ -357,7 +357,11 @@
     { "inputs": ["give laser to microbe", "throw laser to microbe", "feed laser to microbe"], "verb": "give", "nounOne": "laser", "nounTwo": "microbe", "preposition": "to", "originalInput": "give laser to microbe" },
     { "inputs": ["offer laser to microbe"], "verb": "offer", "nounOne": "laser", "nounTwo": "microbe", "preposition": "to", "originalInput": "offer laser to microbe" },
 
-    { "inputs": ["put good in cube"], "verb": "put", "nounOne": "good bedistor", "nounTwo": "cube", "preposition": "in", "originalInput": "put good in cube" },
+    // Issue #550: nounOne is the BARE adjective, which is what the real parser emits for this input
+    // (rule 3 tags the noun phrase the player actually typed). Pre-expanding it to "good bedistor"
+    // here is what kept CI green while the command was a dropped turn in production - the fixture
+    // resolved an intent the parser never produces. Keep this faithful to the parser.
+    { "inputs": ["put good in cube"], "verb": "put", "nounOne": "good", "nounTwo": "cube", "preposition": "in", "originalInput": "put good in cube" },
 
     // Stationfall's form slots. The dynamic put-X-in-Y rule only handles the four-word shape, so the
     // full form titles the game teaches the player need explicit mappings.


### PR DESCRIPTION
Closes #550.

## The bug

`put good in cube` reached no handler in production 2.0.8 — the turn collapsed to narrator prose instead of the Course Control bedistor swap.

The cause is a noun-list asymmetry between the two sibling bedistors. `FusedBedistor` registers the bare adjective `"fused"` (which is why `take fused with pliers` works), but `GoodBedistor` never registered `"good"`. The containment fallback in `ItemBase.HasMatchingNoun` cannot cover for that: it asks whether the player's *phrase* contains one of the item's nouns, so a bare `"good"` matches nothing unless it is registered itself. `MultiNounEngine` then found no noun-one anywhere in scope and fell through to generation.

This is a residual of #538 that PR #540 did not close — the preposition survives here, and the multi-noun routing and cube handler are both healthy.

## ZIL verification

The original registers the adjective on *both* siblings, so this restores original behavior rather than adding a synonym:

- `planetfall-source/compone.zil:1419` — `GOOD-BEDISTOR` … `(ADJECTIVE GOOD NINETY OHM)`
- `planetfall-source/comptwo.zil:591` — `BAD-BEDISTOR` … `(ADJECTIVE FUSED NINETY OHM)`

The Infocom parser resolves an unambiguous adjective with no head noun, which is exactly what `put good in cube` relies on.

## The fix

One noun added to `GoodBedistor.NounsForMatching`. Safe for display: names come from the **longest** noun (and `Name` from the first) — both remain `"good ninety-ohm bedistor"`, so the PR #542 display-name trap does not apply. Disambiguation is untouched: `"bedistor"` still matches both siblings.

## Why CI stayed green — and the fix for that

`base-mappings.json` pre-expanded `put good in cube` to `nounOne: "good bedistor"` — an intent the real parser never produces. Walkthrough step 262 therefore exercised the cube handler and never the bare noun. That mapping is now faithful to what the parser emits.

I verified this is a real guard rather than a cosmetic edit: with the fixture corrected and the item fix temporarily reverted, walkthrough step 262 fails with the exact production symptom (response `"\n"`), cascading into score drift.

## TDD

1. **Red** — `PutTheBedistorByItsBareAdjective_WithTheRealParser_StillFixesCourseControl` in `Planetfall.Tests/LiveParserShapeTests.cs` drives the genuine `ParsingHelper` over the tagged completion gpt-4o emits for this input. It failed on the assertion diff with the response `"\n"` — the dropped turn itself, not a setup error.
2. **Green** — register the bare noun.
3. **Guard** — `BareAdjectives_ResolveToTheirOwnBedistor_AndTheQualifiedPhrasingsStillWork` pins both adjectives to their own sibling (neither may resolve the other), the printed names, and the two phrasings that already worked in prod (`take fused with pliers`, `put good bedistor in cube`).
4. **Verified, run separately** — Planetfall.Tests 4017 ✅ · UnitTests 1304 ✅ · ZorkOne.Tests 1782 ✅ · Stationfall.Tests 123 ✅ · EscapeRoom.Tests 9 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)