### PR TITLE
Fix #580: recover the object when the parser drops it from "enter <thing>"

### DIFF
--- a/Model/ParsingHelper.cs
+++ b/Model/ParsingHelper.cs
@@ -302,7 +302,7 @@ public static class ParsingHelper
         return new GoToDestinationIntent { Destination = nouns.First(), Message = response };
     }
 
-    private static IntentBase? DetermineMoveIntent(string? response)
+    private static IntentBase? DetermineMoveIntent(string? response, string originalInput)
     {
         var intentTag = ExtractElementsByTag(response, "intent").SingleOrDefault();
         if (string.IsNullOrEmpty(intentTag))
@@ -326,7 +326,20 @@ public static class ParsingHelper
         // there is no exit that way at all.
         var direction = DirectionParser.ParseDirection(directionTag ?? string.Empty);
         if (direction != Direction.Unknown)
+        {
+            // Issue #580: and when it buckets the command that way, it often drops the object too. A
+            // DIRECTION has no object, so having decided "enter door" is a move, the model emits no
+            // <noun> at all - which left the #551 recovery below with nothing to look up, and the
+            // Elevator Lobby still answering "You cannot go that way." after 2.11.0 shipped. Only the
+            // enter half broke because "exit the boat" is one of the system prompt's own examples and
+            // keeps its noun, while no example shows "enter <thing>" as a board. The player named the
+            // thing, so read it back out of their own sentence, exactly as the noun and preposition
+            // recoveries for issue #538 do.
+            if (string.IsNullOrWhiteSpace(noun) && direction is Direction.In or Direction.Out)
+                noun = RecoverBoardingNounFromInput(originalInput);
+
             return new MoveIntent { Direction = direction, Noun = noun, Message = response };
+        }
 
         // Issue #268 deterministic safety net: the model tagged this "move" but the direction did not
         // resolve to a real direction (typically "other"). If it also named a place, the player wants
@@ -336,6 +349,37 @@ public static class ParsingHelper
             : new GoToDestinationIntent { Destination = noun, Message = response };
     }
     
+    /// <summary>
+    ///     Issue #580. Reads the object of an "enter &lt;thing&gt;" / "exit &lt;thing&gt;" command out of
+    ///     the player's own input, for the turns where the AI parser bucketed it as a bare directional
+    ///     move and tagged no &lt;noun&gt; at all. Returns null when there was no object to recover.
+    /// </summary>
+    /// <remarks>
+    ///     Keyed off the player's LEADING word rather than the &lt;verb&gt; tag, because this shape is
+    ///     precisely the one where the model has stopped describing the command as a verb plus an
+    ///     object - it may tag the direction word as the verb, or emit no verb at all.
+    ///     <para>
+    ///         A recovered noun that is itself a direction is discarded: "go in" and "out" name no
+    ///         object, and handing one to <c>MoveEngine</c> would have it hunt the room for an item
+    ///         called "in". Everything else is still checked against what is actually in scope there
+    ///         before it can change the turn, so the worst this can do is recover a word that resolves
+    ///         to nothing and leave the refusal exactly as it was.
+    ///     </para>
+    /// </remarks>
+    private static string? RecoverBoardingNounFromInput(string? originalInput)
+    {
+        var leadingWord = originalInput?
+            .Split(WordSeparators, StringSplitOptions.RemoveEmptyEntries)
+            .FirstOrDefault();
+
+        if (string.IsNullOrEmpty(leadingWord))
+            return null;
+
+        var recovered = RecoverNounFromInput(originalInput, leadingWord)?.Noun;
+
+        return DirectionParser.ParseDirection(recovered) == Direction.Unknown ? recovered : null;
+    }
+
     private static T? DetermineSimpleIntent<T>(string? response) where T : IntentBase, new()
     {
         var tag = typeof(T).GetProperty("TagName")?.GetValue(null) as string;
@@ -554,7 +598,7 @@ public static class ParsingHelper
         if (goToIntent != null)
             return goToIntent;
 
-        var moveIntent = DetermineMoveIntent(response?.ToLowerInvariant());
+        var moveIntent = DetermineMoveIntent(response?.ToLowerInvariant(), input);
         if (moveIntent != null)
             return moveIntent;
         

--- a/Planetfall.Tests/LiveParserShapeTests.cs
+++ b/Planetfall.Tests/LiveParserShapeTests.cs
@@ -243,6 +243,109 @@ public class LiveParserShapeTests : EngineTestsBase
         Context.CurrentLocation.Should().BeOfType<UpperElevator>();
     }
 
+    /// <summary>
+    ///     Issue #580. PR #573 fixed the shape above and shipped in 2.11.0, yet "enter door" in the
+    ///     Elevator Lobby still answered "You cannot go that way." on 14 of 14 production trials while
+    ///     its mirror "exit door" reached the question. That asymmetry pins the shape gpt-4o really
+    ///     emits: "exit the boat" is an in-prompt example that KEEPS its noun, but nothing in the
+    ///     prompt shows "enter &lt;thing&gt;" as a board, so the model reads bare "enter door" as a pure
+    ///     DIRECTION move - rule 1a lists "in" as a relative direction and rule 5 lists the literal
+    ///     word "enter" - and a direction has no object, so it emits no &lt;noun&gt; at all. With the
+    ///     object gone, MoveEngine.TryBoardTheNamedObject has nothing to look up and the lobby's
+    ///     missing In exit produces the flat refusal. The other two candidate causes are ruled out by
+    ///     the same report: "examine door" asks the question in this room, so the noun IS resolvable in
+    ///     scope; and a direction that failed to resolve would have gone to destination navigation
+    ///     ("You can't get there from here."), not to MoveEngine's refusal. The player named the door -
+    ///     recover it from their own words.
+    /// </summary>
+    [Test]
+    public async Task EnterADoor_WhenTheParserDropsTheNounEntirely_StillAsksWhichDoor()
+    {
+        var target = GetTarget(ParserReturning("""
+                                               <intent>move</intent>
+                                               <verb>enter</verb>
+                                               <direction>enter</direction>
+                                               """));
+        StartHere<ElevatorLobby>();
+
+        var response = await target.GetResponse("enter door");
+
+        response.Should().Contain("Do you mean");
+        response.Should().Contain("upper elevator door");
+        response.Should().Contain("lower elevator door");
+        Context.CurrentLocation.Should().BeOfType<ElevatorLobby>();
+    }
+
+    /// <summary>
+    ///     Issue #580, the same dropped noun with the direction tagged as the word "in" rather than
+    ///     "enter". Both spellings are on rule 5's list and both resolve to Direction.In, so the
+    ///     recovery must not depend on which one the model happened to pick.
+    /// </summary>
+    [Test]
+    public async Task EnterADoor_WhenTheParserDropsTheNounAndTagsTheDirectionIn_StillAsksWhichDoor()
+    {
+        var target = GetTarget(ParserReturning("""
+                                               <intent>move</intent>
+                                               <verb>enter</verb>
+                                               <direction>in</direction>
+                                               """));
+        StartHere<ElevatorLobby>();
+
+        var response = await target.GetResponse("enter door");
+
+        response.Should().Contain("Do you mean");
+        response.Should().Contain("upper elevator door");
+        response.Should().Contain("lower elevator door");
+        Context.CurrentLocation.Should().BeOfType<ElevatorLobby>();
+    }
+
+    /// <summary>
+    ///     Issue #580's decisive discriminator, reproduced: the Upper Elevator has exactly ONE door in
+    ///     scope, so nothing here is about disambiguation - with the object recovered, "enter door"
+    ///     walks through the door the way "go through door" always did, instead of refusing.
+    /// </summary>
+    [Test]
+    public async Task EnterADoor_WhenTheParserDropsTheNoun_StillWalksThroughTheOnlyDoorInTheRoom()
+    {
+        var target = GetTarget(ParserReturning("""
+                                               <intent>move</intent>
+                                               <verb>enter</verb>
+                                               <direction>enter</direction>
+                                               """));
+        StartHere<UpperElevator>();
+        GetItem<UpperElevatorDoor>().IsOpen = true;
+        GetLocation<UpperElevator>().InLobby = true;
+
+        var response = await target.GetResponse("enter door");
+
+        response.Should().NotContain("cannot go that way");
+        Context.CurrentLocation.Should().BeOfType<ElevatorLobby>();
+    }
+
+    /// <summary>
+    ///     Issue #580, point 5: even the half that worked was model-dependent - "exit door" produced
+    ///     the question on only 1 of 5 production trials. The same dropped noun is the shape behind the
+    ///     trial that refused, and the same recovery fixes it, so neither half depends on which bucket
+    ///     the model picks.
+    /// </summary>
+    [Test]
+    public async Task ExitADoor_WhenTheParserDropsTheNounEntirely_StillAsksWhichDoor()
+    {
+        var target = GetTarget(ParserReturning("""
+                                               <intent>move</intent>
+                                               <verb>exit</verb>
+                                               <direction>exit</direction>
+                                               """));
+        StartHere<ElevatorLobby>();
+
+        var response = await target.GetResponse("exit door");
+
+        response.Should().Contain("Do you mean");
+        response.Should().Contain("upper elevator door");
+        response.Should().Contain("lower elevator door");
+        Context.CurrentLocation.Should().BeOfType<ElevatorLobby>();
+    }
+
     [Test]
     public async Task TakeWithATool_WhenTheParserBucketsItAsATake_StillRemovesTheFusedBedistor()
     {

--- a/UnitTests/Models/ParsingHelperTests.cs
+++ b/UnitTests/Models/ParsingHelperTests.cs
@@ -923,6 +923,113 @@ public class ParsingHelperTests
     }
 
     [Test]
+    public void GetIntent_WithEnterANoun_ButNoNounTag_RecoversTheObjectFromThePlayersOwnWords()
+    {
+        // Issue #580. "enter <thing>" is a board command, but rule 1a calls "in" a relative direction
+        // and rule 5 lists the literal word "enter", so gpt-4o buckets bare "enter door" as a pure
+        // DIRECTION move - and a direction has no object, so it drops the <noun> tag entirely. Without
+        // the object, MoveEngine.TryBoardTheNamedObject (issue #551) has nothing to look up and a room
+        // with no In exit answers "You cannot go that way." The player named the door; read it back out
+        // of their sentence.
+        var input = "enter door";
+        var response = @"<intent>move</intent>
+<verb>enter</verb>
+<direction>enter</direction>";
+
+        var result = ParsingHelper.GetIntent(input, response, _loggerMock?.Object);
+
+        result.Should().BeOfType<MoveIntent>();
+        (result as MoveIntent)?.Direction.Should().Be(Direction.In);
+        (result as MoveIntent)?.Noun.Should().Be("door");
+    }
+
+    [Test]
+    public void GetIntent_WithExitANoun_ButNoNounTag_RecoversTheObjectFromThePlayersOwnWords()
+    {
+        // Issue #580, the mirror half: the same dropped noun in Direction.Out.
+        var input = "exit the pod";
+        var response = @"<intent>move</intent>
+<verb>exit</verb>
+<direction>out</direction>";
+
+        var result = ParsingHelper.GetIntent(input, response, _loggerMock?.Object);
+
+        result.Should().BeOfType<MoveIntent>();
+        (result as MoveIntent)?.Direction.Should().Be(Direction.Out);
+        (result as MoveIntent)?.Noun.Should().Be("pod");
+    }
+
+    [Test]
+    public void GetIntent_WithGetInTheNoun_ButNoNounTag_RecoversTheObjectWithoutItsPreposition()
+    {
+        // Issue #580. The other phrasings that reach Direction.In carry a preposition the noun must
+        // not swallow: "get in the boat" is the boat, not "in the boat".
+        var input = "get in the boat";
+        var response = @"<intent>move</intent>
+<verb>get</verb>
+<direction>in</direction>";
+
+        var result = ParsingHelper.GetIntent(input, response, _loggerMock?.Object);
+
+        result.Should().BeOfType<MoveIntent>();
+        (result as MoveIntent)?.Direction.Should().Be(Direction.In);
+        (result as MoveIntent)?.Noun.Should().Be("boat");
+    }
+
+    [TestCase("go in")]
+    [TestCase("go out")]
+    [TestCase("enter")]
+    public void GetIntent_WithABareDirectionalMove_RecoversNoNoun(string input)
+    {
+        // Issue #580 guard: the player named no object, so there is nothing to recover. The direction
+        // word itself is not a noun - handing "in"/"out" to MoveEngine as one would have it hunt the
+        // room for an item by that name.
+        var response = @"<intent>move</intent>
+<verb>go</verb>
+<direction>" + (input.EndsWith("out") ? "out" : "in") + @"</direction>";
+
+        var result = ParsingHelper.GetIntent(input, response, _loggerMock?.Object);
+
+        result.Should().BeOfType<MoveIntent>();
+        (result as MoveIntent)?.Noun.Should().BeNullOrEmpty();
+    }
+
+    [Test]
+    public void GetIntent_WithACardinalMove_AndNoNounTag_RecoversNothing()
+    {
+        // Issue #580 guard: recovery is only for the In/Out directions the words "enter"/"exit"
+        // produce. A cardinal move has no board/disembark meaning to fall back to, so it must stay
+        // exactly the plain move it has always been.
+        var input = "go north to the kitchen";
+        var response = @"<intent>move</intent>
+<verb>go</verb>
+<direction>north</direction>";
+
+        var result = ParsingHelper.GetIntent(input, response, _loggerMock?.Object);
+
+        result.Should().BeOfType<MoveIntent>();
+        (result as MoveIntent)?.Direction.Should().Be(Direction.N);
+        (result as MoveIntent)?.Noun.Should().BeNullOrEmpty();
+    }
+
+    [Test]
+    public void GetIntent_WithEnterANoun_AndATaggedNoun_KeepsTheParsersNoun()
+    {
+        // Issue #580 guard: recovery only fills a GAP. When the model did tag the object - the shape
+        // PR #573 was built against - that tag still wins.
+        var input = "enter the blue door";
+        var response = @"<intent>move</intent>
+<verb>enter</verb>
+<noun>blue door</noun>
+<direction>enter</direction>";
+
+        var result = ParsingHelper.GetIntent(input, response, _loggerMock?.Object);
+
+        result.Should().BeOfType<MoveIntent>();
+        (result as MoveIntent)?.Noun.Should().Be("blue door");
+    }
+
+    [Test]
     public void GetIntent_TakeIntentPriorityOverDropIntent()
     {
         // Arrange - take should match before other intents


### PR DESCRIPTION
Fixes #580.

## What was wrong

PR #573 shipped in 2.11.0 and fixed `enter door` for **the shape it assumed gpt-4o emits** — a move that still carries the object in `<noun>` tags. On prod, the Elevator Lobby kept answering `You cannot go that way.` 14/14, while the mirrored `exit door` reached the promised "Do you mean...?".

That asymmetry is the whole diagnosis. The issue lists three candidate causes; its own evidence rules out two of them:

| Candidate | Ruled out by |
|---|---|
| noun not resolvable in scope | `examine door` asks the question in that very room, so `"door"` **does** resolve |
| direction not resolving to In | an unresolved direction goes to destination navigation → `You can't get there from here.`, not to `MoveEngine`'s refusal |
| **noun dropped** | ← the only cause left, and it is the one the engine can recover from |

The system prompt's rule 1a calls "in" a relative direction and rule 5 lists the literal word "enter", so the model buckets bare `enter door` as a **pure direction move** — and a direction has no object, so it emits no `<noun>` at all. Only the enter half broke because `"exit the boat"` is one of the prompt's own examples and keeps its noun, while no example shows `enter <thing>` as a board.

With the object gone, `MoveEngine.TryBoardTheNamedObject` (the #551 recovery) had nothing to look up, and the lobby's missing `In` exit produced the flat refusal.

## The fix

`ParsingHelper.DetermineMoveIntent` now reads the object back out of the player's own sentence when the model tags an In/Out move with no noun — the same recovery the `<preposition>` and `<noun>` fixes for #538 already do, reusing `RecoverNounFromInput`.

Deliberately narrow:

- Only when the noun is **missing** — a tagged noun still wins.
- Only for **In/Out**, the directions the words "enter"/"exit" produce. A cardinal move is untouched.
- Keyed off the player's **leading word** rather than the `<verb>` tag, because this is precisely the shape where the model has stopped describing the command as a verb plus an object.
- A recovered noun that is itself a direction is discarded, so `go in` never hunts the room for an item called "in".
- `MoveEngine` still runs only after the map says there is no exit that way at all, and still requires the noun to name something actually in scope — so the worst this can do is recover a word that resolves to nothing and leave the refusal exactly as it was.

## Player-visible

| Command | Before | After |
|---|---|---|
| `enter door` (Elevator Lobby) | `You cannot go that way.` | `Do you mean the lower elevator door or the upper elevator door?` |
| `enter door` (Upper Elevator, one door) | `You cannot go that way.` | walks through the door |
| `exit door` (Elevator Lobby) | intermittently refused | asks which door |

## TDD

All four new `Planetfall.Tests/LiveParserShapeTests` failed with the **verbatim production string** `You cannot go that way.` before the change:

```
Failed EnterADoor_WhenTheParserDropsTheNounEntirely_StillAsksWhichDoor
  Expected response "You cannot go that way." to contain "Do you mean".
Failed EnterADoor_WhenTheParserDropsTheNounAndTagsTheDirectionIn_StillAsksWhichDoor
Failed EnterADoor_WhenTheParserDropsTheNoun_StillWalksThroughTheOnlyDoorInTheRoom
Failed ExitADoor_WhenTheParserDropsTheNounEntirely_StillAsksWhichDoor
```

They include the issue's **decisive discriminator** — the single-door Upper Elevator, where nothing is about disambiguation — and both `<direction>enter</direction>` and `<direction>in</direction>` spellings.

Six `ParsingHelperTests` pin the recovery and its guards (three of them failed before the fix; three are guards that passed before and still pass): a tagged noun still wins, a cardinal move recovers nothing, and bare `go in` / `go out` / `enter` recover nothing.

**Full suite: 7,305 tests, 0 failures** (UnitTests 1326, ZorkOne.Tests 1782, Planetfall.Tests 4031, EscapeRoom.Tests 9, Stationfall.Tests 131, Console.Tests 26).

## Not done

The issue's step 1 asks for a capture of the raw prod completion before touching engine code. I can't reach prod from here, so the shape is established by elimination from the report's own A/B evidence rather than observed directly. If a capture later shows the direction tag is also at fault, that is a separate, additive condition — this change is inert for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)