### PR TITLE
Route a mis-bucketed "enter/exit <thing>" move back to the board path (#551)

### DIFF
--- a/GameEngine/IntentEngine/MoveEngine.cs
+++ b/GameEngine/IntentEngine/MoveEngine.cs
@@ -1,6 +1,7 @@
 using GameEngine.StaticCommand.Implementation;
 using Model.AIGeneration;
 using Model.AIGeneration.Requests;
+using Model.Intent;
 using Model.Interface;
 using Model.Movement;
 
@@ -22,7 +23,13 @@ public class MoveEngine : IIntentEngine
         MovementParameters? movement = context.CurrentLocation.Navigate(moveTo.Direction, context);
 
         if (movement == null)
+        {
+            var entered = await TryEnterTheNamedObject(moveTo, context, generationClient);
+            if (entered is not null)
+                return entered.Value;
+
             return (null, await GetGeneratedCantGoThatWayResponse(generationClient, moveTo.Direction.ToString(), context));
+        }
         
         if (movement.WeightLimit < context.CarryingWeight)
             return (null, movement.WeightLimitFailureMessage);
@@ -41,6 +48,36 @@ public class MoveEngine : IIntentEngine
             .Where(n => context.HasMatchingNoun(n).HasItem).ToList();
 
         return (null, await Go(context, generationClient, movement));
+    }
+
+    /// <summary>
+    ///     Issue #551. "enter &lt;thing&gt;" is a board command, but the AI parser's direction list also
+    ///     contains the word "enter", so gpt-4o routinely buckets bare "enter door" as a move in
+    ///     <see cref="Direction.In" /> with the door merely tagged as a noun. In the Planetfall Elevator
+    ///     Lobby - a room with two doors and no In exit - that meant a real player got "You cannot go
+    ///     that way." where the #532 fix promises "Do you mean the lower or the upper elevator door?".
+    ///     The deterministic TestParser maps "enter door" straight to an EnterSubLocationIntent, so the
+    ///     suite never saw it.
+    ///     <para>
+    ///         Deliberately narrow, so this can only turn a refusal into the action the player asked for
+    ///         and never redirect a move that already worked: it runs only after the map has said there
+    ///         is NO exit this way at all, only for In (the direction the word "enter" produces), and
+    ///         only when the noun they typed names something actually in scope. Everything else - the
+    ///         "which door?" question, a sub-location, a door to walk through, the plain refusal for a
+    ///         noun you can't enter - is <see cref="EnterSubLocationEngine" />'s existing job.
+    ///     </para>
+    /// </summary>
+    private static async Task<(InteractionResult? resultObject, string ResultMessage)?> TryEnterTheNamedObject(
+        MoveIntent moveTo, IContext context, IGenerationClient generationClient)
+    {
+        if (moveTo.Direction != Direction.In || string.IsNullOrWhiteSpace(moveTo.Noun))
+            return null;
+
+        if (Repository.GetItemInScope(moveTo.Noun, context) is null)
+            return null;
+
+        return await new EnterSubLocationEngine().Process(
+            new EnterSubLocationIntent { Noun = moveTo.Noun, Message = moveTo.Message }, context, generationClient);
     }
 
     public static async Task<string> Go(IContext context, IGenerationClient generationClient, MovementParameters movement)

--- a/GameEngine/IntentEngine/MoveEngine.cs
+++ b/GameEngine/IntentEngine/MoveEngine.cs
@@ -24,9 +24,9 @@ public class MoveEngine : IIntentEngine
 
         if (movement == null)
         {
-            var entered = await TryEnterTheNamedObject(moveTo, context, generationClient);
-            if (entered is not null)
-                return entered.Value;
+            var boarded = await TryBoardTheNamedObject(moveTo, context, generationClient);
+            if (boarded is not null)
+                return boarded.Value;
 
             return (null, await GetGeneratedCantGoThatWayResponse(generationClient, moveTo.Direction.ToString(), context));
         }
@@ -51,33 +51,40 @@ public class MoveEngine : IIntentEngine
     }
 
     /// <summary>
-    ///     Issue #551. "enter &lt;thing&gt;" is a board command, but the AI parser's direction list also
-    ///     contains the word "enter", so gpt-4o routinely buckets bare "enter door" as a move in
-    ///     <see cref="Direction.In" /> with the door merely tagged as a noun. In the Planetfall Elevator
-    ///     Lobby - a room with two doors and no In exit - that meant a real player got "You cannot go
-    ///     that way." where the #532 fix promises "Do you mean the lower or the upper elevator door?".
-    ///     The deterministic TestParser maps "enter door" straight to an EnterSubLocationIntent, so the
-    ///     suite never saw it.
+    ///     Issue #551. "enter &lt;thing&gt;" and "exit &lt;thing&gt;" are board/disembark commands, but the
+    ///     AI parser's direction list also contains the words "enter" and "exit", so gpt-4o routinely
+    ///     buckets bare "enter door" as a move in <see cref="Direction.In" /> - and "exit door" as one
+    ///     in <see cref="Direction.Out" /> - with the door merely tagged as a noun. In the Planetfall
+    ///     Elevator Lobby - a room with two doors and neither an In nor an Out exit - that meant a real
+    ///     player got "You cannot go that way." where the #532 fix promises "Do you mean the lower or
+    ///     the upper elevator door?". The deterministic TestParser maps both phrasings straight to
+    ///     their sub-location intents, so the suite never saw either one.
     ///     <para>
     ///         Deliberately narrow, so this can only turn a refusal into the action the player asked for
     ///         and never redirect a move that already worked: it runs only after the map has said there
-    ///         is NO exit this way at all, only for In (the direction the word "enter" produces), and
-    ///         only when the noun they typed names something actually in scope. Everything else - the
-    ///         "which door?" question, a sub-location, a door to walk through, the plain refusal for a
-    ///         noun you can't enter - is <see cref="EnterSubLocationEngine" />'s existing job.
+    ///         is NO exit this way at all, only for In and Out (the directions the words "enter" and
+    ///         "exit" produce), and only when the noun they typed names something actually in scope.
+    ///         Everything else - the "which door?" question, a sub-location to get into or out of, a
+    ///         door to walk through, the plain refusal for a noun you can't enter - is
+    ///         <see cref="EnterSubLocationEngine" />'s and <see cref="ExitSubLocationEngine" />'s
+    ///         existing job, reached here exactly as the board/disembark intents reach it.
     ///     </para>
     /// </summary>
-    private static async Task<(InteractionResult? resultObject, string ResultMessage)?> TryEnterTheNamedObject(
+    private static async Task<(InteractionResult? resultObject, string ResultMessage)?> TryBoardTheNamedObject(
         MoveIntent moveTo, IContext context, IGenerationClient generationClient)
     {
-        if (moveTo.Direction != Direction.In || string.IsNullOrWhiteSpace(moveTo.Noun))
+        if (moveTo.Direction is not (Direction.In or Direction.Out) || string.IsNullOrWhiteSpace(moveTo.Noun))
             return null;
 
         if (Repository.GetItemInScope(moveTo.Noun, context) is null)
             return null;
 
-        return await new EnterSubLocationEngine().Process(
-            new EnterSubLocationIntent { Noun = moveTo.Noun, Message = moveTo.Message }, context, generationClient);
+        return moveTo.Direction == Direction.In
+            ? await new EnterSubLocationEngine().Process(
+                new EnterSubLocationIntent { Noun = moveTo.Noun, Message = moveTo.Message }, context, generationClient)
+            : await new ExitSubLocationEngine().Process(
+                new ExitSubLocationIntent { NounOne = moveTo.Noun, Message = moveTo.Message }, context,
+                generationClient);
     }
 
     public static async Task<string> Go(IContext context, IGenerationClient generationClient, MovementParameters movement)

--- a/Model/Intent/MoveIntent.cs
+++ b/Model/Intent/MoveIntent.cs
@@ -13,8 +13,9 @@ public record MoveIntent : IntentBase
 
     /// <summary>
     ///     The object the player named alongside the direction, when they named one ("enter door",
-    ///     "go in the boat"). Null for a bare direction, which is every move the engine builds
-    ///     internally. Only <see cref="Direction.In" /> consults it - see MoveEngine, issue #551.
+    ///     "exit door", "go in the boat"). Null for a bare direction, which is every move the engine
+    ///     builds internally. Only <see cref="Direction.In" /> and <see cref="Direction.Out" /> consult
+    ///     it - see MoveEngine, issue #551.
     /// </summary>
     public string? Noun { get; init; }
 }

--- a/Model/Intent/MoveIntent.cs
+++ b/Model/Intent/MoveIntent.cs
@@ -10,4 +10,11 @@ namespace Model.Intent;
 public record MoveIntent : IntentBase
 {
     public Direction Direction { get; init; }
+
+    /// <summary>
+    ///     The object the player named alongside the direction, when they named one ("enter door",
+    ///     "go in the boat"). Null for a bare direction, which is every move the engine builds
+    ///     internally. Only <see cref="Direction.In" /> consults it - see MoveEngine, issue #551.
+    /// </summary>
+    public string? Noun { get; init; }
 }

--- a/Model/ParsingHelper.cs
+++ b/Model/ParsingHelper.cs
@@ -315,14 +315,21 @@ public static class ParsingHelper
         if (string.IsNullOrEmpty(directionTag))
             directionTag = ExtractElementsByTag(response, "verb").SingleOrDefault();
 
+        var noun = ExtractElementsByTag(response, "noun").FirstOrDefault();
+
+        // Issue #551: a resolved direction carries the noun through as well. "enter <thing>" is a
+        // board/enter command, but rule 5 also lists "enter" as a direction, so gpt-4o routinely tags
+        // "enter door" as a MOVE with <direction>enter</direction> — a direction the engine CAN honour,
+        // which is why this never reached the #268 safety net below and never reached
+        // EnterSubLocationEngine either. The engine needs the object the player named in order to
+        // recover; MoveEngine consults it only when the direction is In and there is no exit that way.
         var direction = DirectionParser.ParseDirection(directionTag ?? string.Empty);
         if (direction != Direction.Unknown)
-            return new MoveIntent { Direction = direction, Message = response };
+            return new MoveIntent { Direction = direction, Noun = noun, Message = response };
 
         // Issue #268 deterministic safety net: the model tagged this "move" but the direction did not
         // resolve to a real direction (typically "other"). If it also named a place, the player wants
         // destination navigation ("move to the dome room") — emit that rather than dropping the command.
-        var noun = ExtractElementsByTag(response, "noun").FirstOrDefault();
         return string.IsNullOrEmpty(noun)
             ? null
             : new GoToDestinationIntent { Destination = noun, Message = response };

--- a/Model/ParsingHelper.cs
+++ b/Model/ParsingHelper.cs
@@ -317,12 +317,13 @@ public static class ParsingHelper
 
         var noun = ExtractElementsByTag(response, "noun").FirstOrDefault();
 
-        // Issue #551: a resolved direction carries the noun through as well. "enter <thing>" is a
-        // board/enter command, but rule 5 also lists "enter" as a direction, so gpt-4o routinely tags
-        // "enter door" as a MOVE with <direction>enter</direction> — a direction the engine CAN honour,
-        // which is why this never reached the #268 safety net below and never reached
-        // EnterSubLocationEngine either. The engine needs the object the player named in order to
-        // recover; MoveEngine consults it only when the direction is In and there is no exit that way.
+        // Issue #551: a resolved direction carries the noun through as well. "enter <thing>" and
+        // "exit <thing>" are board/disembark commands, but rule 5 also lists "enter" and "exit" as
+        // DIRECTIONS, so gpt-4o routinely tags "enter door" as a MOVE with <direction>enter</direction>
+        // — a direction the engine CAN honour, which is why this never reached the #268 safety net
+        // below and never reached the enter/exit engines either. The engine needs the object the player
+        // named in order to recover; MoveEngine consults it only when the direction is In or Out and
+        // there is no exit that way at all.
         var direction = DirectionParser.ParseDirection(directionTag ?? string.Empty);
         if (direction != Direction.Unknown)
             return new MoveIntent { Direction = direction, Noun = noun, Message = response };

--- a/Planetfall.Tests/LiveParserShapeTests.cs
+++ b/Planetfall.Tests/LiveParserShapeTests.cs
@@ -145,6 +145,56 @@ public class LiveParserShapeTests : EngineTestsBase
         Context.CurrentLocation.Name.Should().Be("Booth 3");
     }
 
+    /// <summary>
+    ///     Issue #551. The deterministic TestParser maps "enter door" straight to an
+    ///     EnterSubLocationIntent, so the #532/#534 disambiguation tests pass while a real player in
+    ///     the Elevator Lobby got "You cannot go that way." — gpt-4o buckets bare "enter &lt;noun&gt;"
+    ///     as a MOVE whose direction is "enter", so MoveEngine answered for a room with no In exit and
+    ///     EnterSubLocationEngine (and its "Do you mean...?") was never reached. Only the longer
+    ///     "go through door" phrasing ever got the question.
+    /// </summary>
+    [Test]
+    public async Task EnterADoor_WhenTheParserBucketsItAsAMove_StillAsksWhichDoor()
+    {
+        var target = GetTarget(ParserReturning("""
+                                               <intent>move</intent>
+                                               <verb>enter</verb>
+                                               <noun>door</noun>
+                                               <direction>enter</direction>
+                                               """));
+        StartHere<ElevatorLobby>();
+
+        var response = await target.GetResponse("enter door");
+
+        response.Should().Contain("Do you mean");
+        response.Should().Contain("upper elevator door");
+        response.Should().Contain("lower elevator door");
+        Context.CurrentLocation.Should().BeOfType<ElevatorLobby>();
+    }
+
+    /// <summary>
+    ///     And the other half of that same mis-bucketed shape: once the noun does name one door, the
+    ///     command has to actually walk through it rather than refuse. Bare "enter blue door" is the
+    ///     phrasing PR #534's table verified by hand in production.
+    /// </summary>
+    [Test]
+    public async Task EnterANamedDoor_WhenTheParserBucketsItAsAMove_StillWalksThroughIt()
+    {
+        var target = GetTarget(ParserReturning("""
+                                               <intent>move</intent>
+                                               <verb>enter</verb>
+                                               <noun>blue door</noun>
+                                               <direction>enter</direction>
+                                               """));
+        StartHere<ElevatorLobby>();
+        GetItem<UpperElevatorDoor>().IsOpen = true;
+        GetLocation<UpperElevator>().InLobby = true;
+
+        await target.GetResponse("enter blue door");
+
+        Context.CurrentLocation.Should().BeOfType<UpperElevator>();
+    }
+
     [Test]
     public async Task TakeWithATool_WhenTheParserBucketsItAsATake_StillRemovesTheFusedBedistor()
     {

--- a/Planetfall.Tests/LiveParserShapeTests.cs
+++ b/Planetfall.Tests/LiveParserShapeTests.cs
@@ -195,6 +195,54 @@ public class LiveParserShapeTests : EngineTestsBase
         Context.CurrentLocation.Should().BeOfType<UpperElevator>();
     }
 
+    /// <summary>
+    ///     The mirror image of the same defect, and the same room proves it: rule 5 lists "exit"
+    ///     alongside "enter", so "exit door" is bucketed as a move in Direction.Out. The lobby has no
+    ///     Out exit either, so ExitSubLocationEngine - which has carried the symmetric #532
+    ///     disambiguation since it was written - was just as unreachable. "exit door" is already in
+    ///     base-mappings.json, so the TestParser suite could never see this.
+    /// </summary>
+    [Test]
+    public async Task ExitADoor_WhenTheParserBucketsItAsAMove_StillAsksWhichDoor()
+    {
+        var target = GetTarget(ParserReturning("""
+                                               <intent>move</intent>
+                                               <verb>exit</verb>
+                                               <noun>door</noun>
+                                               <direction>exit</direction>
+                                               """));
+        StartHere<ElevatorLobby>();
+
+        var response = await target.GetResponse("exit door");
+
+        response.Should().Contain("Do you mean");
+        response.Should().Contain("upper elevator door");
+        response.Should().Contain("lower elevator door");
+        Context.CurrentLocation.Should().BeOfType<ElevatorLobby>();
+    }
+
+    /// <summary>
+    ///     From a given room a door gates exactly one passage, so "exit blue door" traverses it the
+    ///     same way "enter blue door" does - the map says which way (issue #262, DoorReroute).
+    /// </summary>
+    [Test]
+    public async Task ExitANamedDoor_WhenTheParserBucketsItAsAMove_StillWalksThroughIt()
+    {
+        var target = GetTarget(ParserReturning("""
+                                               <intent>move</intent>
+                                               <verb>exit</verb>
+                                               <noun>blue door</noun>
+                                               <direction>exit</direction>
+                                               """));
+        StartHere<ElevatorLobby>();
+        GetItem<UpperElevatorDoor>().IsOpen = true;
+        GetLocation<UpperElevator>().InLobby = true;
+
+        await target.GetResponse("exit blue door");
+
+        Context.CurrentLocation.Should().BeOfType<UpperElevator>();
+    }
+
     [Test]
     public async Task TakeWithATool_WhenTheParserBucketsItAsATake_StillRemovesTheFusedBedistor()
     {


### PR DESCRIPTION
Fixes #551.

## The shortfall

PR #534's player-facing table promises this in the Planetfall Elevator Lobby:

| Command | Before | After |
|---|---|---|
| `enter door` | silently picked the red one | "Do you mean...?" |

A real player on 2.0.8 got `You cannot go that way.` — `MoveEngine`'s refusal, not `EnterSubLocationEngine`'s question. Everything else in that table verified live: `examine door` and `go through door` both disambiguate, `enter blue door` / `enter red door` both work.

## Root cause

The #532 fix is correct and deployed. What was missing is the live routing *to* it.

Rule 5 of the parser's system prompt lists **"enter"** and **"exit"** among the directions, so gpt-4o buckets bare `enter door` as:

```
<intent>move</intent>
<verb>enter</verb>
<noun>door</noun>
<direction>enter</direction>
```

`ParsingHelper.DetermineMoveIntent` resolved that to `Direction.In` and **dropped the noun on the floor**. The Elevator Lobby has no In exit, so `MoveEngine` refused and `EnterSubLocationEngine` — and therefore `NounDisambiguator` — was never reached. The #268 safety net below it did not catch this because the *direction* resolved fine; it is the *object* that was lost.

`exit door` is the same defect mirrored: `Direction.Out`, no Out exit in that room either, and `ExitSubLocationEngine` — which has carried the symmetric #532 disambiguation since it was written — equally unreachable.

Every existing test passed because `UnitTests.TestParser` maps both `enter door` and `exit door` straight to their sub-location intents (`base-mappings.json:391` and `:408`), so the suite proved the engine wiring rather than the live routing — the fixture blind spot from #540 / #526 / #423.

## The fix

`MoveIntent` now carries the noun the player named, and `MoveEngine` falls through to `EnterSubLocationEngine` / `ExitSubLocationEngine` when the map has said there is no exit that way.

Deliberately narrow, so it can only turn a refusal into the action the player asked for and never redirect a move that already worked:

- only after `Navigate` returns `null` (no exit this way at all — a *gated* In/Out exit keeps its own "the door is closed" message),
- only for `Direction.In` and `Direction.Out`, the directions the words "enter" and "exit" produce,
- and only when the noun names something actually in scope.

The "which door?" question, the sub-location to get into or out of, the walk-through-a-door reroute and the plain "you can't enter that" refusal are all the two engines' existing behavior, untouched — reached here exactly as the board/disembark intents reach them. That includes `ExitSubLocationEngine`'s existing precedence, where standing inside a sub-location gets you out of that sub-location whatever noun you named.

## Tests (TDD)

All four new tests live in `Planetfall.Tests/LiveParserShapeTests.cs` — the harness #540 added, which drives the genuine `IntentParser` over the tagged completion the model emits. It is the only place that can express this, since `base-mappings.json` cannot.

| Test | Fails on main with |
|---|---|
| `EnterADoor_WhenTheParserBucketsItAsAMove_StillAsksWhichDoor` | `Expected response "You cannot go that way." to contain "Do you mean"` — the production symptom verbatim |
| `EnterANamedDoor_WhenTheParserBucketsItAsAMove_StillWalksThroughIt` | `Expected type to be UpperElevator, but found ElevatorLobby` |
| `ExitADoor_WhenTheParserBucketsItAsAMove_StillAsksWhichDoor` | `Expected response "You cannot go that way." to contain "Do you mean"` |
| `ExitANamedDoor_WhenTheParserBucketsItAsAMove_StillWalksThroughIt` | `Expected type to be UpperElevator, but found ElevatorLobby` |

All four pass after the fix. Full sweep, all suites green: UnitTests 1304, Planetfall.Tests 4019, ZorkOne.Tests 1782, Stationfall.Tests 123, EscapeRoom.Tests 9, Console.Tests 26.

## Not addressed here

`enter <adjacent room name>` bucketed as a move still refuses rather than navigating. The live parser sends those through `goto`, which already works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)