### PR TITLE
Fix #578: log the parsed intent shape and the turn's terminal path

### DIFF
--- a/CloudWatch/Model/TurnLog.cs
+++ b/CloudWatch/Model/TurnLog.cs
@@ -1,3 +1,6 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
 namespace CloudWatch.Model;
 
 public record TurnLog : ITurnBasedLog
@@ -9,4 +12,25 @@ public record TurnLog : ITurnBasedLog
     public required string Input { get; init; }
     public required string Response { get; init; }
     public string? TurnCorrelationId { get; set; }
+
+    /// <summary>
+    ///     The shape the parser gave this turn's input — the intent subtype plus the fields that
+    ///     actually drive dispatch (verb/noun/adverb, or noun one/noun two/preposition). Parse
+    ///     metadata only: nothing here is raw player text beyond what <see cref="Input" /> already
+    ///     captures (issue #578).
+    ///     <para>
+    ///     Null when the turn never reached the parser — a stateful processor answering its own
+    ///     prompt, an empty command, a location's raw-input interaction, a conversation — which is
+    ///     itself the diagnostic fact.
+    ///     </para>
+    /// </summary>
+    public string? ParsedIntent { get; init; }
+
+    /// <summary>
+    ///     Which branch of the engine ended this turn: a handler, one of the no-handler deflections,
+    ///     or a parse that produced nothing usable. Serialized by name so a log reader sees
+    ///     "NounNotPresent" rather than "12".
+    /// </summary>
+    [JsonConverter(typeof(StringEnumConverter))]
+    public TurnTerminalPath TerminalPath { get; init; }
 }

--- a/CloudWatch/Model/TurnTerminalPath.cs
+++ b/CloudWatch/Model/TurnTerminalPath.cs
@@ -1,0 +1,82 @@
+namespace CloudWatch.Model;
+
+/// <summary>
+///     Which branch of turn processing produced the response the player saw (issue #578).
+///     <para>
+///     Every no-handler deflection in the engine already narrates its own situation-specific
+///     failure, so the distinction is visible to a <em>reader</em> of the turn's prose — but it was
+///     invisible to a <em>tool</em> reading the logs, which is what forced the fragile
+///     "infer a dropped turn from the literal no-effect sentence" trick in issue #538. Recording the
+///     branch on every <see cref="TurnLog" /> gives the harness a first-class signal that survives
+///     the narrator being enabled and names which of the twelve deflections fired.
+///     </para>
+///     <para>
+///     Values are explicit because this is a wire contract: the Lambda writes it, the harness reads
+///     it. Serialized by name (see <see cref="TurnLog.TerminalPath" />), so renaming a member is the
+///     breaking change, not renumbering one.
+///     </para>
+/// </summary>
+public enum TurnTerminalPath
+{
+    /// <summary>
+    ///     Not classified. The engine sets an explicit value on every turn, so this should only ever
+    ///     appear on a <see cref="TurnLog" /> built outside the engine (e.g. in a test).
+    /// </summary>
+    Unknown = 0,
+
+    /// <summary>
+    ///     A handler ran: a processor, an engine, a location or item interaction, a global or system
+    ///     command, a conversation. The turn did something rather than deflecting.
+    /// </summary>
+    Handled = 1,
+
+    /// <summary>The parser produced no usable shape at all — <c>NullIntent</c>.</summary>
+    NullIntent = 2,
+
+    /// <summary>The parsed intent was a type the engine's dispatch switch does not handle.</summary>
+    UnmatchedIntentType = 3,
+
+    /// <summary>
+    ///     The turn threw and was rescued by the engine-error safety net (issue #271).
+    /// </summary>
+    EngineError = 4,
+
+    /// <summary>The noun was present in the LOCATION, but no processor handled the verb.</summary>
+    NoMatchingVerbForNounInLocation = 10,
+
+    /// <summary>The noun was present in INVENTORY, but no processor handled the verb.</summary>
+    NoMatchingVerbForNounInInventory = 11,
+
+    /// <summary>The noun exists in the story, but is not present here.</summary>
+    NounNotPresent = 12,
+
+    /// <summary>The noun does not exist anywhere in the story.</summary>
+    NounNotInTheStory = 13,
+
+    /// <summary>Neither noun of a multi-noun command exists anywhere in the story.</summary>
+    MultiNounNeitherNounInTheStory = 20,
+
+    /// <summary>The first noun is not here, and the second one is a named person.</summary>
+    MultiNounFirstNounMissingSecondIsAPerson = 21,
+
+    /// <summary>The first noun is not here.</summary>
+    MultiNounFirstNounMissing = 22,
+
+    /// <summary>The second noun is not here, and the first one is a named person.</summary>
+    MultiNounSecondNounMissingFirstIsAPerson = 23,
+
+    /// <summary>The second noun is not here.</summary>
+    MultiNounSecondNounMissing = 24,
+
+    /// <summary>Neither noun of a multi-noun command is here.</summary>
+    MultiNounBothNounsMissing = 25,
+
+    /// <summary>
+    ///     One of the two nouns is only scenery in the location description, not a real item, so no
+    ///     interaction between them is possible.
+    /// </summary>
+    MultiNounNounIsSceneryOnly = 26,
+
+    /// <summary>Both items are real and present, but no multi-noun processor handled the pair.</summary>
+    MultiNounNoProcessorMatched = 27
+}

--- a/GameEngine/GameEngine.cs
+++ b/GameEngine/GameEngine.cs
@@ -53,6 +53,13 @@ public class GameEngine<TInfocomGame, TContext> : IGameEngine
     private bool _lastResponseWasGenerated;
     private IStatefulProcessor? _processorInProgress;
     private ICloudWatchLogger<TurnLog>? _turnLogger;
+
+    // Turn-log diagnostics (issue #578), reset at the top of every sentence and read by
+    // PostProcessing. The intent shape stays null on the paths that never reach the parser; the
+    // terminal path starts at Handled and is narrowed by whichever branch actually ends the turn.
+    private string? _parsedIntent;
+    private TurnTerminalPath _terminalPath = TurnTerminalPath.Handled;
+
     public TContext Context { get; private set; }
 
     /// <summary>
@@ -274,6 +281,12 @@ public class GameEngine<TInfocomGame, TContext> : IGameEngine
         // playing" guarantee (issue #271).
         ClearProcessorInProgress();
 
+        // Set before either log is written so both this turn's explicit error entry AND the ordinary
+        // entry SafePostProcess writes below agree on how the turn ended (issue #578). Whatever
+        // branch was mid-flight when the exception was thrown never got to finish, so its own
+        // classification would be a lie.
+        _terminalPath = TurnTerminalPath.EngineError;
+
         _logger?.LogError(ex,
             "Unhandled exception during turn processing for input '{Input}'. TurnCorrelationId: {TurnCorrelationId}",
             _currentInput, _turnCorrelationId);
@@ -289,7 +302,9 @@ public class GameEngine<TInfocomGame, TContext> : IGameEngine
                 Score = Context.Score,
                 Moves = Context.Moves,
                 Input = _currentInput ?? string.Empty,
-                Response = $"ENGINE ERROR ({_turnCorrelationId}): {ex}"
+                Response = $"ENGINE ERROR ({_turnCorrelationId}): {ex}",
+                ParsedIntent = _parsedIntent,
+                TerminalPath = _terminalPath
             });
         }
         catch (Exception loggingEx)
@@ -427,6 +442,11 @@ public class GameEngine<TInfocomGame, TContext> : IGameEngine
     {
         _currentInput = playerInput;
 
+        // Each sentence of a multi-sentence input writes its own TurnLog, so the diagnostics reset
+        // per sentence, not per top-level call (issue #578).
+        _parsedIntent = null;
+        _terminalPath = TurnTerminalPath.Handled;
+
         // 1. ------- Processor in Progress -
         // See if we have something already running like a save, quit, etc.
         // and see if it has any output.  Does not count as a turn. No actor or turn processing.
@@ -462,6 +482,7 @@ public class GameEngine<TInfocomGame, TContext> : IGameEngine
         var systemCommand = _parser.DetermineSystemIntentType(playerInput);
         if (systemCommand is GlobalCommandIntent global)
         {
+            _parsedIntent = IntentShapeDescriber.Describe(global);
             var globalResult = await ProcessGlobalCommandIntent(global);
             return PostProcessing(globalResult);
         }
@@ -609,6 +630,8 @@ public class GameEngine<TInfocomGame, TContext> : IGameEngine
         var simpleIntent = earlyGlobalIntent;
         if (simpleIntent is not null)
         {
+            _parsedIntent = IntentShapeDescriber.Describe(simpleIntent);
+
             var resultMessage = simpleIntent switch
             {
                 GlobalCommandIntent intent => await ProcessGlobalCommandIntent(intent),
@@ -888,15 +911,16 @@ public class GameEngine<TInfocomGame, TContext> : IGameEngine
     {
         _logger?.LogDebug($"Input was parsed as {parsedResult.GetType().Name}");
 
-        // TODO: why does this return an interaction result and a result message? This feels vestigial. 
+        // The Debug line above is not retained in production, which is exactly what made issue #540's
+        // parser-shape defects so expensive to find. Record the shape on the turn log instead (#578).
+        _parsedIntent = IntentShapeDescriber.Describe(parsedResult);
+
+        // TODO: why does this return an interaction result and a result message? This feels vestigial.
         var complexIntentResult = parsedResult switch
         {
             GlobalCommandIntent intent => (null, await ProcessGlobalCommandIntent(intent)),
 
-            NullIntent => (
-                null,
-                await GetGeneratedNoOpResponse(_currentInput!, GenerationClient, Context)
-            ),
+            NullIntent => (null, await ProcessNullIntent()),
 
             InventoryIntent => (null, await new InventoryProcessor().Process("", Context, GenerationClient, Runtime.Unknown)),
             
@@ -938,25 +962,57 @@ public class GameEngine<TInfocomGame, TContext> : IGameEngine
             DropIntent dropIntent => await new TakeOrDropInteractionProcessor(_openAITakeAndDropListParser).Process(
                 dropIntent, Context, GenerationClient),
             
-            SimpleIntent simpleInteraction => await new SimpleInteractionEngine(_itemProcessorFactory).Process(
-                simpleInteraction,
-                Context,
-                GenerationClient
-            ),
+            SimpleIntent simpleInteraction => await ProcessSimpleIntent(simpleInteraction),
 
-            MultiNounIntent multiInteraction => await new MultiNounEngine().Process(
-                multiInteraction,
-                Context,
-                GenerationClient
-            ),
+            MultiNounIntent multiInteraction => await ProcessMultiNounIntent(multiInteraction),
 
-            _ => (null, await GetGeneratedNoOpResponse(_currentInput!, GenerationClient, Context))
+            _ => (null, await ProcessUnmatchedIntent())
         };
 
         if (complexIntentResult.resultObject is DisambiguationInteractionResult complexResult)
             ArmDisambiguation(complexResult);
 
         return complexIntentResult;
+    }
+
+    // The four wrappers below exist so the dispatch switch above can record which branch ended the
+    // turn (issue #578). A switch *expression* arm cannot assign a field, and classifying the intent
+    // in a second switch beside the first would be a trap: adding an intent type to one and not the
+    // other would silently mislabel every turn of that type.
+
+    private async Task<(InteractionResult? resultObject, string ResultMessage)> ProcessSimpleIntent(
+        SimpleIntent simpleInteraction)
+    {
+        var engine = new SimpleInteractionEngine(_itemProcessorFactory);
+        var result = await engine.Process(simpleInteraction, Context, GenerationClient);
+        _terminalPath = engine.TerminalPath;
+        return result;
+    }
+
+    private async Task<(InteractionResult? resultObject, string ResultMessage)> ProcessMultiNounIntent(
+        MultiNounIntent multiInteraction)
+    {
+        var engine = new MultiNounEngine();
+        var result = await engine.Process(multiInteraction, Context, GenerationClient);
+        _terminalPath = engine.TerminalPath;
+        return result;
+    }
+
+    /// <summary>The parser could not produce any usable shape from the input.</summary>
+    private async Task<string> ProcessNullIntent()
+    {
+        _terminalPath = TurnTerminalPath.NullIntent;
+        return await GetGeneratedNoOpResponse(_currentInput!, GenerationClient, Context);
+    }
+
+    /// <summary>
+    ///     The parser produced an intent type the dispatch switch has no arm for. Nothing routes here
+    ///     today; if it ever does, the turn log is what will say so.
+    /// </summary>
+    private async Task<string> ProcessUnmatchedIntent()
+    {
+        _terminalPath = TurnTerminalPath.UnmatchedIntentType;
+        return await GetGeneratedNoOpResponse(_currentInput!, GenerationClient, Context);
     }
 
     private async Task<string> ProcessActorsAndContextEndOfTurn(string? contextPrepend, string? turnResult,
@@ -1012,7 +1068,9 @@ public class GameEngine<TInfocomGame, TContext> : IGameEngine
                 Score = Context.Score,
                 Moves = Context.Moves,
                 Input = _currentInput,
-                Response = finalResult.Trim()
+                Response = finalResult.Trim(),
+                ParsedIntent = _parsedIntent,
+                TerminalPath = _terminalPath
             });
 
         if (!string.IsNullOrEmpty(finalResult))

--- a/GameEngine/IntentEngine/MultiNounEngine.cs
+++ b/GameEngine/IntentEngine/MultiNounEngine.cs
@@ -1,3 +1,4 @@
+using CloudWatch.Model;
 using GameEngine.Item.ItemProcessor;
 using GameEngine.Item.MultiItemProcessor;
 using Model.AIGeneration;
@@ -15,6 +16,14 @@ namespace GameEngine.IntentEngine;
 public class MultiNounEngine : IIntentEngine
 {
     private readonly List<IMultiNounVerbProcessor> _processors = [new PutProcessor()];
+
+    /// <summary>
+    ///     Which branch of <see cref="Process" /> produced the response, for the turn log (issue #578).
+    ///     Read by the engine straight after <see cref="Process" /> returns — a fresh instance is built
+    ///     per turn, so there is nothing to reset. Stays <see cref="TurnTerminalPath.Handled" /> unless
+    ///     one of the no-handler deflections below fires.
+    /// </summary>
+    internal TurnTerminalPath TerminalPath { get; private set; } = TurnTerminalPath.Handled;
 
     public async Task<(InteractionResult? resultObject, string ResultMessage)> Process(IntentBase intent,
         IContext context, IGenerationClient generationClient)
@@ -72,7 +81,10 @@ public class MultiNounEngine : IIntentEngine
         // talked about a unicorn, a bottle of tequila or some other meaningless item. 
         if (!Repository.ItemExistsInTheStory(interaction.NounOne) &&
             !Repository.ItemExistsInTheStory(interaction.NounTwo))
+        {
+            TerminalPath = TurnTerminalPath.MultiNounNeitherNounInTheStory;
             return (null, await GetGeneratedNoOpResponse(interaction.OriginalInput, generationClient, context));
+        }
 
         var (nounOneExistsHere, itemOne) = IsItemHere(context, interaction.NounOne);
         var (nounTwoExistsHere, itemTwo) = IsItemHere(context, interaction.NounTwo);
@@ -83,11 +95,15 @@ public class MultiNounEngine : IIntentEngine
         if (!nounOneExistsHere & nounTwoExistsHere)
         {
             if (itemTwo is IAmANamedPerson)
+            {
+                TerminalPath = TurnTerminalPath.MultiNounFirstNounMissingSecondIsAPerson;
                 return (null, await GetGeneratedResponse<MissingFirstNounMultiNounWithPersonOperationRequest>(
                     interaction,
                     generationClient,
                     context));
+            }
 
+            TerminalPath = TurnTerminalPath.MultiNounFirstNounMissing;
             return (null, await GetGeneratedResponse<MissingFirstNounMultiNounOperationRequest>(interaction,
                 generationClient,
                 context));
@@ -96,27 +112,37 @@ public class MultiNounEngine : IIntentEngine
         if (nounOneExistsHere & !nounTwoExistsHere)
         {
             if (itemOne is IAmANamedPerson)
+            {
+                TerminalPath = TurnTerminalPath.MultiNounSecondNounMissingFirstIsAPerson;
                 return (null, await GetGeneratedResponse<MissingSecondNounWithPersonMultiNounOperationRequest>(
                     interaction,
                     generationClient,
                     context));
+            }
 
+            TerminalPath = TurnTerminalPath.MultiNounSecondNounMissing;
             return (null, await GetGeneratedResponse<MissingSecondNounMultiNounOperationRequest>(interaction,
                 generationClient,
                 context));
         }
 
         if (!nounOneExistsHere & !nounTwoExistsHere)
+        {
+            TerminalPath = TurnTerminalPath.MultiNounBothNounsMissing;
             return (null, await GetGeneratedResponse<MissingBothNounsMultiNounOperationRequest>(interaction,
                 generationClient,
                 context));
+        }
 
-        // This indicates that one of the two items is not real, i.e. it's part of 
-        // the location description like the kitchen table. No real interaction is 
+        // This indicates that one of the two items is not real, i.e. it's part of
+        // the location description like the kitchen table. No real interaction is
         // possible.
         if (itemOne is null || itemTwo is null)
+        {
+            TerminalPath = TurnTerminalPath.MultiNounNounIsSceneryOnly;
             return (null, await GetGeneratedVerbNotUsefulResponse(interaction, generationClient,
                 context));
+        }
 
         // Let all the processors decide if they can handle this interaction. 
         foreach (var processor in _processors)
@@ -129,6 +155,7 @@ public class MultiNounEngine : IIntentEngine
         }
 
         // If not positive interaction.....
+        TerminalPath = TurnTerminalPath.MultiNounNoProcessorMatched;
         return (null, await GetGeneratedVerbNotUsefulResponse(interaction, generationClient,
             context));
     }

--- a/GameEngine/IntentEngine/SimpleInteractionEngine.cs
+++ b/GameEngine/IntentEngine/SimpleInteractionEngine.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using CloudWatch.Model;
 using Model;
 using Model.AIGeneration;
 using Model.AIGeneration.Requests;
@@ -15,6 +16,14 @@ namespace GameEngine.IntentEngine;
 /// </summary>
 internal class SimpleInteractionEngine(IItemProcessorFactory itemProcessorFactory) : IIntentEngine
 {
+    /// <summary>
+    ///     Which branch of <see cref="Process" /> produced the response, for the turn log (issue #578).
+    ///     Read by the engine straight after <see cref="Process" /> returns — a fresh instance is built
+    ///     per turn, so there is nothing to reset. Stays <see cref="TurnTerminalPath.Handled" /> unless
+    ///     one of the no-handler deflections below fires.
+    /// </summary>
+    internal TurnTerminalPath TerminalPath { get; private set; } = TurnTerminalPath.Handled;
+
     public async Task<(InteractionResult? resultObject, string ResultMessage)>
         Process(IntentBase intent, IContext context, IGenerationClient generationClient)
     {
@@ -61,23 +70,33 @@ internal class SimpleInteractionEngine(IItemProcessorFactory itemProcessorFactor
         // The noun was present in the given LOCATION, but the verb applied to
         // it has no meaning in the story. I.E: push the sword...that will accomplish nothing. 
         if (locationInteraction is NoVerbMatchInteractionResult noVerb)
+        {
+            TerminalPath = TurnTerminalPath.NoMatchingVerbForNounInLocation;
             return (locationInteraction,
                 await GetGeneratedNoMatchingVerbResponse(noVerb.Noun, noVerb.Verb, generationClient, context));
+        }
 
         // The noun was present in INVENTORY but the verb applied to
-        // it has no meaning in the story. I.E: push the sword...that will accomplish nothing. 
+        // it has no meaning in the story. I.E: push the sword...that will accomplish nothing.
         if (contextInteraction is NoVerbMatchInteractionResult noVerbContext)
+        {
+            TerminalPath = TurnTerminalPath.NoMatchingVerbForNounInInventory;
             return (contextInteraction, await GetGeneratedNoMatchingVerbResponse(noVerbContext.Noun, noVerbContext.Verb,
                 generationClient,
                 context));
+        }
 
         // The noun exists in the game, but is not currently present. It might be in another location
-        // or is hidden inside something else (like the leaflet in the mailbox) 
+        // or is hidden inside something else (like the leaflet in the mailbox)
         if (Repository.ItemExistsInTheStory(simpleInteraction.Noun))
+        {
+            TerminalPath = TurnTerminalPath.NounNotPresent;
             return (null, await GetGeneratedNounNotPresentResponse(simpleInteraction.Noun, generationClient, context));
+        }
 
         // There is no matching noun at all, anywhere in the game. The user might have
-        // talked about a unicorn, a bottle of tequila or some other meaningless item. 
+        // talked about a unicorn, a bottle of tequila or some other meaningless item.
+        TerminalPath = TurnTerminalPath.NounNotInTheStory;
         return (null, await GetGeneratedNoOpResponse(simpleInteraction.OriginalInput ?? "", generationClient, context));
     }
 

--- a/GameEngine/IntentShapeDescriber.cs
+++ b/GameEngine/IntentShapeDescriber.cs
@@ -1,0 +1,57 @@
+using Model.Intent;
+
+namespace GameEngine;
+
+/// <summary>
+///     Renders a parsed <see cref="IntentBase" /> as one compact line for the turn log (issue #578).
+///     <para>
+///     The engine already knew the intent type at <c>Debug</c> level, which production does not
+///     retain — so diagnosing a parser-shape defect (issue #540: a preposition rewritten to a
+///     hardcoded "with"; "press 3" arriving with no noun) meant inferring it from outcome
+///     frequencies across a 1,352-command trace. Recording the shape makes those defects readable
+///     straight off a single turn.
+///     </para>
+///     <para>
+///     Deliberately hand-written rather than leaning on the records' generated <c>ToString</c>:
+///     that would print <c>Message</c> and, for a global command, the whole command object, and it
+///     would drift silently whenever a property is added. This prints only the fields that decide
+///     dispatch — parse metadata, never raw player text, which <c>TurnLog.Input</c> already holds.
+///     </para>
+/// </summary>
+internal static class IntentShapeDescriber
+{
+    internal static string? Describe(IntentBase? intent)
+    {
+        if (intent is null)
+            return null;
+
+        var name = intent.GetType().Name;
+
+        return intent switch
+        {
+            SimpleIntent simple =>
+                $"{name} verb='{simple.Verb}' noun='{simple.Noun}' adjective='{simple.Adjective}' adverb='{simple.Adverb}'",
+
+            MultiNounIntent multi =>
+                $"{name} verb='{multi.Verb}' nounOne='{multi.NounOne}' nounTwo='{multi.NounTwo}' preposition='{multi.Preposition}'",
+
+            MoveIntent move => $"{name} direction='{move.Direction}' noun='{move.Noun}'",
+
+            GlobalCommandIntent global => $"{name} command='{global.Command.GetType().Name}'",
+
+            GoToDestinationIntent goTo => $"{name} destination='{goTo.Destination}'",
+
+            EnterSubLocationIntent enter => $"{name} noun='{enter.Noun}'",
+
+            ExitSubLocationIntent exit => $"{name} nounOne='{exit.NounOne}' nounTwo='{exit.NounTwo}'",
+
+            TakeIntent take => $"{name} noun='{take.Noun}'",
+
+            DropIntent drop => $"{name} noun='{drop.Noun}'",
+
+            // NullIntent, InventoryIntent, LookIntent, PromptIntent, MultipleCommandsIntent: the
+            // type name IS the whole shape.
+            _ => name
+        };
+    }
+}

--- a/UnitTests/AWS/CloudWatchLoggerTests.cs
+++ b/UnitTests/AWS/CloudWatchLoggerTests.cs
@@ -79,6 +79,86 @@ public class CloudWatchLoggerBehaviorTests
             json.Should().Contain("null");
         }
 
+        /// <summary>
+        ///     Issue #578: the terminal path is a wire contract between the Lambda that writes it and
+        ///     the harness that reads it, so it must land in the JSON as its NAME. Serialized as the
+        ///     default integer it would be unreadable in a log pane and would silently re-point at a
+        ///     different branch the moment a member is inserted above it.
+        /// </summary>
+        [Test]
+        public void Should_SerializeTerminalPath_ByName_AlongsideTheParsedIntentShape()
+        {
+            // Arrange
+            var log = new TurnLog
+            {
+                SessionId = "session-123",
+                Location = "West of House",
+                Score = 0,
+                Moves = 1,
+                Input = "press 3",
+                Response = "Nothing happens.",
+                ParsedIntent = "SimpleIntent verb='press' noun='' adjective='' adverb=''",
+                TerminalPath = TurnTerminalPath.NounNotPresent
+            };
+
+            // Act
+            var json = JsonConvert.SerializeObject(log);
+
+            // Assert
+            json.Should().Contain("\"TerminalPath\":\"NounNotPresent\"");
+            json.Should().NotContain("\"TerminalPath\":12");
+            json.Should().Contain("verb='press'");
+        }
+
+        [Test]
+        public void Should_RoundTripTheTurnDiagnostics_ThroughJson()
+        {
+            // Arrange
+            var log = new TurnLog
+            {
+                SessionId = "session-123",
+                Location = "West of House",
+                Score = 0,
+                Moves = 1,
+                Input = "tie sword to mailbox",
+                Response = "That accomplishes nothing.",
+                ParsedIntent = "MultiNounIntent verb='tie' nounOne='sword' nounTwo='mailbox' preposition='to'",
+                TerminalPath = TurnTerminalPath.MultiNounNoProcessorMatched
+            };
+
+            // Act
+            var restored = JsonConvert.DeserializeObject<TurnLog>(JsonConvert.SerializeObject(log));
+
+            // Assert
+            restored.Should().NotBeNull();
+            restored!.TerminalPath.Should().Be(TurnTerminalPath.MultiNounNoProcessorMatched);
+            restored.ParsedIntent.Should().Be(log.ParsedIntent);
+        }
+
+        /// <summary>
+        ///     A log built without the engine (a test, an older writer) reports Unknown rather than
+        ///     claiming a branch it never observed.
+        /// </summary>
+        [Test]
+        public void Should_DefaultTerminalPath_ToUnknown_WhenNotSet()
+        {
+            // Arrange
+            var log = new TurnLog
+            {
+                SessionId = "s",
+                Location = "L",
+                Score = 0,
+                Moves = 0,
+                Input = "i",
+                Response = "r"
+            };
+
+            // Assert
+            log.TerminalPath.Should().Be(TurnTerminalPath.Unknown);
+            log.ParsedIntent.Should().BeNull();
+            JsonConvert.SerializeObject(log).Should().Contain("\"TerminalPath\":\"Unknown\"");
+        }
+
         [Test]
         public void Should_SerializeGenerationLog_Correctly()
         {

--- a/UnitTests/Engine/LoggingAndHistoryTests.cs
+++ b/UnitTests/Engine/LoggingAndHistoryTests.cs
@@ -6,9 +6,14 @@ using GameEngine.Item;
 using Model.AIGeneration;
 using Model.AIGeneration.Requests;
 using Model.AIParsing;
+using Model.Intent;
 using Model.Interface;
+using Model.Item;
+using Model.Location;
 using ZorkOne;
 using ZorkOne.GlobalCommand;
+using ZorkOne.Item;
+using ZorkOne.Location;
 
 namespace UnitTests.Engine;
 
@@ -16,7 +21,8 @@ public class LoggingAndHistoryTests
 {
     private static GameEngine<ZorkI, ZorkIContext> BuildEngine(
         Mock<IGenerationClient> client,
-        Mock<ICloudWatchLogger<TurnLog>> turnLogger)
+        Mock<ICloudWatchLogger<TurnLog>> turnLogger,
+        IIntentParser? intentParser = null)
     {
         // Simple take/drop parser used by ItemProcessorFactory in tests
         var takeAndDropParser = new Mock<IAITakeAndAndDropParser>();
@@ -36,7 +42,7 @@ public class LoggingAndHistoryTests
             });
 
         var itemProcessorFactory = new ItemProcessorFactory(takeAndDropParser.Object);
-        var parser = new IntentParser(Mock.Of<IAIParser>(), new ZorkOneGlobalCommandFactory());
+        var parser = intentParser ?? new IntentParser(Mock.Of<IAIParser>(), new ZorkOneGlobalCommandFactory());
         var secrets = Mock.Of<ISecretsManager>();
 
         var engine = new GameEngine<ZorkI, ZorkIContext>(
@@ -47,8 +53,10 @@ public class LoggingAndHistoryTests
             turnLogger.Object,
             Mock.Of<IParseConversation>());
 
-        // Ensure starting location is initialized consistently
-        Repository.Reset();
+        // Ensure starting location is initialized consistently. NOTE: no Repository.Reset() here —
+        // the test constructor above already reset it before building Context, so resetting again
+        // would hand Init() a SECOND WestOfHouse instance while Context.CurrentLocation still points
+        // at the first, leaving the player standing in a room with no mailbox in it.
         Repository.GetLocation<WestOfHouse>().Init();
         engine.Context.Verbosity = Verbosity.Verbose;
         return engine;
@@ -94,5 +102,392 @@ public class LoggingAndHistoryTests
         var last = client.Object.LastFiveInputOutputs.Last();
         last.Item1.Should().Be("look"); // last input
         last.Item2.Should().NotBeNullOrEmpty(); // response
+    }
+
+    /// <summary>
+    ///     Issue #578: every turn log carries the shape the parser produced and which branch of the
+    ///     engine ended the turn, so a tool reading the logs can tell "the engine considered this and
+    ///     declined" from "nothing ran" — and can name WHICH deflection fired — without inferring it
+    ///     from the narration. This retires the fragile <c>noGeneratedResponses</c> sentinel that
+    ///     issue #538 had to resort to.
+    /// </summary>
+    [TestFixture]
+    public class TurnDiagnosticsTests
+    {
+        private Mock<IGenerationClient> _client = null!;
+        private List<TurnLog> _logs = null!;
+        private Mock<ICloudWatchLogger<TurnLog>> _turnLogger = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            Repository.Reset();
+
+            _client = new Mock<IGenerationClient>();
+            _client.SetupAllProperties();
+            _client.Object.LastFiveInputOutputs = [];
+            _client
+                .Setup(c => c.GenerateNarration(It.IsAny<Request>(), It.IsAny<string>()))
+                .ReturnsAsync("Generated");
+
+            _logs = [];
+            _turnLogger = new Mock<ICloudWatchLogger<TurnLog>>();
+            _turnLogger
+                .Setup(l => l.WriteLogEvents(It.IsAny<TurnLog>()))
+                .Callback<TurnLog>(_logs.Add)
+                .Returns(Task.CompletedTask);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Repository.Reset();
+        }
+
+        /// <summary>An engine whose complex parse is pinned to exactly this intent.</summary>
+        private GameEngine<ZorkI, ZorkIContext> EngineFor(IntentBase intent)
+        {
+            return BuildEngine(_client, _turnLogger, new StubParser(intent));
+        }
+
+        private TurnLog LastLog
+        {
+            get
+            {
+                _logs.Should().NotBeEmpty("the turn must have written a log");
+                return _logs[^1];
+            }
+        }
+
+        [Test]
+        public async Task ParsedIntent_RecordsTheSimpleIntentShape()
+        {
+            // Issue #540's defect 3 — "press 3" reaching the engine with no noun tag — was found by
+            // inference from outcome frequencies across a 1,352-command trace. This is what it looks
+            // like when a single turn simply says so.
+            var engine = EngineFor(new SimpleIntent { Verb = "press", Noun = null, OriginalInput = "press 3" });
+
+            await engine.GetResponse("press 3");
+
+            LastLog.ParsedIntent.Should().Be("SimpleIntent verb='press' noun='' adjective='' adverb=''");
+        }
+
+        [Test]
+        public async Task ParsedIntent_RecordsTheMultiNounShape_IncludingThePreposition()
+        {
+            // Issue #540's defect 1: the parsed preposition was being rewritten to a hardcoded
+            // "with", which no log could show while only the player-facing prose was recorded.
+            var engine = EngineFor(new MultiNounIntent
+            {
+                Verb = "put",
+                NounOne = "leaflet",
+                NounTwo = "mailbox",
+                Preposition = "with",
+                OriginalInput = "put leaflet in mailbox"
+            });
+
+            await engine.GetResponse("put leaflet in mailbox");
+
+            LastLog.ParsedIntent.Should()
+                .Be("MultiNounIntent verb='put' nounOne='leaflet' nounTwo='mailbox' preposition='with'");
+        }
+
+        [Test]
+        public async Task ParsedIntent_RecordsAGlobalCommand_WithoutTheAIParser()
+        {
+            var engine = BuildEngine(_client, _turnLogger);
+
+            await engine.GetResponse("look");
+
+            LastLog.ParsedIntent.Should().Be("GlobalCommandIntent command='LookProcessor'");
+            LastLog.TerminalPath.Should().Be(TurnTerminalPath.Handled);
+        }
+
+        [Test]
+        public async Task ParsedIntent_RecordsTheDirectionOfAMove()
+        {
+            var engine = BuildEngine(_client, _turnLogger);
+
+            await engine.GetResponse("north");
+
+            LastLog.ParsedIntent.Should().Be("MoveIntent direction='N' noun=''");
+            LastLog.TerminalPath.Should().Be(TurnTerminalPath.Handled);
+        }
+
+        [Test]
+        public async Task TerminalPath_IsHandled_WhenAHandlerRan()
+        {
+            var engine = EngineFor(new SimpleIntent { Verb = "open", Noun = "mailbox", OriginalInput = "open mailbox" });
+
+            await engine.GetResponse("open mailbox");
+
+            LastLog.TerminalPath.Should().Be(TurnTerminalPath.Handled);
+        }
+
+        [Test]
+        public async Task TerminalPath_IsNullIntent_WhenTheParserProducedNoUsableShape()
+        {
+            var engine = EngineFor(new NullIntent());
+
+            await engine.GetResponse("this game is stupid");
+
+            LastLog.TerminalPath.Should().Be(TurnTerminalPath.NullIntent);
+            LastLog.ParsedIntent.Should().Be("NullIntent");
+        }
+
+        [Test]
+        public async Task TerminalPath_IsUnmatchedIntentType_WhenDispatchHasNoArmForTheIntent()
+        {
+            var engine = EngineFor(new UnroutedTestIntent());
+
+            await engine.GetResponse("something the switch has never heard of");
+
+            LastLog.TerminalPath.Should().Be(TurnTerminalPath.UnmatchedIntentType);
+            LastLog.ParsedIntent.Should().Be("UnroutedTestIntent");
+        }
+
+        [Test]
+        public async Task TerminalPath_IsNoMatchingVerbForNounInLocation_WhenTheVerbLandsOnSomethingHere()
+        {
+            var engine = EngineFor(new SimpleIntent { Verb = "kick", Noun = "mailbox", OriginalInput = "kick mailbox" });
+
+            await engine.GetResponse("kick mailbox");
+
+            LastLog.TerminalPath.Should().Be(TurnTerminalPath.NoMatchingVerbForNounInLocation);
+        }
+
+        [Test]
+        public async Task TerminalPath_IsNoMatchingVerbForNounInInventory_WhenTheVerbLandsOnSomethingCarried()
+        {
+            var engine = EngineFor(new SimpleIntent { Verb = "kick", Noun = "sword", OriginalInput = "kick sword" });
+            engine.Context.Take(Repository.GetItem<Sword>());
+
+            await engine.GetResponse("kick sword");
+
+            LastLog.TerminalPath.Should().Be(TurnTerminalPath.NoMatchingVerbForNounInInventory);
+        }
+
+        [Test]
+        public async Task TerminalPath_IsNounNotPresent_WhenTheNounExistsElsewhereInTheStory()
+        {
+            var engine = EngineFor(new SimpleIntent { Verb = "examine", Noun = "sword", OriginalInput = "examine sword" });
+            Repository.GetItem<Sword>(); // in the story, but not here and not carried
+
+            await engine.GetResponse("examine sword");
+
+            LastLog.TerminalPath.Should().Be(TurnTerminalPath.NounNotPresent);
+        }
+
+        [Test]
+        public async Task TerminalPath_IsNounNotInTheStory_WhenNothingAnywhereAnswersToTheNoun()
+        {
+            var engine = EngineFor(new SimpleIntent { Verb = "examine", Noun = "unicorn", OriginalInput = "examine unicorn" });
+
+            await engine.GetResponse("examine unicorn");
+
+            LastLog.TerminalPath.Should().Be(TurnTerminalPath.NounNotInTheStory);
+        }
+
+        [Test]
+        public async Task TerminalPath_IsMultiNounNeitherNounInTheStory_WhenBothNounsAreInvented()
+        {
+            var engine = EngineFor(MultiNoun("tie", "unicorn", "to", "tequila"));
+
+            await engine.GetResponse("tie unicorn to tequila");
+
+            LastLog.TerminalPath.Should().Be(TurnTerminalPath.MultiNounNeitherNounInTheStory);
+        }
+
+        [Test]
+        public async Task TerminalPath_IsMultiNounFirstNounMissing_WhenOnlyTheSecondIsHere()
+        {
+            var engine = EngineFor(MultiNoun("tie", "sword", "to", "mailbox"));
+            Repository.GetItem<Sword>();
+
+            await engine.GetResponse("tie sword to mailbox");
+
+            LastLog.TerminalPath.Should().Be(TurnTerminalPath.MultiNounFirstNounMissing);
+        }
+
+        [Test]
+        public async Task TerminalPath_IsMultiNounSecondNounMissing_WhenOnlyTheFirstIsHere()
+        {
+            var engine = EngineFor(MultiNoun("tie", "mailbox", "to", "sword"));
+            Repository.GetItem<Sword>();
+
+            await engine.GetResponse("tie mailbox to sword");
+
+            LastLog.TerminalPath.Should().Be(TurnTerminalPath.MultiNounSecondNounMissing);
+        }
+
+        [Test]
+        public async Task TerminalPath_IsMultiNounBothNounsMissing_WhenNeitherIsHere()
+        {
+            var engine = EngineFor(MultiNoun("tie", "sword", "to", "lantern"));
+            Repository.GetItem<Sword>();
+            Repository.GetItem<Lantern>();
+
+            await engine.GetResponse("tie sword to lantern");
+
+            LastLog.TerminalPath.Should().Be(TurnTerminalPath.MultiNounBothNounsMissing);
+        }
+
+        [Test]
+        public async Task TerminalPath_IsMultiNounNounIsSceneryOnly_WhenOneNounIsOnlyInTheRoomDescription()
+        {
+            // "field" is in West of House's prose but is not backed by an item, so no real
+            // interaction between it and the mailbox is possible.
+            var engine = EngineFor(MultiNoun("tie", "field", "to", "mailbox"));
+
+            await engine.GetResponse("tie field to mailbox");
+
+            LastLog.TerminalPath.Should().Be(TurnTerminalPath.MultiNounNounIsSceneryOnly);
+        }
+
+        [Test]
+        public async Task TerminalPath_IsMultiNounNoProcessorMatched_WhenBothItemsAreRealAndPresent()
+        {
+            var engine = EngineFor(MultiNoun("tie", "sword", "to", "mailbox"));
+            engine.Context.Take(Repository.GetItem<Sword>());
+
+            await engine.GetResponse("tie sword to mailbox");
+
+            LastLog.TerminalPath.Should().Be(TurnTerminalPath.MultiNounNoProcessorMatched);
+        }
+
+        [Test]
+        public async Task TerminalPath_IsMultiNounFirstNounMissingSecondIsAPerson()
+        {
+            var engine = EngineFor(MultiNoun("give", "sword", "to", "bob"));
+            Repository.GetItem<Sword>();
+            PlaceNamedPersonHere();
+
+            await engine.GetResponse("give sword to bob");
+
+            LastLog.TerminalPath.Should().Be(TurnTerminalPath.MultiNounFirstNounMissingSecondIsAPerson);
+        }
+
+        [Test]
+        public async Task TerminalPath_IsMultiNounSecondNounMissingFirstIsAPerson()
+        {
+            var engine = EngineFor(MultiNoun("tie", "bob", "to", "sword"));
+            Repository.GetItem<Sword>();
+            PlaceNamedPersonHere();
+
+            await engine.GetResponse("tie bob to sword");
+
+            LastLog.TerminalPath.Should().Be(TurnTerminalPath.MultiNounSecondNounMissingFirstIsAPerson);
+        }
+
+        [Test]
+        public async Task TerminalPath_IsEngineError_OnEveryLogTheRescuedTurnWrites()
+        {
+            var engine = BuildEngine(_client, _turnLogger, new ThrowingParser());
+
+            var response = await engine.GetResponse("anything at all");
+
+            // The safety net still returns a normal turn (issue #271)...
+            response.Should().NotBeNullOrWhiteSpace();
+            // ...and both the explicit error log and the ordinary one agree on how the turn ended,
+            // rather than one of them claiming a branch that never finished.
+            _logs.Should().HaveCount(2);
+            _logs.Should().OnlyContain(l => l.TerminalPath == TurnTerminalPath.EngineError);
+        }
+
+        [Test]
+        public async Task EverySentenceOfAMultiSentenceCommand_IsClassifiedSeparately()
+        {
+            // The diagnostics reset per sentence, not per request. Without that reset the second
+            // sentence's log would inherit the first's deflection and report a handled LOOK as a
+            // no-handler turn.
+            var engine = EngineFor(new SimpleIntent
+            {
+                Verb = "examine", Noun = "unicorn", OriginalInput = "examine unicorn"
+            });
+
+            await engine.GetResponse("examine unicorn. look");
+
+            _logs.Should().HaveCount(2);
+
+            _logs[0].ParsedIntent.Should().Be("SimpleIntent verb='examine' noun='unicorn' adjective='' adverb=''");
+            _logs[0].TerminalPath.Should().Be(TurnTerminalPath.NounNotInTheStory);
+
+            _logs[1].ParsedIntent.Should().Be("GlobalCommandIntent command='LookProcessor'");
+            _logs[1].TerminalPath.Should().Be(TurnTerminalPath.Handled);
+        }
+
+        private static MultiNounIntent MultiNoun(string verb, string nounOne, string preposition, string nounTwo)
+        {
+            return new MultiNounIntent
+            {
+                Verb = verb,
+                NounOne = nounOne,
+                NounTwo = nounTwo,
+                Preposition = preposition,
+                OriginalInput = $"{verb} {nounOne} {preposition} {nounTwo}"
+            };
+        }
+
+        private static void PlaceNamedPersonHere()
+        {
+            Repository.GetLocation<WestOfHouse>().ItemPlacedHere(Repository.GetItem<TestNamedPerson>());
+        }
+
+        /// <summary>Zork has no named people; the two person-specific deflections need one.</summary>
+        private class TestNamedPerson : ItemBase, IAmANamedPerson
+        {
+            public override string[] NounsForMatching => ["bob"];
+
+            public string ExaminationDescription => "Bob looks back at you.";
+
+            public override string GenericDescription(ILocation? currentLocation) => "Bob is here.";
+        }
+
+        /// <summary>An intent type the engine's dispatch switch deliberately has no arm for.</summary>
+        private record UnroutedTestIntent : IntentBase;
+
+        /// <summary>
+        ///     Pins the complex parse to one exact intent, so a test can aim at one branch. The cheap
+        ///     global/system passes are left real, so a sentence like "look" still resolves the way it
+        ///     does in play.
+        /// </summary>
+        private sealed class StubParser(IntentBase intent) : IIntentParser
+        {
+            private readonly IntentParser _staticPasses = new(Mock.Of<IAIParser>(), new ZorkOneGlobalCommandFactory());
+
+            public Guid? TurnCorrelationId { get; set; }
+
+            public ICloudWatchLogger<GenerationLog>? Logger { get; set; }
+
+            public IntentBase? DetermineGlobalIntentType(string? input)
+                => _staticPasses.DetermineGlobalIntentType(input);
+
+            public IntentBase? DetermineSystemIntentType(string? input)
+                => _staticPasses.DetermineSystemIntentType(input);
+
+            public Task<IntentBase> DetermineComplexIntentType(string? input, string locationDescription,
+                string sessionId) => Task.FromResult(intent);
+
+            public Task<string?> ResolvePronounsAsync(string input, string? lastInput, string? lastResponse)
+                => Task.FromResult<string?>(null);
+        }
+
+        /// <summary>Blows up mid-turn, to exercise the engine-error safety net's own turn log.</summary>
+        private sealed class ThrowingParser : IIntentParser
+        {
+            public Guid? TurnCorrelationId { get; set; }
+
+            public ICloudWatchLogger<GenerationLog>? Logger { get; set; }
+
+            public IntentBase? DetermineGlobalIntentType(string? input) => null;
+
+            public IntentBase? DetermineSystemIntentType(string? input) => null;
+
+            public Task<IntentBase> DetermineComplexIntentType(string? input, string locationDescription,
+                string sessionId) => throw new InvalidOperationException("boom");
+
+            public Task<string?> ResolvePronounsAsync(string input, string? lastInput, string? lastResponse)
+                => Task.FromResult<string?>(null);
+        }
     }
 }


### PR DESCRIPTION
Closes #578.

## The gap

A turn's logs could not say whether the engine had **considered** a command and declined it, or whether **nothing had run at all**. That is what forced issue #538's `noGeneratedResponses` sentinel — inferring a dropped turn from the literal string `This action or command has no effect on the game.` appearing alone — which is fragile, only works with the narrator disabled, and cannot distinguish *which* no-handler path was taken.

Diagnosing the three parser-shape defects behind #538 (all fixed in #540) took a 1,352-command production trace and a lot of inference, because `GameEngine.cs` logged the intent type at `Debug` only, which production does not retain.

## What this adds

Two fields on `TurnLog`, populated on every turn.

**1. `ParsedIntent`** — the `IntentBase` subtype plus the fields that actually drive dispatch:

```
SimpleIntent verb='press' noun='' adjective='' adverb=''
MultiNounIntent verb='tie' nounOne='rope' nounTwo='railing' preposition='with'
GlobalCommandIntent command='LookProcessor'
MoveIntent direction='N' noun=''
```

This alone names #540's defect 1 (preposition rewritten to a hardcoded `"with"`) and defect 3 (`press 3` arriving with no noun tag) straight off a single turn, rather than by inference from outcome frequencies. It is parse metadata only — no raw player text beyond what `TurnLog.Input` already captures, so no new PII surface. It stays null on the paths that never reach the parser (a stateful processor answering its own prompt, an empty command, a location's raw-input interaction, a conversation), which is itself the diagnostic fact.

Rendered by a new `IntentShapeDescriber`, hand-written rather than leaning on the records' generated `ToString` — that would print `Message`, print the whole command object for a global command, and drift silently whenever a property is added.

**2. `TerminalPath`** — a `TurnTerminalPath` enum, kept in `CloudWatch/Model/` next to `TurnLog` so the Lambda and the harness both deserialize it, and serialized **by name** (`"NounNotPresent"`, not `12`). All twelve no-handler deflections are tagged individually:

| Site | Enum value |
|---|---|
| `SimpleInteractionEngine` verb has no effect, noun in location | `NoMatchingVerbForNounInLocation` |
| verb has no effect, noun in inventory | `NoMatchingVerbForNounInInventory` |
| noun exists in story, not present here | `NounNotPresent` |
| noun exists nowhere in the story | `NounNotInTheStory` |
| `MultiNounEngine` neither noun exists in the story | `MultiNounNeitherNounInTheStory` |
| first noun missing (± person) | `MultiNounFirstNounMissing{SecondIsAPerson}` |
| second noun missing (± person) | `MultiNounSecondNounMissing{FirstIsAPerson}` |
| both nouns missing | `MultiNounBothNounsMissing` |
| one noun is scenery, not a real item | `MultiNounNounIsSceneryOnly` |
| no processor handled the pair | `MultiNounNoProcessorMatched` |
| `NullIntent` — parser produced no usable shape | `NullIntent` |
| unmatched intent type (fallthrough) | `UnmatchedIntentType` |

Everything else is `Handled`. The engine-error safety net (issue #271) sets `EngineError` explicitly **before either of the two logs that turn writes**, rather than leaving the ordinary one claiming a branch that never finished.

## Implementation notes

- The two engines report their branch on a per-turn instance property the engine reads back after `Process` returns — a fresh engine per turn, so there is nothing to reset.
- The dispatch switch's own arms (`NullIntent`, fallthrough) are tagged via small wrappers. A switch *expression* arm cannot assign a field, and classifying the intent in a second switch beside the first would be a trap: adding an intent type to one and not the other would silently mislabel every turn of that type.
- Diagnostics reset per **sentence**, not per request, since each sentence of a multi-sentence command writes its own `TurnLog`.
- `TerminalPath` is deliberately not `required` — that would force edits to six existing `TurnLog` constructions in tests for no gain, and `Unknown = 0` is an honest default for a log built outside the engine.

## Why this and not #541's canned refusals

The distinction #541 wanted is already in the *player-visible* output — twelve situation-specific generation requests, each telling the narrator exactly which failure occurred. What was missing was the same distinction in a form a *tool* can read. This is a better signal than the sentinel: it survives the narrator being enabled and it names the branch. **Zero player-visible change, zero churn against existing assertions.** Retires the AB-105 sentinel convention.

## Tests

- **21 new** in `LoggingAndHistoryTests.TurnDiagnosticsTests` — every enum value, including both person-specific multi-noun variants (via a test-local `IAmANamedPerson`, since Zork has none), the engine-error path asserting *both* of that turn's logs agree, and a multi-sentence test that fails if the per-sentence reset is removed.
- **3 new** in `CloudWatchLoggerTests` — name-not-integer serialization, JSON round-trip, and the `Unknown` default.

Drive-by fix found while writing them: `LoggingAndHistoryTests.BuildEngine` called `Repository.Reset()` *after* constructing the engine, handing `Init()` a second `WestOfHouse` instance while `Context.CurrentLocation` still pointed at the first — the player stood in a room with no mailbox in it. Removed, with a comment.

All suites green: UnitTests 1330, ZorkOne 1782, Planetfall 4026, Stationfall 128, EscapeRoom 9, Console 26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)