### PR TITLE
Fix #568: the walkthrough's own phrasing for the activation form

### DIFF
--- a/Stationfall.Tests/DuffyRegressionTests.cs
+++ b/Stationfall.Tests/DuffyRegressionTests.cs
@@ -1,3 +1,4 @@
+using Model.Intent;
 using FluentAssertions;
 using GameEngine;
 using Stationfall.Item.Duffy;
@@ -191,6 +192,47 @@ public class DuffyRegressionTests : EngineTestsBase
     }
 
     // --- helpers -------------------------------------------------------------------------------
+
+    /// <summary>
+    ///     Issue #568. The walkthrough's own canonical phrasing, "put class three activation form in
+    ///     slot", failed on production with "There's no room." — the generic container refusal — because
+    ///     the form did not answer to that exact phrase and FormSlotBase.ResolveForm needs an exact hit.
+    ///     <para>
+    ///         This drives the slot directly with the noun the phrase produces, rather than going through
+    ///         the engine, on purpose. The walkthrough row that supposedly covers this passes today only
+    ///         because a test mapping rewrites the noun to the full title before the form ever sees it
+    ///         (base-mappings.json), so the oracle could never have caught this. The intent below is what
+    ///         production actually hands the slot.
+    ///     </para>
+    /// </summary>
+    [TestCase("class three activation form")]
+    [TestCase("class three spacecraft activation form")]
+    [TestCase("activation form")]
+    [TestCase("activation")]
+    [TestCase("form")]
+    public async Task EveryDocumentedPhrasingForTheActivationForm_ActivatesTheSpacecraft(string noun)
+    {
+        var engine = GetTarget();
+        await BoardTheTruckWithFloyd(engine);
+        await engine.GetResponse("close hatch");
+        await engine.GetResponse("sit in pilot seat");
+
+        // ItemOne is deliberately left null: production's parser did not resolve it either, which is
+        // exactly why resolution fell through to the noun list.
+        var result = await Repository.GetItem<SpacetruckSlot>().RespondToMultiNounInteraction(
+            new MultiNounIntent
+            {
+                Verb = "put",
+                NounOne = noun,
+                NounTwo = "slot",
+                Preposition = "in",
+                OriginalInput = $"put {noun} in slot"
+            },
+            engine.Context);
+
+        result!.InteractionMessage.Should().Contain("Spacecraft activated",
+            $"\"{noun}\" is a phrasing the player is invited to type");
+    }
 
     private static async Task SelectFloyd(GameEngine<StationfallGame, StationfallContext> engine)
     {

--- a/Stationfall/Item/Duffy/ClassThreeSpacecraftActivationForm.cs
+++ b/Stationfall/Item/Duffy/ClassThreeSpacecraftActivationForm.cs
@@ -13,8 +13,8 @@ public class ClassThreeSpacecraftActivationForm : FormBase
     // "activation" is the unique single-word handle for this form; see RobotUseAuthorizationForm.
     public override string[] NounsForMatching =>
     [
-        "activation", "class three spacecraft activation form", "spacecraft activation form", "activation form",
-        "spacecraft form", "class three form", "hb-56-v", "form"
+        "activation", "class three spacecraft activation form", "class three activation form", "spacecraft activation form", "activation form", "spacecraft form", "class three form",
+        "hb-56-v", "form"
     ];
 
     public override string ReadDescription =>

--- a/UnitTests/IntentMappings/base-mappings.json
+++ b/UnitTests/IntentMappings/base-mappings.json
@@ -362,7 +362,12 @@
     // Stationfall's form slots. The dynamic put-X-in-Y rule only handles the four-word shape, so the
     // full form titles the game teaches the player need explicit mappings.
     { "inputs": ["put robot use authorization form in slot", "insert robot use authorization form in slot"], "verb": "put", "nounOne": "robot use authorization form", "nounTwo": "slot", "preposition": "in", "originalInput": "put robot use authorization form in slot" },
-    { "inputs": ["put class three activation form in slot", "put class three spacecraft activation form in slot"], "verb": "put", "nounOne": "class three spacecraft activation form", "nounTwo": "slot", "preposition": "in", "originalInput": "put class three activation form in slot" },
+    // Split deliberately (issue #568): one entry covering both phrasings had to pick ONE nounOne, so it
+    // rewrote "class three activation form" into the full title before the form ever saw it. That hid a
+    // real gap in the form's noun list - the walkthrough row passed while production failed on the very
+    // phrasing the walkthrough documents. Each phrasing now passes through the noun the player typed.
+    { "inputs": ["put class three activation form in slot"], "verb": "put", "nounOne": "class three activation form", "nounTwo": "slot", "preposition": "in", "originalInput": "put class three activation form in slot" },
+    { "inputs": ["put class three spacecraft activation form in slot"], "verb": "put", "nounOne": "class three spacecraft activation form", "nounTwo": "slot", "preposition": "in", "originalInput": "put class three spacecraft activation form in slot" },
     { "inputs": ["put assignment completion form in slot", "insert assignment completion form in slot"], "verb": "put", "nounOne": "assignment completion form", "nounTwo": "slot", "preposition": "in", "originalInput": "put assignment completion form in slot" },
 
     // Stationfall: handing a form to one of the Duffy's robots. "give" is not one of the test parser's


### PR DESCRIPTION
Fixes #568.

## Heads up before you read the diff

The repo owner has never played Stationfall and is building this port in order to play it. **This PR body is spoiler-free; the diff is not.**

## The bug

`put class three activation form in slot` — the wording the shipped walkthrough tells a player to type — failed on production with `There's no room.`, the generic container refusal, which says nothing about what actually went wrong. The spacecraft never activated, so every step of the launch sequence after it silently did nothing.

The form answered to the full title and to several short forms, but not to the middle variant that drops "spacecraft". `FormSlotBase.ResolveForm` needs an exact hit, so the phrase resolved to nothing and fell through to `ContainerBase`, whose slot deliberately has no room for anything.

One missing noun. The noun is added.

## The more useful half: why the oracle didn't catch it

The walkthrough fixture drives this exact phrasing and has been green throughout.

It passed because a test mapping in `base-mappings.json` covered both phrasings with a single entry — and an entry can only emit one `nounOne`, so it **rewrote** `"class three activation form"` into the full title before the form ever saw it. The oracle was asserting against a noun the player never typed. It could not have caught this bug, or any bug of this shape.

The entry is now split, one per phrasing, each passing through the noun actually typed.

**Verified rather than assumed:** with the mapping split and the product fix reverted, the walkthrough now fails at the documented step and cascades through the launch sequence, exactly as production did. Before the split it passed blind.

## TDD

Per `CLAUDE.md`. The failing test drives the slot directly with the intent production hands it — `ItemOne` left null, because production's parser didn't resolve it either — rather than through the engine, where the mapping would have masked it a second time.

Red first, and for the right reason: of the five documented phrasings driven, **only the missing one failed**.

## Scope checks the issue asked for

- **Sibling forms** (`RobotUseAuthorizationForm`, `AssignmentCompletionForm`): their noun lists cover their own documented phrasings. No change needed.
- **Other masking mappings**: scanned for entries emitting a noun absent from their own inputs. Three exist, all in the other games and all deliberate synonym normalisation (`turn on lantern` → `lamp`) rather than masking. Left alone.

## Tests

| Suite | Result |
|---|---|
| Stationfall | 128 |
| Planetfall | 4015 |
| UnitTests | 1304 |
| ZorkOne | 1782 |
| EscapeRoom | 9 |
| Console | 26 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)