### PR TITLE
Let the game backends start in Development, and share one hosted service

### DIFF
--- a/Docs/RUNNING_GAMES_LOCALLY.md
+++ b/Docs/RUNNING_GAMES_LOCALLY.md
@@ -158,7 +158,7 @@ one (`Planetfall/Hints/PlanetfallHintProvider.cs`).
 | `ZORKAI_SAVE_DIR` | Root for sessions and saves. Default `~/.zorkai`; the containers set `/data`. |
 | `ZORKAI_SYSTEM_PROMPT` | Overrides the built-in narrator prompt used in self-hosted mode. |
 | `ASPNETCORE_URLS` | Bind address. Containers use `http://+:8080`. |
-| `ASPNETCORE_ENVIRONMENT` | Must be `Production`. See traps. |
+| `ASPNETCORE_ENVIRONMENT` | `Production` in the containers. `Development` also works now — see traps. |
 
 **`ZORKAI_SELF_HOSTED` is separate from `OPENAI_BASE_URL` on purpose.** Setting only the endpoint
 leaves the backend on DynamoDB — the endpoint says where the *model* lives, which is a different
@@ -240,10 +240,11 @@ Ordered by how much time they cost.
    (not_found_error)` for an unknown model, and the engine turns that into its graceful in-fiction
    error — so a wrong model id looks exactly like a game bug. `curl -s
    http://localhost:11434/v1/models` lists what is available.
-2. **`ASPNETCORE_ENVIRONMENT` must be `Production`.** Planetfall, EscapeRoom and Stationfall each
-   register `GameEngineInitializer`, an `IHostedService` (singleton) that injects the scoped
-   `IGameEngine`. Under `Development`, DI scope validation is on and the host throws at startup.
-   Pre-existing, worked around rather than fixed.
+2. **`ASPNETCORE_ENVIRONMENT` defaults to `Production`, and that is a preference now, not a
+   requirement.** `Development` used to be impossible: `GameEngineInitializer` consumed the scoped
+   `IGameEngine` from a singleton, and the `IGenerationClient` descriptor could not be constructed
+   at all, so the two validations `Development` enables killed host startup. Both are fixed, so you
+   can override it to debug. Production remains the right default for a long-running backend.
 3. **`ZORKAI_SELF_HOSTED` alone controls de-clouding.** Setting `OPENAI_BASE_URL` without it leaves
    you on DynamoDB and you will see `security token` / credential errors.
 4. **`POST /saveGame` needs a session that has already played a turn** (§3).

--- a/EscapeRoom-Lambda/src/EscapeRoom-Lambda/Startup.cs
+++ b/EscapeRoom-Lambda/src/EscapeRoom-Lambda/Startup.cs
@@ -48,21 +48,3 @@ public class Startup
         });
     }
 }
-
-public class GameEngineInitializer(IGameEngine gameEngine) : IHostedService
-{
-    // This will be called when the application starts
-    public async Task StartAsync(CancellationToken cancellationToken)
-    {
-        // Call the async initialization method on GameEngine
-        await gameEngine.InitializeEngine();
-        Console.WriteLine("GameEngine initialized!");
-    }
-
-    // Optional: This method is called during application shutdown
-    public Task StopAsync(CancellationToken cancellationToken)
-    {
-        // Perform any cleanup or shutdown logic if necessary
-        return Task.CompletedTask;
-    }
-}

--- a/GameEngine/GameEngine.csproj
+++ b/GameEngine/GameEngine.csproj
@@ -27,6 +27,9 @@
 
     <ItemGroup>
         <PackageReference Include="JetBrains.Annotations" Version="2025.2.4" />
+        <!-- Abstractions only (IHostedService), for GameEngineInitializer in Web/. The four game
+             backends share that one hosted service instead of each carrying its own copy. -->
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.3" />
         <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.3" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     </ItemGroup>

--- a/GameEngine/Web/GameEngineInitializer.cs
+++ b/GameEngine/Web/GameEngineInitializer.cs
@@ -1,0 +1,48 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Model.Interface;
+
+namespace GameEngine.Web;
+
+/// <summary>
+///     Warms the engine once at host startup so the first request does not pay for it.
+///     <para>
+///     <b>Why the scope.</b> A hosted service is a singleton, and <c>IGameEngine</c> is registered
+///     scoped. Injecting it directly — which all three game Startups used to do, each with its own
+///     copy of this class — made the host throw
+///     <c>"Cannot consume scoped service 'Model.Interface.IGameEngine' from singleton
+///     'Microsoft.Extensions.Hosting.IHostedService'"</c> whenever DI scope validation was on, i.e.
+///     under <c>ASPNETCORE_ENVIRONMENT=Development</c>. The backends could not run in Development at
+///     all. Resolving from an explicit scope is the supported way for a singleton to reach a scoped
+///     service, and it works in every environment.
+///     </para>
+///     <para>
+///     <b>What this actually warms.</b> Not the engine any request uses: <c>IGameEngine</c> is
+///     scoped, so every request builds its own, and each controller action already calls
+///     <c>InitializeEngine()</c> on it. What carries over is the <i>static</i>
+///     <see cref="Repository" />, which the engine's constructor populates with the game's items and
+///     locations and which every later engine then reuses. Keep that in mind before assuming this
+///     saves a per-request cost — it does not; it moves one-time world construction off the first
+///     request.
+///     </para>
+/// </summary>
+public class GameEngineInitializer(
+    IServiceScopeFactory scopeFactory,
+    ILogger<GameEngineInitializer> logger) : IHostedService
+{
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        using var scope = scopeFactory.CreateScope();
+        var engine = scope.ServiceProvider.GetRequiredService<IGameEngine>();
+
+        await engine.InitializeEngine();
+
+        logger.LogInformation("GameEngine initialized.");
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
+    }
+}

--- a/GameEngine/Web/ServicesHelper.cs
+++ b/GameEngine/Web/ServicesHelper.cs
@@ -58,7 +58,16 @@ public static class ServicesHelper
         // Endpoint-agnostic: ChatGPTClient resolves its endpoint and model through
         // OpenAIEndpointSettings, so the same registration serves the real OpenAI API and any
         // OpenAI-compatible server.
-        services.AddScoped<IGenerationClient, ChatGPTClient>();
+        //
+        // Built by factory, not by type. ChatGPTClient's constructor takes the NON-generic ILogger,
+        // which the container never registers (only ILogger<T>), so AddScoped<IGenerationClient,
+        // ChatGPTClient>() could never actually be constructed: "No constructor for type
+        // 'ZorkAI.OpenAI.ChatGPTClient' can be instantiated using services from the service
+        // container". That stayed invisible because nothing resolves IGenerationClient from DI — the
+        // engine news up its own — but ValidateOnBuild, which ASP.NET Core turns on under
+        // ASPNETCORE_ENVIRONMENT=Development, validates every descriptor and killed host startup.
+        services.AddScoped<IGenerationClient>(sp =>
+            new ChatGPTClient(sp.GetService<ILogger<ChatGPTClient>>()));
     }
 
     /// <summary>

--- a/Planetfall-Lambda/src/Planetfall-Lambda/Startup.cs
+++ b/Planetfall-Lambda/src/Planetfall-Lambda/Startup.cs
@@ -57,23 +57,3 @@ public class Startup
         });
     }
 }
-
-public class GameEngineInitializer(IGameEngine gameEngine) : IHostedService
-{
-    // Inject the GameEngine into the initializer
-
-    // This will be called when the application starts
-    public async Task StartAsync(CancellationToken cancellationToken)
-    {
-        // Call the async initialization method on GameEngine
-        await gameEngine.InitializeEngine();
-        Console.WriteLine("GameEngine initialized!");
-    }
-
-    // Optional: This method is called during application shutdown
-    public Task StopAsync(CancellationToken cancellationToken)
-    {
-        // Perform any cleanup or shutdown logic if necessary
-        return Task.CompletedTask;
-    }
-}

--- a/Stationfall-Lambda/src/Stationfall-Lambda/Startup.cs
+++ b/Stationfall-Lambda/src/Stationfall-Lambda/Startup.cs
@@ -54,23 +54,3 @@ public class Startup
         });
     }
 }
-
-public class GameEngineInitializer(IGameEngine gameEngine) : IHostedService
-{
-    // Inject the GameEngine into the initializer
-
-    // This will be called when the application starts
-    public async Task StartAsync(CancellationToken cancellationToken)
-    {
-        // Call the async initialization method on GameEngine
-        await gameEngine.InitializeEngine();
-        Console.WriteLine("GameEngine initialized!");
-    }
-
-    // Optional: This method is called during application shutdown
-    public Task StopAsync(CancellationToken cancellationToken)
-    {
-        // Perform any cleanup or shutdown logic if necessary
-        return Task.CompletedTask;
-    }
-}

--- a/UnitTests/Engine/GameEngineInitializerTests.cs
+++ b/UnitTests/Engine/GameEngineInitializerTests.cs
@@ -1,0 +1,87 @@
+using GameEngine.Web;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Model.Interface;
+
+namespace UnitTests.Engine;
+
+/// <summary>
+///     The hosted service that warms the engine at host startup. One fixture, because all three game
+///     backends now share one implementation in <c>GameEngine/Web/</c> — each used to carry its own
+///     copy of the class and its own copy of these tests.
+/// </summary>
+[TestFixture]
+public class GameEngineInitializerTests
+{
+    private static ServiceProvider BuildProvider(Mock<IGameEngine> engine, bool validateScopes)
+    {
+        var services = new ServiceCollection();
+
+        // Scoped, exactly as every game Startup registers it. That lifetime is the whole point: a
+        // hosted service is a singleton and may not depend on a scoped service directly.
+        services.AddScoped(_ => engine.Object);
+
+        return services.BuildServiceProvider(new ServiceProviderOptions { ValidateScopes = validateScopes });
+    }
+
+    private static GameEngineInitializer Create(ServiceProvider provider)
+    {
+        return new GameEngineInitializer(
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            NullLogger<GameEngineInitializer>.Instance);
+    }
+
+    [Test]
+    public async Task StartAsync_Should_InitializeTheEngine()
+    {
+        var engine = new Mock<IGameEngine>();
+        engine.Setup(e => e.InitializeEngine()).Returns(Task.CompletedTask);
+
+        using var provider = BuildProvider(engine, validateScopes: false);
+
+        await Create(provider).StartAsync(CancellationToken.None);
+
+        engine.Verify(e => e.InitializeEngine(), Times.Once);
+    }
+
+    [Test]
+    public async Task StartAsync_Should_Work_When_ScopeValidationIsOn()
+    {
+        // The regression. Injecting the scoped IGameEngine straight into this singleton threw
+        //   "Cannot consume scoped service 'Model.Interface.IGameEngine' from singleton
+        //    'Microsoft.Extensions.Hosting.IHostedService'"
+        // whenever ValidateScopes was on — which ASP.NET Core does for itself under
+        // ASPNETCORE_ENVIRONMENT=Development, so the backends simply could not start there.
+        // Resolving through IServiceScopeFactory is the supported route and works either way.
+        var engine = new Mock<IGameEngine>();
+        engine.Setup(e => e.InitializeEngine()).Returns(Task.CompletedTask);
+
+        using var provider = BuildProvider(engine, validateScopes: true);
+
+        var starting = async () => await Create(provider).StartAsync(CancellationToken.None);
+
+        await starting.Should().NotThrowAsync();
+        engine.Verify(e => e.InitializeEngine(), Times.Once);
+    }
+
+    [Test]
+    public async Task StopAsync_Should_CompleteSuccessfully()
+    {
+        var engine = new Mock<IGameEngine>();
+        using var provider = BuildProvider(engine, validateScopes: true);
+
+        var stopping = async () => await Create(provider).StopAsync(CancellationToken.None);
+
+        await stopping.Should().NotThrowAsync();
+    }
+
+    [Test]
+    public void Should_ImplementIHostedService()
+    {
+        var engine = new Mock<IGameEngine>();
+        using var provider = BuildProvider(engine, validateScopes: true);
+
+        Create(provider).Should().BeAssignableTo<IHostedService>();
+    }
+}

--- a/UnitTests/PlanetfallLambda/StartupTests.cs
+++ b/UnitTests/PlanetfallLambda/StartupTests.cs
@@ -1,7 +1,9 @@
+using GameEngine.Web;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Model.Interface;
 using Planetfall_Lambda;
@@ -96,6 +98,32 @@ public class StartupTests
     }
 
     [Test]
+    public void HostedServices_Should_ResolveUnderScopeValidation()
+    {
+        // ValidateScopes is what ASP.NET Core turns on for itself when
+        // ASPNETCORE_ENVIRONMENT=Development. GameEngineInitializer is a hosted service — a singleton
+        // — and it injected the scoped IGameEngine, so the host threw
+        //   "Cannot consume scoped service 'Model.Interface.IGameEngine' from singleton
+        //    'Microsoft.Extensions.Hosting.IHostedService'"
+        // at startup, and this backend could not run in Development at all. That is why the
+        // containers pin Production.
+        //
+        // Deliberately NOT ValidateOnBuild: that validates every descriptor in the container and
+        // reports eleven unrelated MVC infrastructure failures here, because AddControllers() in
+        // isolation does not register everything the real host adds. This resolves only the hosted
+        // services, so the test can fail for exactly one reason.
+        var serviceCollection = new ServiceCollection();
+        _startup.ConfigureServices(serviceCollection);
+
+        using var provider = serviceCollection.BuildServiceProvider(
+            new ServiceProviderOptions { ValidateScopes = true });
+
+        var resolving = () => provider.GetServices<IHostedService>().ToList();
+
+        resolving.Should().NotThrow();
+    }
+
+    [Test]
     public void Configure_Should_HaveCorrectSignature()
     {
         // Arrange & Act
@@ -118,51 +146,5 @@ public class StartupTests
         configureServicesMethod.Should().NotBeNull();
         configureServicesMethod!.GetParameters().Length.Should().Be(1);
         configureServicesMethod.GetParameters()[0].ParameterType.Should().Be(typeof(IServiceCollection));
-    }
-}
-
-[TestFixture]
-public class GameEngineInitializerTests
-{
-    [SetUp]
-    public void Setup()
-    {
-        _mockGameEngine = new Mock<IGameEngine>();
-        _initializer = new GameEngineInitializer(_mockGameEngine.Object);
-    }
-
-    private Mock<IGameEngine> _mockGameEngine;
-    private GameEngineInitializer _initializer;
-
-    [Test]
-    public async Task StartAsync_Should_CallInitializeEngine()
-    {
-        // Arrange
-        _mockGameEngine.Setup(e => e.InitializeEngine()).Returns(Task.CompletedTask);
-        var cancellationToken = CancellationToken.None;
-
-        // Act
-        await _initializer.StartAsync(cancellationToken);
-
-        // Assert
-        _mockGameEngine.Verify(e => e.InitializeEngine(), Times.Once);
-    }
-
-    [Test]
-    public async Task StopAsync_Should_CompleteSuccessfully()
-    {
-        // Arrange
-        var cancellationToken = CancellationToken.None;
-
-        // Act & Assert
-        await FluentActions.Invoking(() => _initializer.StopAsync(cancellationToken))
-            .Should().NotThrowAsync();
-    }
-
-    [Test]
-    public void Should_ImplementIHostedService()
-    {
-        // Assert
-        _initializer.Should().BeAssignableTo<Microsoft.Extensions.Hosting.IHostedService>();
     }
 }

--- a/UnitTests/SelfHosted/ServicesHelperSelfHostedTests.cs
+++ b/UnitTests/SelfHosted/ServicesHelperSelfHostedTests.cs
@@ -7,6 +7,8 @@ using GameEngine.Web;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Model.AIGeneration;
+using ZorkAI.OpenAI;
 using Model.Interface;
 using SecretsManager;
 
@@ -241,6 +243,22 @@ public class ServicesHelperSelfHostedTests
         var engine = (GameEngine<EscapeRoomGame, EscapeRoomContext>)provider.GetRequiredService<IGameEngine>();
 
         engine.CloudLoggingEnabled.Should().BeTrue();
+    }
+
+    [TestCase(true)]
+    [TestCase(false)]
+    public void Should_ResolveTheGenerationClient_InEitherMode(bool selfHosted)
+    {
+        if (selfHosted) GoSelfHosted(); else GoCloud();
+
+        using var provider = BuildProvider();
+
+        // ChatGPTClient's constructor takes the NON-generic ILogger, which the container never
+        // registers, so registering it by type produced a descriptor that could never be
+        // constructed. Nothing resolved IGenerationClient from DI (the engine news up its own), so
+        // it stayed invisible until ValidateOnBuild - on under ASPNETCORE_ENVIRONMENT=Development -
+        // validated every descriptor and refused to start the host.
+        provider.GetRequiredService<IGenerationClient>().Should().BeOfType<ChatGPTClient>();
     }
 
     private static Type? Implementation<TService>(IServiceCollection services)

--- a/UnitTests/StationfallLambda/StartupTests.cs
+++ b/UnitTests/StationfallLambda/StartupTests.cs
@@ -1,7 +1,9 @@
+using GameEngine.Web;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Model.Interface;
 using Stationfall_Lambda;
@@ -96,6 +98,25 @@ public class StartupTests
     }
 
     [Test]
+    public void HostedServices_Should_ResolveUnderScopeValidation()
+    {
+        // ValidateScopes is what ASP.NET Core turns on for itself under
+        // ASPNETCORE_ENVIRONMENT=Development. GameEngineInitializer is a hosted service — a singleton —
+        // and it injected the scoped IGameEngine, so the host threw at startup and this backend could
+        // not run in Development at all. Resolving only the hosted services keeps the failure specific;
+        // ValidateOnBuild would add unrelated MVC infrastructure noise.
+        var serviceCollection = new ServiceCollection();
+        _startup.ConfigureServices(serviceCollection);
+
+        using var provider = serviceCollection.BuildServiceProvider(
+            new ServiceProviderOptions { ValidateScopes = true });
+
+        var resolving = () => provider.GetServices<IHostedService>().ToList();
+
+        resolving.Should().NotThrow();
+    }
+
+    [Test]
     public void Configure_Should_HaveCorrectSignature()
     {
         // Arrange & Act
@@ -118,51 +139,5 @@ public class StartupTests
         configureServicesMethod.Should().NotBeNull();
         configureServicesMethod!.GetParameters().Length.Should().Be(1);
         configureServicesMethod.GetParameters()[0].ParameterType.Should().Be(typeof(IServiceCollection));
-    }
-}
-
-[TestFixture]
-public class GameEngineInitializerTests
-{
-    [SetUp]
-    public void Setup()
-    {
-        _mockGameEngine = new Mock<IGameEngine>();
-        _initializer = new GameEngineInitializer(_mockGameEngine.Object);
-    }
-
-    private Mock<IGameEngine> _mockGameEngine;
-    private GameEngineInitializer _initializer;
-
-    [Test]
-    public async Task StartAsync_Should_CallInitializeEngine()
-    {
-        // Arrange
-        _mockGameEngine.Setup(e => e.InitializeEngine()).Returns(Task.CompletedTask);
-        var cancellationToken = CancellationToken.None;
-
-        // Act
-        await _initializer.StartAsync(cancellationToken);
-
-        // Assert
-        _mockGameEngine.Verify(e => e.InitializeEngine(), Times.Once);
-    }
-
-    [Test]
-    public async Task StopAsync_Should_CompleteSuccessfully()
-    {
-        // Arrange
-        var cancellationToken = CancellationToken.None;
-
-        // Act & Assert
-        await FluentActions.Invoking(() => _initializer.StopAsync(cancellationToken))
-            .Should().NotThrowAsync();
-    }
-
-    [Test]
-    public void Should_ImplementIHostedService()
-    {
-        // Assert
-        _initializer.Should().BeAssignableTo<Microsoft.Extensions.Hosting.IHostedService>();
     }
 }

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -38,9 +38,11 @@ ENV ZORKAI_SAVE_DIR=/data
 # these are local backends behind nothing.
 ENV ASPNETCORE_URLS=http://+:8080
 
-# Production, not Development, and not incidentally: each game except Zork registers
-# GameEngineInitializer, an IHostedService (singleton) that injects the scoped IGameEngine. Under
-# Development, DI scope validation is on and the host throws at startup.
+# Production because that is what a long-running backend wants: no developer exception page, less
+# logging, no per-startup DI validation. It is no longer a workaround — Development used to be
+# impossible (GameEngineInitializer consumed the scoped IGameEngine from a singleton, and the
+# IGenerationClient descriptor could not be constructed at all), and both are fixed, so you can
+# override this for debugging if you want to.
 ENV ASPNETCORE_ENVIRONMENT=Production
 
 # curl is here only so compose can run a real healthcheck — the aspnet image ships without it, and a


### PR DESCRIPTION
The `ASPNETCORE_ENVIRONMENT=Production` pin in the containers was covering **two** separate startup failures. Both are only visible under `Development`, which turns on `ValidateScopes` *and* `ValidateOnBuild`.

## 1. The reported bug — scoped service in a singleton

`GameEngineInitializer` is a hosted service (a singleton) and injected the scoped `IGameEngine` directly:

```
Cannot consume scoped service 'Model.Interface.IGameEngine' from singleton
'Microsoft.Extensions.Hosting.IHostedService'
```

Now it takes `IServiceScopeFactory` and resolves the engine inside an explicit scope — the supported route for a singleton reaching a scoped service, and it works in every environment.

## 2. The one hiding behind it

With that fixed, `Development` still refused to start. `ValidateOnBuild` rejected the `IGenerationClient` descriptor: **`ChatGPTClient`'s constructor takes the non-generic `ILogger`**, which the container never registers (only `ILogger<T>`), so `AddScoped<IGenerationClient, ChatGPTClient>()` could never be constructed.

That has been true since it was written. It stayed invisible because **nothing resolves `IGenerationClient` from DI** — `GameEngine` news up its own (`GameEngine.cs:108`) — so the dead descriptor was never exercised until `ValidateOnBuild` validated every one of them. Registered by factory now, which is behavior-neutral in Production and makes the registration actually mean something.

## Consolidation

Planetfall, EscapeRoom and Stationfall each carried an **identical copy** of `GameEngineInitializer`, so this bug existed three times and the next game would have inherited a fourth. One implementation now lives in `GameEngine/Web/` beside `ServicesHelper`, which costs `Microsoft.Extensions.Hosting.Abstractions` (interfaces only). `Console.WriteLine` became `ILogger`.

Its doc comment records what the warm-up actually accomplishes, which was not obvious: the engine it initializes is **not** the one requests use, because `IGameEngine` is scoped and every controller action calls `InitializeEngine()` on its own. What carries over is the **static `Repository`** the constructor populates. Worth knowing before assuming this saves a per-request cost — it does not.

## TDD

`HostedServices_Should_ResolveUnderScopeValidation` resolves only the hosted services under `ValidateScopes`, and before the fix failed with exactly the message above.

I first wrote it with `ValidateOnBuild = true` and it failed with **eleven** aggregated exceptions — `AddControllers()` in an isolated `ServiceCollection` doesn't register everything the real host adds, so the MVC infrastructure fails validation. That test could not have failed for one reason, so I narrowed it. CLAUDE.md's "fails for the right reason" earned its keep here.

## Verified end to end

Planetfall booted with `ASPNETCORE_ENVIRONMENT=Development`:

```
root            -> Welcome to running ASP.NET Core on AWS Lambda
unhandled exceptions -> 0
hosted service  -> "GameEngine initialized."
POST /Planetfall {"Input":"look"} -> "locationName":"Deck Nine"
```

Before this it crashed during `HostBuilder.Build()`.

## Docs

The "must be Production" comments in `docker/Dockerfile` and `Docs/RUNNING_GAMES_LOCALLY.md` were stale the moment this landed. They now say Production is a *preference* for a long-running backend, not a workaround, and that `Development` works if you want to debug. I left the containers on Production deliberately — no developer exception page, less logging, no per-startup validation.

## Production impact

None expected. Deployed Lambdas run Production, so neither validation is on; the scope fix changes only *how* the initializer reaches the engine, and the `IGenerationClient` factory replaces a descriptor nothing resolved. `LambdaEntryPoint`, `serverless.template` and `deploy.yml` are untouched.

Six duplicated tests replaced with six better ones, plus two new guards. Full suites: UnitTests 1306, ZorkOne.Tests 1782, Planetfall.Tests 4015, EscapeRoom.Tests 9, Stationfall.Tests 123, Console.Tests 26 — **7261 passed, 0 failed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ZWv6Q7uMu9BKxPDyrzWiJ