### PR TITLE
Close the opening's verb gaps: 22 to zero

### DIFF
--- a/Docs/Stationfall-Port-Plan.md
+++ b/Docs/Stationfall-Port-Plan.md
@@ -98,8 +98,12 @@ ceiling, air, the player's own body — which the engine had no equivalent for a
 now declares `GlobalScenery`, checked after a room's own, so one system closed 92% of the gap and did
 it for Zork and Planetfall too.
 
-Note what the sweep covers today: `examine` on the nouns each room's prose puts in front of the
-player. That is the floor, not the ceiling. The next passes should widen it to the full verb set the
+The verb sweep now measures zero too, and `EveryVerbTheOriginalAnswersFor_IsAnsweredHere` gates it:
+all 54 object/verb pairs the originals' action routines author an answer for, across the objects
+reachable in the opening, are answered here. It started at 22.
+
+Note what the sweeps cover today: the nouns each room's prose raises, and the verbs each object's ZIL
+action routine names. That is the floor, not the ceiling. The next passes should widen it to the full verb set the
 original answers for, then to the objects rather than just the rooms — and each widening should be
 expected to find new gaps. A zero here means "nothing known is missing", never "nothing is missing".
 

--- a/Stationfall.Tests/VerbSweepTests.cs
+++ b/Stationfall.Tests/VerbSweepTests.cs
@@ -108,6 +108,33 @@ public class VerbSweepTests : EngineTestsBase
     }
 
     /// <summary>
+    ///     The gate. Every verb the original authors an answer for, in the opening, is answered here
+    ///     too. A new object that declares verbs it does not handle - or a room description that puts a
+    ///     new noun in front of the player - fails this, so content and its coverage land together.
+    /// </summary>
+    [Test]
+    public async Task EveryVerbTheOriginalAnswersFor_IsAnsweredHere()
+    {
+        var gaps = new List<string>();
+
+        foreach (var (travel, noun, verbs) in Targets)
+        foreach (var verb in verbs)
+        {
+            var target = GetTarget();
+            foreach (var step in Route(travel, noun))
+                await target.GetResponse(step);
+
+            LeakRecorder.Clear();
+            await target.GetResponse(Command(verb, noun));
+
+            if (LeakRecorder.CompletenessLeaks.Count > 0)
+                gaps.Add(Command(verb, noun));
+        }
+
+        gaps.Should().BeEmpty("the original authors an answer for each of these, so the port must too");
+    }
+
+    /// <summary>
     ///     The full route from the start of the game to where this noun is in scope. Cumulative,
     ///     because each target starts from a fresh game.
     /// </summary>

--- a/Stationfall/Item/Duffy/BlueSoup.cs
+++ b/Stationfall/Item/Duffy/BlueSoup.cs
@@ -95,6 +95,39 @@ public class BlueSoup : ItemBase, ICanBeExamined, ICanBeEaten, ITurnBasedActor
         Warmth = Math.Max(0, Warmth - degrees);
     }
 
+    public override async Task<InteractionResult?> RespondToSimpleInteraction(SimpleIntent action,
+        IContext context, IGenerationClient client, IItemProcessorFactory itemProcessorFactory)
+    {
+        if (action.MatchNounAndAdjective(NounsForMatching))
+        {
+            // Touching or tasting it reports the temperature - which is the only reason the
+            // temperature exists (ship.zil SOUP-F).
+            if (action.MatchVerb(["touch", "taste", "feel", "reach in", "reach into"]))
+                return new PositiveInteractionResult(ExaminationDescription);
+
+            if (action.MatchVerb(["pour", "empty", "pour out", "dump", "spill"]))
+                return new PositiveInteractionResult(SpillIt());
+        }
+
+        return await base.RespondToSimpleInteraction(action, context, client, itemProcessorFactory);
+    }
+
+    /// <summary>
+    ///     Tips the soup out wherever you are standing. It is gone for good.
+    /// </summary>
+    public string SpillIt()
+    {
+        var thermos = Repository.GetItem<Thermos>();
+
+        if (thermos.Items.Contains(this))
+            thermos.RemoveItem(this);
+
+        CurrentLocation = null;
+
+        return "You tip the soup out. It spreads across the deck in a wide blue disc, and the smell of " +
+               "blueberries fills the place. ";
+    }
+
     public (string Message, bool WasConsumed) OnEating(IContext context)
     {
         if (context is StationfallContext stationfallContext)

--- a/Stationfall/Item/Duffy/FormBase.cs
+++ b/Stationfall/Item/Duffy/FormBase.cs
@@ -1,3 +1,4 @@
+using Model.AIGeneration;
 using GameEngine.Item;
 using Model.Interface;
 using Model.Item;
@@ -15,6 +16,22 @@ public abstract class FormBase : ItemBase, ICanBeTakenAndDropped, ICanBeExamined
     /// <summary>
     ///     The form's serial designation, e.g. "QX-17-T".
     /// </summary>
+    /// <summary>
+    ///     Destroying Patrol paperwork is an offence, and the form says so rather than letting the
+    ///     narrator improvise a refusal (ship.zil FORM-F).
+    /// </summary>
+    public override async Task<InteractionResult?> RespondToSimpleInteraction(SimpleIntent action,
+        IContext context, IGenerationClient client, IItemProcessorFactory itemProcessorFactory)
+    {
+        if (action.MatchNounAndAdjective(NounsForMatching) &&
+            action.MatchVerb(["crumple", "destroy", "tear", "rip", "shred", "burn", "eat", "break"]))
+            return new PositiveInteractionResult(
+                "Destroying a Patrol form is a violation of the Uniform Code of Paperwork, and you " +
+                "have no intention of explaining yourself at a hearing. ");
+
+        return await base.RespondToSimpleInteraction(action, context, client, itemProcessorFactory);
+    }
+
     public abstract string FormNumber { get; }
 
     /// <summary>

--- a/Stationfall/Item/Duffy/GooBase.cs
+++ b/Stationfall/Item/Duffy/GooBase.cs
@@ -28,6 +28,23 @@ public abstract class GooBase : ItemBase, ICanBeExamined, ICanBeEaten
 
         // Both refusals end by naming the only thing that does work, so the player is never left
         // holding a food item they cannot figure out how to eat.
+        // Eating it where it sits is the ONLY thing that works, so it has to work even though the kit
+        // is on the deck rather than in your hands (ship.zil GOO-F gates on being in the kit, not on
+        // the player holding it).
+        if (action.MatchVerb(["eat", "drink", "swallow"]))
+        {
+            var (message, consumed) = OnEating(context);
+
+            if (consumed)
+            {
+                CurrentLocation?.RemoveItem(this);
+                context.RemoveItem(this);
+                CurrentLocation = null;
+            }
+
+            return new PositiveInteractionResult(message);
+        }
+
         if (action.MatchVerb(["take", "get", "pick up", "remove", "grab"]))
             return new PositiveInteractionResult(
                 "It would ooze through your fingers. You'll have to eat it right out of the survival " +

--- a/Stationfall/Item/Duffy/Pallets.cs
+++ b/Stationfall/Item/Duffy/Pallets.cs
@@ -43,6 +43,16 @@ public class Pallets : ItemBase, ICanBeExamined, ICanBeRead
                 "You work a box open. Inside are forms" + string.Concat(Enumerable.Repeat(" and forms", 50)) +
                 ". Horrified, you reseal the box. ");
 
+        if (action.MatchVerb(["count"]))
+            return new PositiveInteractionResult(
+                "You get as far as the fourth row before losing your place, and the thought of " +
+                "starting again is more than you can bear. ");
+
+        if (action.MatchVerb(["destroy", "tear", "rip", "shred", "burn", "break", "crumple"]))
+            return new PositiveInteractionResult(
+                "Destroying Patrol forms on this scale would be a violation of the Uniform Code of " +
+                "Paperwork so comprehensive that it probably has its own form. ");
+
         if (action.MatchVerb(["close", "shut", "seal"]))
             return new PositiveInteractionResult("The boxes are already sealed. ");
 

--- a/Stationfall/Item/Duffy/PatrolUniform.cs
+++ b/Stationfall/Item/Duffy/PatrolUniform.cs
@@ -1,3 +1,4 @@
+using Model.AIGeneration;
 namespace Stationfall.Item.Duffy;
 
 /// <summary>
@@ -32,6 +33,20 @@ public class PatrolUniform : ContainerBase, ICanBeTakenAndDropped, ICanBeExamine
     {
         return OnTheGroundDescription(currentLocation);
     }
+    /// <summary>
+    ///     The pocket is part of the garment - there is nothing to work (ship.zil PATROL-UNIFORM-F).
+    /// </summary>
+    public override async Task<InteractionResult?> RespondToSimpleInteraction(SimpleIntent action,
+        IContext context, IGenerationClient client, IItemProcessorFactory itemProcessorFactory)
+    {
+        if (action.MatchNounAndAdjective(NounsForMatching) &&
+            action.MatchVerb(["open", "close", "shut", "unfasten", "fasten"]))
+            return new PositiveInteractionResult(
+                "There's no way to open or close the pocket of the uniform. ");
+
+        return await base.RespondToSimpleInteraction(action, context, client, itemProcessorFactory);
+    }
+
 
     public override void Init()
     {

--- a/Stationfall/Item/Duffy/SpacetruckExteriorBase.cs
+++ b/Stationfall/Item/Duffy/SpacetruckExteriorBase.cs
@@ -31,15 +31,42 @@ public abstract class SpacetruckExteriorBase : ItemBase, ICanBeExamined
         return string.Empty;
     }
 
+    private static string OperateHatch(bool open, IContext context)
+    {
+        var hatch = Repository.GetItem<SpacetruckHatch>();
+
+        if (hatch.IsOpen == open)
+            return open ? "It is already open. " : "It is already closed. ";
+
+        var refusal = open ? hatch.CannotBeOpenedDescription(context) : null;
+        if (refusal is not null)
+            return refusal;
+
+        hatch.IsOpen = open;
+        return open ? hatch.NowOpen(context.CurrentLocation) : hatch.NowClosed(context.CurrentLocation);
+    }
+
     public override async Task<InteractionResult?> RespondToSimpleInteraction(SimpleIntent action,
         IContext context, IGenerationClient client, IItemProcessorFactory itemProcessorFactory)
     {
         if (action.MatchNounAndAdjective(NounsForMatching))
         {
             // Opening "the truck" means opening its hatch; there is nothing else on it to open.
-            if (action.MatchVerb(["open", "close", "shut", "unseal"]))
-                return await Repository.GetItem<SpacetruckHatch>()
-                    .RespondToSimpleInteraction(action, context, client, itemProcessorFactory);
+            // Acting on the hatch directly rather than forwarding the intent: the intent names the
+            // truck, which the hatch does not answer to, so forwarding it just fell through to the
+            // narrator - the very gap the sweep caught.
+            if (action.MatchVerb(["open", "unseal"]))
+                return new PositiveInteractionResult(OperateHatch(true, context));
+
+            if (action.MatchVerb(["close", "shut"]))
+                return new PositiveInteractionResult(OperateHatch(false, context));
+
+            if (action.MatchVerb(["search", "look in", "look inside"]))
+                return new PositiveInteractionResult(
+                    Repository.GetItem<SpacetruckHatch>().IsOpen
+                        ? "Through the open hatch you can see two seats and an empty cargo section. "
+                        : "The hatch is closed, and the viewport shows you nothing but your own " +
+                          "reflection. ");
 
             if (action.MatchVerb(["launch", "start", "drive", "fly", "turn on"]))
                 return new PositiveInteractionResult("You're not even in it! ");

--- a/Stationfall/Item/Duffy/SurvivalKit.cs
+++ b/Stationfall/Item/Duffy/SurvivalKit.cs
@@ -1,3 +1,4 @@
+using Model.AIGeneration;
 namespace Stationfall.Item.Duffy;
 
 /// <summary>
@@ -25,6 +26,22 @@ public class SurvivalKit : OpenAndCloseContainerBase, ICanBeTakenAndDropped, ICa
     public override string NeverPickedUpDescription(ILocation currentLocation)
     {
         return OnTheGroundDescription(currentLocation);
+    }
+
+    /// <summary>
+    ///     Emptying the kit amounts to trying to get the goo out of it, which is the one thing the goo
+    ///     will not allow (ship.zil FOOD-KIT-F hands EMPTY straight to the goo).
+    /// </summary>
+    public override async Task<InteractionResult?> RespondToSimpleInteraction(SimpleIntent action,
+        IContext context, IGenerationClient client, IItemProcessorFactory itemProcessorFactory)
+    {
+        if (action.MatchNounAndAdjective(NounsForMatching) &&
+            action.MatchVerb(["empty", "dump", "pour out", "tip out"]))
+            return new PositiveInteractionResult(
+                "You tip the kit up. The goo stays exactly where it is, and the Thermos rolls back " +
+                "into the corner. You'll have to eat the goo right out of the kit. ");
+
+        return await base.RespondToSimpleInteraction(action, context, client, itemProcessorFactory);
     }
 
     public override void Init()

--- a/UnitTests/IntentMappings/stationfall-mappings.json
+++ b/UnitTests/IntentMappings/stationfall-mappings.json
@@ -40,6 +40,8 @@
     { "inputs": ["examine blue soup"], "verb": "examine", "noun": "blue soup" },
     { "inputs": ["take gray goo", "take the gray goo"], "verb": "take", "noun": "gray goo" },
     { "inputs": ["drop gray goo"], "verb": "drop", "noun": "gray goo" },
+    { "inputs": ["eat gray goo", "eat the gray goo"], "verb": "eat", "noun": "gray goo" },
+    { "inputs": ["remove gray goo"], "verb": "remove", "noun": "gray goo" },
     { "inputs": ["pick floyd", "choose floyd"], "verb": "pick", "noun": "floyd" },
     { "inputs": ["pick rex", "choose rex"], "verb": "pick", "noun": "rex" },
     { "inputs": ["examine floyd", "look at floyd"], "verb": "examine", "noun": "floyd" },

--- a/UnitTests/TestParser.cs
+++ b/UnitTests/TestParser.cs
@@ -28,7 +28,10 @@ public class TestParser : IntentParser
             "drink", "use", "count", "touch", "read", "turn", "wave", "move", "ring", "activate", "search",
             "smell", "turn on", "turn off", "throw", "light", "rub", "kiss", "wind", "kick", "deflate",
             "lower", "raise", "get", "carry", "inflate", "leave", "unlock", "lock", "climb", "extend", "lift", "shake",
-            "oil", "lubricate", "cross", "through", "go", "break", "smash", "squeeze", "attack", "kill", "salute"
+            "oil", "lubricate", "cross", "through", "go", "break", "smash", "squeeze", "attack", "kill", "salute",
+            // Ordinary verbs the originals answer for that this parser could not see at all, so any
+            // object handling them looked unimplemented under test while working in play.
+            "pour", "crumple", "taste", "destroy"
         ];
 
         _allNouns = Repository.GetNouns(gameName);


### PR DESCRIPTION
## Heads up before you read the diff

The repo owner has never played Stationfall and is building this port in order to play it. **This PR body is spoiler-free; the diff is not.** See [`Docs/Stationfall-Port-Plan.md`](Docs/Stationfall-Port-Plan.md) for spoiler-free status.

## What this does

Acts on the verb sweep from #575, which measured **22 of 54** authored object/verb pairs falling through to the narrator. It is now **zero**, and gated.

Every verb the originals' action routines author an answer for, across the objects reachable in the opening, is answered here: destroying any of the forms or the pallets, counting the pallets, working the uniform's pocket, opening/closing/searching the truck from outside, and the whole of the food and drink.

## Two were real bugs, not absences

**The truck's open/close was broken.** It forwarded the player's intent to the hatch — but that intent names *the truck*, which the hatch does not answer to, so it fell straight through to the narrator. It now acts on the hatch directly.

**The goo could not be eaten out of the kit** unless the kit was in your hands. The original gates on the goo being *in* the kit, not on the player holding it — and since eating it where it sits is the only thing that works, that made the one available action impossible.

## Twelve of the twenty-two were never game defects

Four verbs the originals answer for — `pour`, `crumple`, `taste`, `destroy` — were absent from the deterministic test parser's vocabulary, and two goo phrasings had no mapping. The game never saw any of them. The sweep reported them as missing content, convincingly.

Adding them to the harness moved the number without touching the game.

**This keeps happening, and it is the thing to remember about this tooling: a measurement reports its own defects as defects in the thing being measured.** Each of these was caught only by checking whether the verb could reach the game *before* writing code to handle it. The same trap produced a false 40 in #575, and a false 53 before that.

## Gate

`EveryVerbTheOriginalAnswersFor_IsAnsweredHere` joins the noun gate. A new object that declares verbs it does not handle now fails the build, so content and its coverage land together.

## Tests

| Suite | Result |
|---|---|
| Stationfall | 133 |
| Planetfall | 4031 |
| UnitTests | 1350 |
| ZorkOne | 1782 |
| EscapeRoom | 9 |
| Console | 26 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)