### PR TITLE
Fix #549: Floyd never returns (or leaves) in silence again

### DIFF
--- a/Planetfall.Tests/FloydTests.cs
+++ b/Planetfall.Tests/FloydTests.cs
@@ -1303,6 +1303,169 @@ public class FloydTests : EngineTestsBase
         mockClient.Verify(x => x.GenerateCompanionSpeech(It.IsAny<CompanionRequest>()), Times.Once);
     }
 
+    // Issue #549: Floyd's return is committed (placed back in the room, IsOffWandering cleared) BEFORE
+    // the return line is generated. When that generation call fails or comes back empty, the player is
+    // left with no way to know their companion is back - he silently rematerializes, and a player who
+    // keeps waiting has no idea he is already standing beside them. A companion's comings and goings
+    // are load-bearing state changes, so the announcement must never depend on a live LLM call, the
+    // same way Floyd.OnBeingTalkedTo already falls back to a canned line when the chat service fails.
+    [Test]
+    public async Task FloydWanders_Returns_WithCannedMessage_WhenGenerationThrows()
+    {
+        var target = GetTarget();
+        StartHere<RobotShop>();
+        var floyd = GetItem<Floyd>();
+        floyd.IsOn = true;
+        floyd.HasEverBeenOn = true;
+        floyd.TurnOnCountdown = 0;
+        floyd.IsOffWandering = true;
+        floyd.WanderingTurnsRemaining = 1;
+        floyd.CurrentLocation = null; // Floyd is wandering, not in any location
+        target.Context.RegisterActor(floyd);
+
+        var mockChooser = new Mock<IRandomChooser>();
+        mockChooser.Setup(r => r.Choose(It.IsAny<List<string>>()))
+            .Returns(FloydConstants.ReturnMessages[0]);
+        floyd.Chooser = mockChooser.Object;
+
+        // The generation path really does fail in production - a proxy 502 was recorded in the
+        // session that produced this bug report.
+        var mockClient = Mock.Get(target.GenerationClient);
+        mockClient.Setup(x => x.GenerateCompanionSpeech(It.IsAny<CompanionRequest>()))
+            .ThrowsAsync(new HttpRequestException("502 Bad Gateway"));
+
+        var response = await target.GetResponse("wait");
+
+        response.Should().Contain(FloydConstants.ReturnMessages[0].Trim());
+        floyd.IsOffWandering.Should().BeFalse();
+        floyd.WanderingTurnsRemaining.Should().Be(0);
+        floyd.CurrentLocation.Should().Be(GetLocation<RobotShop>());
+    }
+
+    [Test]
+    public async Task FloydWanders_Returns_WithCannedMessage_WhenGenerationIsEmpty()
+    {
+        var target = GetTarget();
+        StartHere<RobotShop>();
+        var floyd = GetItem<Floyd>();
+        floyd.IsOn = true;
+        floyd.HasEverBeenOn = true;
+        floyd.TurnOnCountdown = 0;
+        floyd.IsOffWandering = true;
+        floyd.WanderingTurnsRemaining = 1;
+        floyd.CurrentLocation = null;
+        target.Context.RegisterActor(floyd);
+
+        var mockChooser = new Mock<IRandomChooser>();
+        mockChooser.Setup(r => r.Choose(It.IsAny<List<string>>()))
+            .Returns(FloydConstants.ReturnMessages[0]);
+        floyd.Chooser = mockChooser.Object;
+
+        var mockClient = Mock.Get(target.GenerationClient);
+        mockClient.Setup(x => x.GenerateCompanionSpeech(It.IsAny<CompanionRequest>()))
+            .ReturnsAsync(string.Empty);
+
+        var response = await target.GetResponse("wait");
+
+        response.Should().Contain(FloydConstants.ReturnMessages[0].Trim());
+        floyd.IsOffWandering.Should().BeFalse();
+        floyd.CurrentLocation.Should().Be(GetLocation<RobotShop>());
+    }
+
+    // The departure path (issue #549) has exactly the same shape: Floyd is pulled out of the room
+    // before his goodbye is generated, so a failed call would have him vanish without a word.
+    [Test]
+    public async Task FloydWanders_Leaves_WithCannedMessage_WhenGenerationThrows()
+    {
+        var target = GetTarget();
+        var robotShop = StartHere<RobotShop>();
+        var floyd = GetItem<Floyd>();
+        floyd.IsOn = true;
+        floyd.HasEverBeenOn = true;
+        floyd.TurnOnCountdown = 0;
+        floyd.CurrentLocation = robotShop;
+        robotShop.ItemPlacedHere(floyd);
+        target.Context.RegisterActor(floyd);
+
+        var mockChooser = new Mock<IRandomChooser>();
+        mockChooser.Setup(r => r.RollDiceSuccess(20)).Returns(true); // Trigger wandering
+        mockChooser.Setup(r => r.RollDice(5)).Returns(3);
+        floyd.Chooser = mockChooser.Object;
+
+        var mockClient = Mock.Get(target.GenerationClient);
+        mockClient.Setup(x => x.GenerateCompanionSpeech(It.IsAny<CompanionRequest>()))
+            .ThrowsAsync(new HttpRequestException("502 Bad Gateway"));
+
+        var response = await target.GetResponse("wait");
+
+        response.Should().Contain(FloydConstants.GoingExploring);
+        floyd.IsOffWandering.Should().BeTrue();
+        floyd.WanderingTurnsRemaining.Should().Be(3);
+        GetLocation<RobotShop>().Items.Should().NotContain(floyd);
+    }
+
+    [Test]
+    public async Task FloydWanders_Leaves_WithCannedMessage_WhenGenerationIsEmpty()
+    {
+        var target = GetTarget();
+        var robotShop = StartHere<RobotShop>();
+        var floyd = GetItem<Floyd>();
+        floyd.IsOn = true;
+        floyd.HasEverBeenOn = true;
+        floyd.TurnOnCountdown = 0;
+        floyd.CurrentLocation = robotShop;
+        robotShop.ItemPlacedHere(floyd);
+        target.Context.RegisterActor(floyd);
+
+        var mockChooser = new Mock<IRandomChooser>();
+        mockChooser.Setup(r => r.RollDiceSuccess(20)).Returns(true);
+        mockChooser.Setup(r => r.RollDice(5)).Returns(3);
+        floyd.Chooser = mockChooser.Object;
+
+        var mockClient = Mock.Get(target.GenerationClient);
+        mockClient.Setup(x => x.GenerateCompanionSpeech(It.IsAny<CompanionRequest>()))
+            .ReturnsAsync("   ");
+
+        var response = await target.GetResponse("wait");
+
+        response.Should().Contain(FloydConstants.GoingExploring);
+        floyd.IsOffWandering.Should().BeTrue();
+        GetLocation<RobotShop>().Items.Should().NotContain(floyd);
+    }
+
+    // Third member of the same family (issue #549): when Floyd follows the player into a special
+    // interaction location, "Floyd follows you." is concatenated with a generated comment about the
+    // room. A failing generation call took the whole follow announcement down with it - and burned
+    // the location's one-shot InteractionHasHappened flag on the way, so the beat was lost forever.
+    [Test]
+    public async Task FloydFollows_StillAnnouncesFollow_WhenSpecialLocationCommentGenerationThrows()
+    {
+        var target = GetTarget();
+        var corridor = StartHere<MechCorridor>();
+        var floyd = GetItem<Floyd>();
+        floyd.IsOn = true;
+        floyd.HasEverBeenOn = true;
+        floyd.TurnOnCountdown = 0;
+        floyd.CurrentLocation = corridor;
+        corridor.ItemPlacedHere(floyd);
+        target.Context.RegisterActor(floyd);
+
+        var mockChooser = new Mock<IRandomChooser>();
+        mockChooser.Setup(r => r.RollDice(5)).Returns(2); // Not 1, so Floyd follows normally
+        floyd.Chooser = mockChooser.Object;
+
+        var mockClient = Mock.Get(target.GenerationClient);
+        mockClient.Setup(x => x.GenerateCompanionSpeech(It.IsAny<CompanionRequest>()))
+            .ThrowsAsync(new HttpRequestException("502 Bad Gateway"));
+
+        var response = await target.GetResponse("west");
+
+        response.Should().Contain("Floyd follows you");
+        floyd.CurrentLocation.Should().Be(GetLocation<Planetfall.Location.Kalamontee.Mech.PhysicalPlant>());
+        // The one-shot beat was never delivered, so it must not be marked as spent.
+        GetLocation<Planetfall.Location.Kalamontee.Mech.PhysicalPlant>().InteractionHasHappened.Should().BeFalse();
+    }
+
     [Test]
     public async Task FloydWanders_CountsDown_OverMultipleTurns()
     {

--- a/Planetfall/Item/Kalamontee/Mech/FloydPart/FloydMovementManager.cs
+++ b/Planetfall/Item/Kalamontee/Mech/FloydPart/FloydMovementManager.cs
@@ -75,9 +75,19 @@ public class FloydMovementManager(Floyd floyd)
         if (specialLocation.InteractionHasHappened)
             return string.Empty;
 
+        // This one is an embellishment on "Floyd follows you. ", so it has no canned stand-in - it
+        // just drops. What it must never do is take the follow announcement down with it (issue #549),
+        // nor burn the location's one-shot flag on a beat the player never saw: the flag is spent only
+        // once a line actually exists, so a failed call leaves the moment available to fire later.
+        var comment = await GenerateOrFallBack(
+            () => floyd.GenerateCompanionSpeech(context, client, specialLocation.FloydPrompt),
+            () => string.Empty);
+
+        if (string.IsNullOrWhiteSpace(comment))
+            return string.Empty;
+
         specialLocation.InteractionHasHappened = true;
-        return Environment.NewLine + Environment.NewLine +
-               await floyd.GenerateCompanionSpeech(context, client, specialLocation.FloydPrompt);
+        return Environment.NewLine + Environment.NewLine + comment;
     }
 
     /// <summary>
@@ -123,11 +133,46 @@ public class FloydMovementManager(Floyd floyd)
 
     private async Task<string> GenerateDepartureMessage(IContext context, IGenerationClient client)
     {
-        return await floyd.GenerateCompanionSpeech(context, client, FloydPrompts.LeavingToExplore);
+        return await GenerateOrFallBack(
+            () => floyd.GenerateCompanionSpeech(context, client, FloydPrompts.LeavingToExplore),
+            () => FloydConstants.GoingExploring);
     }
 
     private async Task<string> GenerateReturnMessage(IContext context, IGenerationClient client)
     {
-        return await floyd.GenerateCompanionSpeech(context, client, FloydPrompts.ReturningFromExploring);
+        return await GenerateOrFallBack(
+            () => floyd.GenerateCompanionSpeech(context, client, FloydPrompts.ReturningFromExploring),
+            () => floyd.Chooser.Choose(FloydConstants.ReturnMessages.ToList()));
+    }
+
+    /// <summary>
+    /// Runs a generated line, falling back to a canned one if the generation throws or comes back
+    /// empty.
+    /// </summary>
+    /// <remarks>
+    /// Every one of Floyd's comings and goings commits its state change - him being placed back in
+    /// the room, or pulled out of it - BEFORE the line announcing it is generated. So when the
+    /// generation call failed, the move still happened and the player was never told: Floyd simply
+    /// rematerialized beside a player who sat through ten more "wait" turns believing he was still
+    /// gone (issue #549). A thrown call was worse still, since the engine's top-level guard replaced
+    /// the entire turn's output with its generic "something goes wrong" line.
+    /// <para>
+    /// A companion's movements are load-bearing state changes, so the announcement must never depend
+    /// on a live LLM call succeeding - the same reasoning behind the canned fallback in
+    /// <see cref="Floyd.OnBeingTalkedTo" />. The fallback is lazy so the chooser is only consulted on
+    /// the path that actually needs it.
+    /// </para>
+    /// </remarks>
+    private static async Task<string> GenerateOrFallBack(Func<Task<string>> generate, Func<string> fallback)
+    {
+        try
+        {
+            var message = await generate();
+            return string.IsNullOrWhiteSpace(message) ? fallback() : message;
+        }
+        catch (Exception)
+        {
+            return fallback();
+        }
     }
 }


### PR DESCRIPTION
Fixes #549.

## The bug

Floyd's comings and goings commit their state change — him being placed back in the room, or pulled out of it — **before** the line announcing it is generated. When that generation call failed, the move still happened and the player was never told.

`FloydMovementManager.HandleWanderingCountdown` is the reported case: Floyd is placed back in the room and `IsOffWandering` is cleared, *then* the LLM is asked for a return line, with no try/catch and no fallback.

## What the failing tests found

Both failure modes reproduce deterministically (real `Repository`, mocked `IRandomChooser`, mocked `IGenerationClient`). The second turned out to be worse than the report guessed:

| Generation fails by… | What the player saw before this PR |
| --- | --- |
| returning empty | `Time passes...` and nothing else — exactly the reported silent rematerialization |
| throwing (a proxy 502 was recorded in the same prod session) | the exception escapes `Act()` and the engine's top-level guard replaces the **whole turn's** output with *"Something goes wrong, and for a moment the world seems to flicker."* |

In both cases Floyd is in fact back: `look` lists the robot, `god mode where floyd` reports the player's own room, and he answers conversation normally.

## The fix

A single `GenerateOrFallBack` helper wraps each generated movement line: if the call throws *or* comes back empty, a canned line stands in — the same treatment `Floyd.OnBeingTalkedTo` already gives chat.

The fallbacks are constants this file had been carrying **unused** all along, so the register is already the game's own:

- return → `FloydConstants.ReturnMessages` ("Floyd bounds into the room. \"Floyd here now!\" he cries.", and two siblings), picked through the injected `IRandomChooser` so it stays deterministic under test
- departure → `FloydConstants.GoingExploring`

The fallback is passed lazily, so the chooser is only consulted on the path that actually needs it.

### Scope beyond the reported path

The issue names the departure path (`GenerateDepartureMessage`) as having the same shape — it does, and it gets the same guard.

I also included the third member of the family, since the issue's own principle covers it ("a companion's comings and goings … the announcement should never depend on a live LLM call succeeding"): the special-location comment Floyd adds when he follows the player into a room like the Physical Plant. A failure there took the entire `"Floyd follows you. "` announcement down with it — and burned the location's one-shot `InteractionHasHappened` flag on a beat the player never saw. That flag is now spent only once a line actually exists, so a failed call leaves the moment available to fire later. This comment is an embellishment rather than an announcement in its own right, so it has no canned stand-in; it just drops quietly.

## Tests (TDD — red first)

Five new tests in `Planetfall.Tests/FloydTests.cs`, in the existing Wandering Behavior region. All five failed on the assertion diff before the fix, with the two distinct symptoms above:

- `FloydWanders_Returns_WithCannedMessage_WhenGenerationThrows`
- `FloydWanders_Returns_WithCannedMessage_WhenGenerationIsEmpty`
- `FloydWanders_Leaves_WithCannedMessage_WhenGenerationThrows`
- `FloydWanders_Leaves_WithCannedMessage_WhenGenerationIsEmpty`
- `FloydFollows_StillAnnouncesFollow_WhenSpecialLocationCommentGenerationThrows`

Each asserts both halves: the state change landed (Floyd is back in / gone from the room) **and** the player was told about it.

All suites green, no regressions: Planetfall 4036, UnitTests 1350, ZorkOne 1782, Stationfall 131, Console 26, EscapeRoom 9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PyX1bi2WpVvyKe8cCxi3cz

---
_Generated by [Claude Code](https://claude.ai/code/session_01PyX1bi2WpVvyKe8cCxi3cz)_