### PR TITLE
Fix #577: reach scenery from the take path, not just the get path

### DIFF
--- a/GameEngine/Item/ItemProcessor/TakeOrDropInteractionProcessor.cs
+++ b/GameEngine/Item/ItemProcessor/TakeOrDropInteractionProcessor.cs
@@ -66,11 +66,28 @@ public class TakeOrDropInteractionProcessor : IVerbProcessor
     public async Task<(InteractionResult? resultObject, string? ResultMessage)> Process(TakeIntent action,
         IContext context, IGenerationClient client)
     {
-        var result = await GetItemsToTake(context,
-            new SimpleIntent { OriginalInput = action.OriginalInput, Verb = "take", Noun = action.Noun }, client);
+        var takeAction = new SimpleIntent
+            { OriginalInput = action.OriginalInput, Verb = "take", Noun = action.Noun };
+
+        var result = await GetItemsToTake(context, takeAction, client);
 
         if (result is null or NoNounMatchInteractionResult)
         {
+            // Issue #577: the noun resolved to no real item, but it may still name the room's (or the
+            // game's) inert scenery, whose authored "you can't take that" this path never consulted -
+            // so every CannotBeTakenReason in every game was reachable only by phrasing luck. Which
+            // intent shape the live parser produces varies by noun, and the canonical verb is the one
+            // that landed here: "get wall" answered, "take wall" got improvised prose that contradicted
+            // the game's own facts. Asked AFTER the item lookup, exactly as LocationBase orders it, so a
+            // genuine object sharing the noun still wins. Nothing is scenery in the dark - the
+            // SimpleIntent path never reaches its own scenery branch without light (SimpleInteractionEngine),
+            // and TakeIt's darkness guard (issue #342) is skipped entirely when no item resolved.
+            if (context.CurrentLocation?.MatchScenery(takeAction, context) is { } scenery)
+            {
+                var refusal = context.ItIsDarkHere ? "It's too dark to see! " : scenery.TakeRefusal;
+                return (new PositiveInteractionResult(refusal), refusal);
+            }
+
             var message = await client.GenerateNarration(
                 new TakeSomethingThatIsNotPortable(action.OriginalInput), context.SystemPromptAddendum);
             return (new PositiveInteractionResult(message), message);

--- a/GameEngine/Location/LocationBase.cs
+++ b/GameEngine/Location/LocationBase.cs
@@ -345,24 +345,34 @@ public abstract class LocationBase : ILocation, ICanContainItems
         // Inert scenery (issue #315). Checked AFTER real items so a genuine object that shares a noun
         // always wins. Matching the noun makes the thing "present", so an unsupported verb yields a
         // NoVerbMatch ("you can't do that to it") — never the narrator's false "no such thing is here".
-        // The room's own scenery first, then the game's global scenery - walls, floor, ceiling, the
-        // air, the player's own body - which answer everywhere. A room that has something particular
-        // to say about its walls therefore always wins over the generic reply.
-        var scenery = Scenery.FirstOrDefault(s => action.MatchNounAndAdjective(s.Nouns))
-                      ?? context.Game.GlobalScenery.FirstOrDefault(s => action.MatchNounAndAdjective(s.Nouns));
+        var scenery = MatchScenery(action, context);
         if (scenery is not null)
         {
             if (action.MatchVerb(Verbs.ExamineVerbs))
                 return new PositiveInteractionResult(scenery.ExaminationDescription);
 
             if (action.MatchVerb(Verbs.TakeVerbs))
-                return new PositiveInteractionResult(
-                    scenery.CannotBeTakenReason ?? "That's not something you can take. ");
+                return new PositiveInteractionResult(scenery.TakeRefusal);
 
             return new NoVerbMatchInteractionResult { Verb = action.Verb, Noun = action.Noun };
         }
 
         return result ?? new NoNounMatchInteractionResult();
+    }
+
+    /// <summary>
+    ///     The room's own scenery first, then the game's global scenery — walls, floor, ceiling, the
+    ///     air, the player's own body — which answer everywhere. A room that has something particular
+    ///     to say about its walls therefore always wins over the generic reply.
+    /// </summary>
+    /// <remarks>
+    ///     See <see cref="ILocation.MatchScenery" /> for why this is a seam of its own rather than a few
+    ///     lines inside <see cref="RespondToSimpleInteraction" />.
+    /// </remarks>
+    public SceneryItem? MatchScenery(SimpleIntent action, IContext context)
+    {
+        return Scenery.FirstOrDefault(s => action.MatchNounAndAdjective(s.Nouns))
+               ?? context.Game.GlobalScenery.FirstOrDefault(s => action.MatchNounAndAdjective(s.Nouns));
     }
 
     /// <summary>

--- a/Model/Location/ILocation.cs
+++ b/Model/Location/ILocation.cs
@@ -82,6 +82,21 @@ public interface ILocation
         IItemProcessorFactory itemProcessorFactory);
 
     /// <summary>
+    ///     Resolves a noun to the inert scenery it names (issue #315) — this room's own first, then the
+    ///     game's <see cref="IInfocomGame.GlobalScenery" /> — or null when it names none.
+    ///     <para>
+    ///         The single seam for that lookup. <see cref="RespondToSimpleInteraction" /> is not the only
+    ///         way a take reaches a room: the parser also emits a bare take intent, which the engine
+    ///         dispatches to the take processor instead, and that path used to resolve real items only.
+    ///         The authored "you can't take that" therefore answered "get wall" and not "take wall"
+    ///         (issue #577). Both paths ask this, so a noun cannot be scenery to one and unknown to the
+    ///         other. Callers must check <see cref="IContext.ItIsDarkHere" /> first: scenery is seen, not
+    ///         felt for.
+    ///     </para>
+    /// </summary>
+    SceneryItem? MatchScenery(SimpleIntent action, IContext context);
+
+    /// <summary>
     ///     We have parsed the user input and determined that we have a <see cref="MultiNounIntent" /> corresponding
     ///     of a verb and two nouns. Does that combination do anything in this location? The default implementation
     ///     of the base class checks each item in this locations and asks them if they provide any interaction. This

--- a/Model/Location/SceneryItem.cs
+++ b/Model/Location/SceneryItem.cs
@@ -20,4 +20,13 @@ namespace Model.Location;
 public sealed record SceneryItem(
     string[] Nouns,
     string ExaminationDescription,
-    string? CannotBeTakenReason = null);
+    string? CannotBeTakenReason = null)
+{
+    /// <summary>
+    ///     The whole answer to a take, generic fallback included. Two unrelated call sites reach a
+    ///     take refusal — the verb-and-noun path in <c>LocationBase.RespondToSimpleInteraction</c> and
+    ///     the take-intent path in <c>TakeOrDropInteractionProcessor</c> — and issue #577 was precisely
+    ///     the two disagreeing, so the sentence lives here rather than being spelled out at each one.
+    /// </summary>
+    public string TakeRefusal => CannotBeTakenReason ?? "That's not something you can take. ";
+}

--- a/Planetfall.Tests/SceneryInvariantTests.cs
+++ b/Planetfall.Tests/SceneryInvariantTests.cs
@@ -2,12 +2,14 @@ using System.Reflection;
 using FluentAssertions;
 using GameEngine;
 using GameEngine.Item;
+using GameEngine.Item.ItemProcessor;
 using GameEngine.Location;
 using Model.AIGeneration;
 using Model.AIParsing;
 using Model.Intent;
 using Model.Interaction;
 using Moq;
+using Planetfall.Item.Lawanda.Lab;
 using Planetfall.Location.Lawanda;
 
 namespace Planetfall.Tests;
@@ -118,6 +120,45 @@ public class SceneryInvariantTests : EngineTestsBase
                         new SimpleIntent { Verb = "take", Noun = noun }, engine.Context, client, factory);
                     take.InteractionMessage.Should().Be(s.CannotBeTakenReason, $"{type.Name} take '{noun}'");
                 }
+            }
+        }
+    }
+
+    /// <summary>
+    ///     Issue #577: the test above proves the refusal exists; this proves a player can reach it.
+    ///     The live parser classifies a take as a TakeIntent or a SimpleIntent depending on the noun,
+    ///     and only the SimpleIntent shape ever consulted scenery, so every authored reason in the game
+    ///     was a coin flip from the player's seat — one phrasing answered, the canonical "take" got
+    ///     improvised prose. A room's scenery is not finished until both shapes say the same thing.
+    /// </summary>
+    [Test]
+    public async Task EverySceneryTakeRefusal_IsAlsoReachable_ThroughTheTakeIntentPath()
+    {
+        var engine = GetTarget();
+
+        // Carried and lit, as a player exploring Resida would be: nothing is scenery in the dark, so
+        // an unlit sweep would measure the darkness refusal instead of the authored one.
+        engine.Context.Take(Repository.GetItem<Lamp>());
+        Repository.GetItem<Lamp>().IsOn = true;
+
+        var processor = new TakeOrDropInteractionProcessor(Mock.Of<IAITakeAndAndDropParser>());
+
+        foreach (var (type, scenery) in LocationsWithScenery())
+        {
+            var loc = (LocationBase)Activator.CreateInstance(type)!;
+            loc.Init();
+            engine.Context.CurrentLocation = loc;
+            engine.Context.ItIsDarkHere.Should().BeFalse($"{type.Name} must be lit for this sweep");
+
+            foreach (var s in scenery.Where(s => s.CannotBeTakenReason is not null))
+            {
+                var noun = s.Nouns[0];
+
+                var (_, message) = await processor.Process(
+                    new TakeIntent { Noun = noun, OriginalInput = $"take {noun}" },
+                    engine.Context, Mock.Of<IGenerationClient>());
+
+                message.Should().Be(s.CannotBeTakenReason, $"{type.Name} take '{noun}'");
             }
         }
     }

--- a/Stationfall.Tests/CompletenessSweepTests.cs
+++ b/Stationfall.Tests/CompletenessSweepTests.cs
@@ -1,6 +1,10 @@
 using FluentAssertions;
 using GameEngine;
 using GameEngine.Diagnostics;
+using GameEngine.Item.ItemProcessor;
+using Model.AIParsing;
+using Model.Intent;
+using Moq;
 
 namespace Stationfall.Tests;
 
@@ -53,17 +57,72 @@ public class CompletenessSweepTests : EngineTestsBase
         return LeakRecorder.CompletenessLeaks.ToList();
     }
 
+    /// <summary>
+    ///     The same route, asking to pick each noun up instead of looking at it — the other half of what
+    ///     a curious player does with a thing the prose just named (issue #577).
+    ///     <para>
+    ///         Deliberately NOT driven through <c>GetResponse</c>: TestParser resolves every "take X" to a
+    ///         SimpleIntent, while production's parser frequently tags it as a TakeIntent and the engine
+    ///         dispatches that to <see cref="TakeOrDropInteractionProcessor" /> instead. Sweeping only the
+    ///         shape the test parser produces is what let the take path go unmeasured while the examine
+    ///         sweep read zero. This drives the TakeIntent overload exactly as GameEngine.cs does, so the
+    ///         gaps it records are the ones a real player hits.
+    ///     </para>
+    ///     <para>
+    ///         Runs on its own engine: a take that succeeds moves an object out of the room, which would
+    ///         quietly change what the examine sweep above is looking at.
+    ///     </para>
+    /// </summary>
+    private async Task<List<NarrationLeak>> SweepTheOpeningForTakes()
+    {
+        var target = GetTarget();
+
+        // What the real take/drop list-parser does with a noun the room description does not offer as
+        // a takeable object; the processor then falls back to resolving the player's own noun.
+        var takeAndDropParser = new Mock<IAITakeAndAndDropParser>();
+        takeAndDropParser.Setup(s => s.GetListOfItemsToTake(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync([]);
+        var processor = new TakeOrDropInteractionProcessor(takeAndDropParser.Object);
+
+        foreach (var (travel, nouns) in OpeningRooms)
+        {
+            if (!string.IsNullOrEmpty(travel))
+                await target.GetResponse(travel);
+
+            foreach (var noun in nouns.Concat(UniversalNouns))
+            {
+                target.Context.LastInput = $"take {noun}";
+                await processor.Process(
+                    new TakeIntent { Noun = noun, OriginalInput = $"take {noun}" },
+                    target.Context, LeakRecorder);
+            }
+        }
+
+        return LeakRecorder.CompletenessLeaks.ToList();
+    }
+
     [Test]
     public async Task Report_WhatTheOpeningStillLeavesToTheNarrator()
     {
-        var leaks = await SweepTheOpening();
+        var examineLeaks = await SweepTheOpening();
+        var takeLeaks = await SweepTheOpeningForTakes();
 
+        Report("examine", examineLeaks);
+        Report("take", takeLeaks);
+
+        // Reporting only. The assertion that these must reach zero is the pair of tests below, which
+        // are what gate "the opening is finished".
+        Assert.Pass($"{examineLeaks.Count + takeLeaks.Count} gaps recorded.");
+    }
+
+    private static void Report(string verb, List<NarrationLeak> leaks)
+    {
         var byNoun = leaks
             .GroupBy(l => $"{l.Location} :: {l.Input}")
             .OrderBy(g => g.Key)
             .ToList();
 
-        TestContext.Out.WriteLine($"=== {leaks.Count} narrator fall-throughs across the opening ===");
+        TestContext.Out.WriteLine($"=== {leaks.Count} narrator fall-throughs across the opening ({verb}) ===");
 
         var universal = leaks.Count(l => UniversalNouns.Any(n => l.Input.EndsWith(n, StringComparison.OrdinalIgnoreCase)));
         TestContext.Out.WriteLine($"  {universal} from nouns every room should answer for (walls/floor/ceiling/air/me/hands)");
@@ -71,10 +130,6 @@ public class CompletenessSweepTests : EngineTestsBase
         TestContext.Out.WriteLine("--- room-specific gaps ---");
         foreach (var group in byNoun.Where(g => !UniversalNouns.Any(n => g.First().Input.EndsWith(n, StringComparison.OrdinalIgnoreCase))))
             TestContext.Out.WriteLine($"  {group.Key}");
-
-        // Reporting only. The assertion that this must reach zero is the test below, which is the one
-        // that gates "the opening is finished".
-        Assert.Pass($"{leaks.Count} gaps recorded.");
     }
 
     /// <summary>
@@ -89,5 +144,19 @@ public class CompletenessSweepTests : EngineTestsBase
 
         leaks.Should().BeEmpty(
             "every noun the opening's own prose puts in front of the player must have an authored answer");
+    }
+
+    /// <summary>
+    ///     The same gate for the other half of the sweep. "Examine it" and "take it" are the two things
+    ///     a player does with a noun the prose just handed them; a zero that only counts the first is a
+    ///     floor, not a ceiling (issue #577).
+    /// </summary>
+    [Test]
+    public async Task TheOpeningLeavesNothingToTheNarrator_WhenYouTryToPickThingsUp()
+    {
+        var leaks = await SweepTheOpeningForTakes();
+
+        leaks.Should().BeEmpty(
+            "every noun the opening's own prose puts in front of the player must say why it can't be taken");
     }
 }

--- a/Stationfall.Tests/GlobalSceneryTests.cs
+++ b/Stationfall.Tests/GlobalSceneryTests.cs
@@ -1,0 +1,88 @@
+using FluentAssertions;
+using GameEngine;
+using GameEngine.Item;
+using GameEngine.Item.ItemProcessor;
+using Model.AIGeneration;
+using Model.AIParsing;
+using Model.Intent;
+using Model.Interaction;
+using Moq;
+using Stationfall.Location.Duffy;
+
+namespace Stationfall.Tests;
+
+/// <summary>
+///     The nouns <see cref="StationfallGame.GlobalScenery" /> answers for in every room — walls, floor,
+///     ceiling, the air, the player's own body. They exist because an improvised answer is
+///     indistinguishable from a real one and therefore worse than nothing (issue #563), so what matters
+///     is not that the strings exist but that a player reaches them by typing the obvious thing.
+///     <para>
+///         Issue #577: they were reachable only by phrasing luck. Which intent shape the live parser
+///         produces for a take varies by noun, and only one of the two shapes ever consulted scenery —
+///         "get wall" answered, "take wall" got improvised prose that contradicted the game's own facts
+///         about the player. These pin both shapes to the same authored answer.
+///     </para>
+/// </summary>
+[TestFixture]
+public class GlobalSceneryTests : EngineTestsBase
+{
+    private static Mock<IAITakeAndAndDropParser> ParserThatFindsNothingInTheRoom()
+    {
+        // What the real take/drop list-parser does with a scenery noun: it is shown the room
+        // description and asked which of those things the player means, and a wall is not one of them.
+        var parser = new Mock<IAITakeAndAndDropParser>();
+        parser.Setup(s => s.GetListOfItemsToTake(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync([]);
+        return parser;
+    }
+
+    [Test]
+    public async Task TakeWall_ViaTakeIntent_GivesTheAuthoredRefusal()
+    {
+        // The reported repro, verbatim: on prod, "get wall" on Deck Twelve answered with the bulkhead
+        // line while "take wall" — the canonical verb the line was written for — reached no handler at
+        // all. Production's real AI parser tags it as a TakeIntent, which GameEngine dispatches
+        // straight to TakeOrDropInteractionProcessor.Process(TakeIntent, ...); TestParser can only
+        // ever produce a SimpleIntent, so the overload has to be invoked directly as GameEngine does.
+        var engine = GetTarget();
+        engine.Context.CurrentLocation = Repository.GetLocation<DeckTwelve>();
+
+        var processor = new TakeOrDropInteractionProcessor(ParserThatFindsNothingInTheRoom().Object);
+        var (_, message) = await processor.Process(
+            new TakeIntent { Noun = "wall", OriginalInput = "take wall" },
+            engine.Context, Mock.Of<IGenerationClient>());
+
+        message.Should().Contain("The bulkheads are structural, and you are not.");
+    }
+
+    [Test]
+    public async Task EveryGlobalSceneryNoun_RefusesTheSameWay_ThroughBothIntentShapes()
+    {
+        // Game-wide rather than per-noun: a new entry in GlobalScenery is covered the day it is added.
+        var engine = GetTarget();
+        var location = Repository.GetLocation<DeckTwelve>();
+        engine.Context.CurrentLocation = location;
+
+        var client = Mock.Of<IGenerationClient>();
+        var takeAndDropParser = ParserThatFindsNothingInTheRoom();
+        var processor = new TakeOrDropInteractionProcessor(takeAndDropParser.Object);
+        var factory = new ItemProcessorFactory(takeAndDropParser.Object);
+
+        foreach (var scenery in new StationfallGame().GlobalScenery)
+        foreach (var noun in scenery.Nouns)
+        {
+            var expected = scenery.CannotBeTakenReason!;
+            expected.Should().NotBeNull($"'{noun}' needs an authored reason it can't be taken");
+
+            var viaSimpleIntent = await location.RespondToSimpleInteraction(
+                new SimpleIntent { Verb = "get", Noun = noun, OriginalInput = $"get {noun}" },
+                engine.Context, client, factory);
+
+            var (_, viaTakeIntent) = await processor.Process(
+                new TakeIntent { Noun = noun, OriginalInput = $"take {noun}" }, engine.Context, client);
+
+            viaSimpleIntent.InteractionMessage.Should().Be(expected, $"get {noun}");
+            viaTakeIntent.Should().Be(expected, $"take {noun}");
+        }
+    }
+}

--- a/Stationfall/Item/Duffy/FormSlotBase.cs
+++ b/Stationfall/Item/Duffy/FormSlotBase.cs
@@ -22,6 +22,8 @@ public abstract class FormSlotBase : ContainerBase, ICanBeExamined
     public virtual string ExaminationDescription =>
         "A narrow slot, exactly wide enough to swallow a standard Patrol form. ";
 
+    public override string CannotBeTakenDescription => "The slot is part of the wall. ";
+
     /// <summary>
     ///     The form this particular slot is willing to accept, or null if it accepts none.
     /// </summary>

--- a/Stationfall/Item/Duffy/Pallets.cs
+++ b/Stationfall/Item/Duffy/Pallets.cs
@@ -18,6 +18,10 @@ public class Pallets : ItemBase, ICanBeExamined, ICanBeRead
         "Row upon row of pallets, stacked to the ceiling with identical boxes. Each box has something " +
         "stamped on the side. ";
 
+    public override string CannotBeTakenDescription =>
+        "A pallet of boxed forms is a job for a forklift, and the Patrol has not seen fit to issue " +
+        "you one. ";
+
     public string ReadDescription =>
         "The nearer boxes are labelled with the names of forms: a form for disbursing form pallets, a " +
         "form for reporting the loss of a form pallet label, and a form for releasing that report. ";

--- a/Stationfall/Item/Duffy/ShipRobot.cs
+++ b/Stationfall/Item/Duffy/ShipRobot.cs
@@ -85,6 +85,16 @@ public abstract class ShipRobot : ContainerBase, ICanBeExamined, ITurnBasedActor
 
     public abstract string ExaminationDescription { get; }
 
+    /// <summary>
+    ///     Spelled out here and not only in the physical-verb branch of
+    ///     <see cref="RespondToSimpleInteraction" />: a take never runs that branch — the engine routes
+    ///     it to the take processor, which consults this and nothing else (issue #577).
+    /// </summary>
+    public override string CannotBeTakenDescription =>
+        IsWithinReach
+            ? $"{Name} is a colleague, not a piece of luggage. "
+            : $"You can't reach {Name} from here. ";
+
     protected override int SpaceForItems => 5;
 
     /// <summary>

--- a/Stationfall/Item/Duffy/SpacetruckHatchBase.cs
+++ b/Stationfall/Item/Duffy/SpacetruckHatchBase.cs
@@ -37,6 +37,8 @@ public abstract class SpacetruckHatchBase : OpenAndCloseContainerBase, ICanBeExa
     public string ExaminationDescription =>
         $"A broad loading hatch in the side of the spacetruck. It is {(IsOpen ? "open" : "closed")}. ";
 
+    public override string CannotBeTakenDescription => "The hatch is part of the spacetruck. ";
+
     // No backing field and nothing to serialize here: the flag belongs to the holder, which is
     // serialized in its own right. This must be Newtonsoft's JsonIgnore, not System.Text.Json's - saves
     // go through JsonConvert (GameEngine.SaveGame), which ignores the STJ attribute entirely and would

--- a/UnitTests/SingleNounProcessors/TakeProcessorTests.cs
+++ b/UnitTests/SingleNounProcessors/TakeProcessorTests.cs
@@ -894,4 +894,96 @@ public class TakeProcessorTests : EngineTestsBase
         result.Should().Contain("Taken");
         target.Context.HasItem<NastyKnife>().Should().BeTrue();
     }
+
+    /// <summary>
+    ///     Issue #577: inert scenery answers "take" only when the parser happens to produce a
+    ///     SimpleIntent. Production's real AI parser tags the canonical "take &lt;noun&gt;" as a
+    ///     TakeIntent, which GameEngine dispatches straight to
+    ///     TakeOrDropInteractionProcessor.Process(TakeIntent, ...) — a path that resolves real items
+    ///     only and hands anything else to the narrator. So the authored CannotBeTakenReason existed,
+    ///     was correct, and was unreachable through the one verb players actually type: "get house"
+    ///     answered, "take house" got improvised prose. These drive the TakeIntent overload directly,
+    ///     exactly as GameEngine.cs does (same technique as the issue #342 tests above).
+    /// </summary>
+    [Test]
+    public async Task TakeScenery_ViaTakeIntent_GivesTheAuthoredRefusal()
+    {
+        var target = GetTarget();
+        target.Context.CurrentLocation = Repository.GetLocation<NorthOfHouse>();
+
+        var processor = new TakeOrDropInteractionProcessor(TakeAndDropParser.Object);
+        var (_, message) = await processor.Process(
+            new TakeIntent { Noun = "house", OriginalInput = "take house" }, target.Context, Client.Object);
+
+        message.Should().Contain("You can't take a house with you.");
+    }
+
+    [TestCase("take")]
+    [TestCase("get")]
+    [TestCase("grab")]
+    [TestCase("pick up")]
+    [TestCase("hold")]
+    [TestCase("acquire")]
+    [TestCase("snatch")]
+    [TestCase("carry")]
+    public async Task TakeScenery_EveryTakeVerb_GivesTheSameAuthoredRefusal(string verb)
+    {
+        // The whole point of the fix: which of the two intent shapes a phrasing lands in is decided by
+        // the live parser and varies by noun, so every verb in the family must produce the same answer
+        // whichever way it is classified. The verbs are deliberately spelled out rather than sourced
+        // from Verbs.TakeVerbs - a self-referential list would shrink in lockstep with a removed
+        // synonym and hide the regression (same reasoning as CannotBeTaken_CoversTheWholeTakeVerbFamily).
+        var target = GetTarget();
+        var location = Repository.GetLocation<NorthOfHouse>();
+        target.Context.CurrentLocation = location;
+
+        var viaSimpleIntent = await location.RespondToSimpleInteraction(
+            new SimpleIntent { Verb = verb, Noun = "house", OriginalInput = $"{verb} house" },
+            target.Context, Client.Object, new ItemProcessorFactory(TakeAndDropParser.Object));
+
+        var processor = new TakeOrDropInteractionProcessor(TakeAndDropParser.Object);
+        var (_, viaTakeIntent) = await processor.Process(
+            new TakeIntent { Noun = "house", OriginalInput = $"{verb} house" }, target.Context, Client.Object);
+
+        viaSimpleIntent.InteractionMessage.Should().Contain("You can't take a house with you.");
+        viaTakeIntent.Should().Contain("You can't take a house with you.");
+    }
+
+    [Test]
+    public async Task TakeScenery_ViaTakeIntent_WhenARealItemSharesTheNoun_TakesTheItemInstead()
+    {
+        // Scenery is matched only after real items on the SimpleIntent path; the TakeIntent path must
+        // keep that ordering, or declaring scenery anywhere could shadow a genuine takeable object.
+        var target = GetTarget();
+        var location = Repository.GetLocation<NorthOfHouse>();
+        target.Context.CurrentLocation = location;
+        location.ItemPlacedHere(Repository.GetItem<Leaflet>());
+
+        var processor = new TakeOrDropInteractionProcessor(TakeAndDropParser.Object);
+        var (_, message) = await processor.Process(
+            new TakeIntent { Noun = "leaflet", OriginalInput = "take leaflet" }, target.Context, Client.Object);
+
+        message.Should().Contain("Taken");
+        target.Context.HasItem<Leaflet>().Should().BeTrue();
+    }
+
+    [Test]
+    public async Task TakeScenery_ViaTakeIntent_InADarkRoom_SaysTooDark()
+    {
+        // Scenery is a thing you can see, not a thing you can feel for: the SimpleIntent path never
+        // reaches the scenery branch in the dark (SimpleInteractionEngine's darkness guard fires
+        // first), so the TakeIntent path must not describe the Torch Room's railing to a player
+        // standing in the pitch black either.
+        var target = GetTarget();
+        target.Context.CurrentLocation = Repository.GetLocation<TorchRoom>();
+
+        target.Context.ItIsDarkHere.Should().BeTrue();
+
+        var processor = new TakeOrDropInteractionProcessor(TakeAndDropParser.Object);
+        var (_, message) = await processor.Process(
+            new TakeIntent { Noun = "railing", OriginalInput = "take railing" }, target.Context, Client.Object);
+
+        message.Should().Contain("too dark");
+        message.Should().NotContain("twenty feet up");
+    }
 }

--- a/UnitTests/ZorkSceneryInvariantTests.cs
+++ b/UnitTests/ZorkSceneryInvariantTests.cs
@@ -2,6 +2,7 @@ using Model.Location;
 using System.Reflection;
 using GameEngine;
 using GameEngine.Item;
+using GameEngine.Item.ItemProcessor;
 using GameEngine.Location;
 using Model.AIGeneration;
 using Model.AIParsing;
@@ -110,6 +111,45 @@ public class ZorkSceneryInvariantTests : EngineTestsBase
                         new SimpleIntent { Verb = "take", Noun = noun }, engine.Context, client, factory);
                     take.InteractionMessage.Should().Be(s.CannotBeTakenReason, $"{type.Name} take '{noun}'");
                 }
+            }
+        }
+    }
+
+    /// <summary>
+    ///     Issue #577: the test above proves the refusal exists; this proves a player can reach it.
+    ///     The live parser classifies a take as a TakeIntent or a SimpleIntent depending on the noun,
+    ///     and only the SimpleIntent shape ever consulted scenery, so every authored reason in the game
+    ///     was a coin flip from the player's seat — "get house" answered, "take house" got improvised
+    ///     prose. A room's scenery is not finished until both shapes say the same thing.
+    /// </summary>
+    [Test]
+    public async Task EverySceneryTakeRefusal_IsAlsoReachable_ThroughTheTakeIntentPath()
+    {
+        var engine = GetTarget();
+
+        // Carried and lit, as a player exploring the underground would be: nothing is scenery in the
+        // dark, so an unlit sweep would measure the darkness refusal instead of the authored one.
+        engine.Context.Take(Repository.GetItem<Lantern>());
+        Repository.GetItem<Lantern>().IsOn = true;
+
+        var processor = new TakeOrDropInteractionProcessor(Mock.Of<IAITakeAndAndDropParser>());
+
+        foreach (var (type, scenery) in LocationsWithScenery())
+        {
+            var loc = (LocationBase)Activator.CreateInstance(type)!;
+            loc.Init();
+            engine.Context.CurrentLocation = loc;
+            engine.Context.ItIsDarkHere.Should().BeFalse($"{type.Name} must be lit for this sweep");
+
+            foreach (var s in scenery.Where(s => s.CannotBeTakenReason is not null))
+            {
+                var noun = s.Nouns[0];
+
+                var (_, message) = await processor.Process(
+                    new TakeIntent { Noun = noun, OriginalInput = $"take {noun}" },
+                    engine.Context, Mock.Of<IGenerationClient>());
+
+                message.Should().Be(s.CannotBeTakenReason, $"{type.Name} take '{noun}'");
             }
         }
     }


### PR DESCRIPTION
Fixes #577.

## The bug

Every `SceneryItem.CannotBeTakenReason` in every game was reachable only by phrasing luck, and the canonical verb was the one that failed:

```
> get wall          (Stationfall, Deck Twelve)
The bulkheads are structural, and you are not.

> take wall
This action or command has no effect on the game.      <- no engine handler at all
```

The two phrasings land in different intent classes. A `SimpleIntent` reaches `LocationBase.RespondToSimpleInteraction`, whose scenery branch answers correctly. A `TakeIntent` is dispatched by [GameEngine.cs:935](GameEngine/GameEngine.cs:935) straight to `TakeOrDropInteractionProcessor.Process(TakeIntent)`, which resolves **real items only** and hands anything else to the narrator — which then improvises prose that contradicts the game's own established facts. `Verbs.TakeVerbs` being checked in both places is what made this look covered when it wasn't.

## The fix

The scenery lookup moves to one seam — `ILocation.MatchScenery` — that **both** paths ask, so a noun cannot be scenery to one and unknown to the other. The generic fallback sentence moves onto `SceneryItem.TakeRefusal` for the same reason: the two call sites used to each spell it out.

The take path consults it *after* the item lookup, exactly as `LocationBase` orders it, so a genuine object sharing a noun still wins. In a dark room it answers `"It's too dark to see! "` instead — the `SimpleIntent` path never reaches its own scenery branch without light (`SimpleInteractionEngine`'s guard), and `TakeIt`'s own darkness guard (#342) is skipped entirely when no item resolved.

## TDD

**Red** (all failed on the narrator hand-off, not on setup):
- `take house` at North of House and `take wall` on Deck Twelve, driven as real `TakeIntent`s exactly as `GameEngine.cs` does.
- The verb-family parity test failed only on its `viaTakeIntent` half — proving the authored refusal existed and was reachable the other way.

**Guards:**
- `EverySceneryTakeRefusal_IsAlsoReachable_ThroughTheTakeIntentPath` sweeps **every** scenery refusal in Zork I and in Planetfall through the take path (verified failing without the fix: `AragainFalls take 'waterfall'`).
- `GlobalSceneryTests` pins Stationfall's global scenery through **both** intent shapes, for every noun every entry declares — so a new entry is covered the day it's added.
- `take`/`get`/`grab`/`pick up`/`hold`/`acquire`/`snatch`/`carry` all return the same authored reason; a real item sharing a noun with scenery still wins; a dark room still says "too dark".

## Widening the completeness sweep

The issue asks for `CompletenessSweepTests` to grow from `examine` to the take verbs. That only means something if it drives the shape production produces, so the take pass invokes the `TakeIntent` overload rather than `GetResponse` (TestParser can only ever emit a `SimpleIntent` — which is exactly why this path went unmeasured while the examine sweep read zero). It runs on its own engine, since a successful take moves an object out of the room.

It immediately found eight more gaps in the opening — objects whose prose names them but which had no authored refusal: the form slots, the pallets, the spacetruck hatch, and the three robots. Each now has one. Both sweeps read zero.

## Verification

All suites pass, run separately: UnitTests 1318, ZorkOne.Tests 1782, Planetfall.Tests 4027, Stationfall.Tests 131, EscapeRoom.Tests 9.

## Not in scope

`push wall` returning the quiet sentinel, which the issue notes is by design (scenery matched + unsupported verb → `NoVerbMatchInteractionResult`), and the `DropIntent` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)