### PR TITLE
Guard flask possession before the Comm Room coolant pour (#547)

### DIFF
--- a/Planetfall.Tests/CommRoomAndMachineRoomTests.cs
+++ b/Planetfall.Tests/CommRoomAndMachineRoomTests.cs
@@ -501,6 +501,104 @@ public class CommRoomAndMachineRoomTests : EngineTestsBase
         Console.WriteLine(GetLocation<SystemsMonitors>().GetDescriptionForGeneration(target.Context));
     }
 
+    // Issue #547: the coolant pour resolved the flask through the repository-global singleton with no
+    // possession or scope check at all, so a player standing here empty-handed drained -- and consumed --
+    // a flask sitting anywhere on the map. In the original the possession check is the first thing the
+    // PUT/POUR branch does, before any state mutation (planetfall-source/compone.zil:2982-2985), and the
+    // fluid is only in scope when the flask is: pouring a flask you are not holding is not possible.
+    // Here the flask is on the floor of the Comm Room -- visible, so the refusal names it.
+    [Test]
+    public async Task PourLiquid_FlaskOnTheFloorHere_Refuses()
+    {
+        var target = GetTarget();
+        StartHere<CommRoom>();
+        GetLocation<CommRoom>().ItemPlacedHere(GetItem<Flask>());
+        GetItem<Flask>().LiquidColor = "black";
+
+        var response = await target.GetResponse("pour fluid into hole");
+
+        response.Should().Contain("You're not holding the flask.");
+        GetItem<Flask>().LiquidColor.Should().Be("black"); // not drained
+        GetLocation<CommRoom>().CurrentColor.Should().Be("black"); // puzzle did not advance
+        GetLocation<CommRoom>().IsFixed.Should().BeFalse();
+        GetLocation<CommRoom>().SystemIsCritical.Should().BeFalse();
+    }
+
+    // Issue #547, repro A: the flask left behind in the next room over. The puzzle must not advance and
+    // the remote flask must not be silently emptied -- the player would have no way to connect the empty
+    // flask they later find to the command they typed a room away.
+    [Test]
+    public async Task PourLiquid_FlaskLeftInAnotherRoom_DoesNotDrainItOrAdvancePuzzle()
+    {
+        var target = GetTarget();
+        StartHere<CommRoom>();
+        GetLocation<TowerCore>().ItemPlacedHere(GetItem<Flask>());
+        GetItem<Flask>().LiquidColor = "black";
+
+        var response = await target.GetResponse("pour fluid into hole");
+
+        response.Should().NotContain("The liquid disappears into the hole.");
+        GetItem<Flask>().LiquidColor.Should().Be("black");
+        GetLocation<CommRoom>().CurrentColor.Should().Be("black");
+        GetLocation<CommRoom>().IsFixed.Should().BeFalse();
+    }
+
+    // Issue #547, repro B -- the destructive half, and the one that actually costs the player the game.
+    // Forgetting "take flask" after filling it is an ordinary slip the walkthrough's own "put flask under
+    // spout" step sets up. With the wrong color still in the abandoned flask, one pour here used to shut
+    // the send console down permanently (PermanentlyBroken), putting the 6 points out of reach forever.
+    [Test]
+    public async Task PourLiquid_FlaskLeftUnderSpout_DoesNotShutDownConsole()
+    {
+        var target = GetTarget();
+        Take<Flask>();
+        StartHere<MachineShop>();
+        await target.GetResponse("put flask under spout"); // flask leaves inventory
+        GetItem<Flask>().LiquidColor = "red"; // wrong color
+
+        StartHere<CommRoom>();
+        var response = await target.GetResponse("pour fluid into hole");
+
+        response.Should().NotContain("the send console shuts down");
+        GetLocation<CommRoom>().SystemIsCritical.Should().BeFalse();
+        GetItem<Flask>().LiquidColor.Should().Be("red");
+        target.Context.Score.Should().Be(0);
+    }
+
+    // Issue #547 guard, mirroring PutFlaskUnderSpout_FlaskInUniformPocket_Success: the possession check
+    // must be the container-aware IsCarrying<T>(), not the flat HasItem<T>(), or the flask carried in the
+    // Patrol uniform pocket counts as "not held" and the pour falls to the narrator again (issue #503).
+    [Test]
+    public async Task PourLiquid_FlaskInUniformPocket_Success()
+    {
+        var target = GetTarget();
+        Pocket<Flask>();
+        StartHere<CommRoom>();
+        GetItem<Flask>().LiquidColor = "black";
+
+        var response = await target.GetResponse("pour fluid into hole");
+
+        response.Should().Contain("and all go off except one, a gray light");
+        GetLocation<CommRoom>().CurrentColor.Should().Be("gray");
+    }
+
+    // Issue #547 defect 2: the funnel-shaped hole is printed in all three console states in the original
+    // -- only the "whose lights are all dark" clause is conditional (planetfall-source/compone.zil:2835-2846).
+    // The critical description dropped the sentence, so after a shutdown the room answered commands aimed
+    // at a hole it no longer mentioned.
+    [Test]
+    public async Task CommRoom_CriticalDescription_MentionsFunnelHole()
+    {
+        var target = GetTarget();
+        StartHere<CommRoom>();
+        GetLocation<CommRoom>().SystemIsCritical = true;
+
+        var response = await target.GetResponse("look");
+
+        response.Should().Contain("funnel-shaped hole");
+        response.Should().Contain("Kuulint Sistum Manyuuwul Oovuriid");
+    }
+
     // Issue #463: a wrong-color pour shuts the send console down (SystemIsCritical) and the failure is
     // described as permanent ("...Shuteeng Down Awl Sistumz... the send console shuts down"). But PourLiquid
     // branched only on flask color vs CurrentColor, and PermanentlyBroken() left CurrentColor untouched --

--- a/Planetfall/Location/Kalamontee/Tower/CommRoom.cs
+++ b/Planetfall/Location/Kalamontee/Tower/CommRoom.cs
@@ -7,10 +7,19 @@ namespace Planetfall.Location.Kalamontee.Tower;
 
 internal class CommRoom : LocationWithNoStartingItems, IFloydDoesNotTalkHere
 {
+    /// <summary>
+    ///     The funnel hole is part of the console itself, so it is described in every state of the send
+    ///     station -- broken, shut down, or transmitting. Issue #547: the critical description was the one
+    ///     that dropped this sentence, so after a shutdown the room kept answering commands aimed at a hole
+    ///     it no longer mentioned. Shared by all three descriptions so they cannot drift apart again.
+    /// </summary>
+    private const string FunnelHoleDescription =
+        "On the console next to the enunciator panel is a funnel-shaped hole labelled \"Kuulint Sistum Manyuuwul Oovuriid.\"";
+
     private const string FixedDescription =
         " A screen on the console displays a message. Next to the screen is a flashing sign which " +
         "says \"Tranzmishun in pragres.\" Next to this console is an enunciator whose lights are all dark. " +
-        "On the console next to the enunciator panel is a funnel-shaped hole labelled \"Kuulint Sistum Manyuuwul Oovuriid.\"";
+        FunnelHoleDescription;
 
     public override string Name => "Comm Room";
 
@@ -24,15 +33,14 @@ internal class CommRoom : LocationWithNoStartingItems, IFloydDoesNotTalkHere
 
     private string BrokenDescription => "A screen on the console displays a message. Next to the screen " +
                                         "is a flashing sign which says \"Malfunkshun in Sendeeng Kuulint Sistum.\" Next to this console " +
-                                        "is an enunciator. On the console next to the enunciator panel is a funnel-shaped hole " +
-                                        "labelled \"Kuulint Sistum Manyuuwul Oovuriid.\"" +
+                                        "is an enunciator. " + FunnelHoleDescription +
                                         $"\n\nA {CurrentColor} colored light is flashing on the enunciator panel.";
 
     private string CriticalDescription =>
         "A screen on the console displays a message. Next to the screen is " +
         "a flashing sign which says \"Kuulint Sistum Imbalins Kritikul -- " +
         "Shuteeng Down Awl Sistumz.\" Next to this console is an enunciator " +
-        "whose lights are all dark. ";
+        "whose lights are all dark. " + FunnelHoleDescription;
 
 
     public override Task<InteractionResult?> RespondToMultiNounInteraction(MultiNounIntent action, IContext context)
@@ -45,7 +53,24 @@ internal class CommRoom : LocationWithNoStartingItems, IFloydDoesNotTalkHere
         if (!action.Match(verbs, liquidNouns, holeNouns, prepositions))
             return base.RespondToMultiNounInteraction(action, context);
 
-        if (string.IsNullOrEmpty(GetItem<Flask>().LiquidColor))
+        var flask = GetItem<Flask>();
+
+        // Issue #547: everything below resolves the flask through the repository-global singleton, so
+        // without this guard a player standing here empty-handed drained -- and consumed -- a flask sitting
+        // anywhere else on the map, either advancing the puzzle or shutting the send console down for good.
+        // Possession is settled before any state branch runs, exactly as in the original, where the
+        // not-holding check opens the PUT/POUR branch ahead of every mutation and the fluid is in scope only
+        // while the flask is. IsCarrying (not the flat HasItem) so the flask still works from the Patrol
+        // uniform pocket -- the issue #503 correction. If the flask isn't in scope at all there is nothing
+        // to name, so fall through normally rather than announcing a flask the player may never have seen.
+        if (flask.IsHereButNotInInventory(context))
+            return Task.FromResult<InteractionResult?>(new PositiveInteractionResult(
+                "You're not holding the flask. "));
+
+        if (!context.IsCarrying<Flask>())
+            return base.RespondToMultiNounInteraction(action, context);
+
+        if (string.IsNullOrEmpty(flask.LiquidColor))
             return base.RespondToMultiNounInteraction(action, context);
 
         return PourLiquid(context);


### PR DESCRIPTION
Fixes #547.

## The bug

`Planetfall/Location/Kalamontee/Tower/CommRoom.cs` matched `pour fluid into hole` and then went straight to `GetItem<Flask>()` — a repository-global singleton lookup with no possession, room, or scope check between. A player standing in the Comm Room **empty-handed** drained, and consumed, a flask sitting anywhere else on the map:

- **Puzzle bypass.** Drop the full flask in Tower Core, walk NE, `pour fluid into hole` → the enunciator advances a stage and the remote flask is silently emptied. The Machine Shop → Tower → Comm Room fetch loop, twice, *is* the design of this puzzle; it could be completed with the flask parked anywhere.
- **Permanent score loss on an ordinary slip.** Fill the flask and forget `take flask` — the state the walkthrough's own `put flask under spout` step sets up — and one `pour fluid into hole` with the wrong colour still in the abandoned flask runs `PermanentlyBroken()`. The send console shuts down for good, the 6 points are unreachable, and the flask that caused it was eleven rooms and an elevator ride away.

Separately, `CriticalDescription` had dropped the funnel-hole sentence that the broken and fixed descriptions both print, so after a shutdown the room kept answering commands aimed at a hole it no longer mentioned.

## The fix

Settle possession **first**, before any state branch or global read, mirroring the guard `MachineShop` already has for `put flask under spout`:

- Flask visible here but not held → `"You're not holding the flask. "`.
- Flask nowhere in scope → fall through normally, rather than naming a flask the player may never have seen.
- The check is the container-aware `context.IsCarrying<Flask>()`, not the flat `HasItem<T>()`, so the flask still pours from the Patrol uniform pocket (the issue #503 correction).

The `SystemIsCritical` / `IsFixed` terminal guards from #463 are untouched; the new check sits ahead of them.

`CriticalDescription` gets the funnel-hole sentence back, and the sentence is now one shared `const` used by all three states so they cannot drift apart again. The fixed and broken descriptions render byte-for-byte as before.

### Original behavior (ZIL — verification only, nothing ported)

The not-holding check opens the `PUT`/`POUR` branch ahead of every mutation (`planetfall-source/compone.zil:2982-2985`), and the chemical fluid is in scope only while the flask is — pouring a flask you are not holding is not possible in the original. The funnel-hole sentence is printed in all three console states; only the "whose lights are all dark" clause is conditional (`planetfall-source/compone.zil:2835-2846`).

## Tests

TDD — all five added to `Planetfall.Tests/CommRoomAndMachineRoomTests.cs`; the four marked ✗ failed on the current code for the right reason and pass after the fix:

| Test | Before |
|---|---|
| `PourLiquid_FlaskOnTheFloorHere_Refuses` | ✗ poured successfully and advanced the puzzle |
| `PourLiquid_FlaskLeftInAnotherRoom_DoesNotDrainItOrAdvancePuzzle` | ✗ drained the remote flask |
| `PourLiquid_FlaskLeftUnderSpout_DoesNotShutDownConsole` | ✗ shut the console down permanently |
| `CommRoom_CriticalDescription_MentionsFunnelHole` | ✗ no hole in the description |
| `PourLiquid_FlaskInUniformPocket_Success` | green — pins the container-aware guard against a `HasItem<T>()` "fix" |

The existing `PourLiquid_Black` / `_Red` / `_Gray` tests all `Take<Flask>()` first, so the new guard is a no-op for them; they are unchanged and still green.

Full sweep, every suite run separately: Planetfall.Tests 4020, UnitTests 1304, ZorkOne.Tests 1782, Stationfall.Tests 123, EscapeRoom.Tests 9 — **0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)