### PR TITLE
Fix #521: let Floyd hand back and drop what he is holding

### DIFF
--- a/Model/Verbs.cs
+++ b/Model/Verbs.cs
@@ -49,6 +49,16 @@ public static class Verbs
         ["give", "offer", "transfer", "present", "provide", "hand", "donate", "deliver", "pass", "feed"];
 
     /// <summary>
+    ///     The "ask someone for something" family. The original's grammar is
+    ///     <c>TELL &lt;actor&gt; FOR &lt;object&gt;</c> with <c>SYNONYM TELL ASK</c>
+    ///     (Planetfall syntax.zil:341-342), which routes to <c>V-ASK-FOR</c> - so both words are the
+    ///     original's, and "request" is the modern synonym a player is just as likely to type.
+    ///     Always pair this with the "for" preposition: "ask floyd ABOUT mudge" is conversation, not a
+    ///     request to be handed something.
+    /// </summary>
+    public static readonly string[] AskForVerbs = ["ask", "tell", "request"];
+
+    /// <summary>
     ///     The "show it to someone" family. Distinct from <see cref="GiveVerbs" /> — showing keeps the
     ///     object in your hand (the ZIL syntax is <c>SHOW OBJECT (HAVE) TO OBJECT</c>), whereas giving
     ///     transfers it. Deliberately excludes "present" (a give synonym) so the two verbs don't collide.

--- a/Planetfall.Tests/FloydTests.cs
+++ b/Planetfall.Tests/FloydTests.cs
@@ -3029,4 +3029,277 @@ public class FloydTests : EngineTestsBase
     }
 
     #endregion
+
+    #region Handing Back And Dropping What Floyd Holds (issue #521)
+
+    /// <summary>
+    /// Floyd holding the diary, with his chat backend stubbed to a sentinel no test should ever see.
+    /// Asking him for something he holds is a real mechanic in the original, so these requests must
+    /// never reach the conversation service - which is instructed to decline them in character and so
+    /// answers with a refusal the direct "take diary" command immediately contradicts (issue #521).
+    /// </summary>
+    private Mock<IChatWithFloyd> FloydHoldingTheDiary()
+    {
+        var floyd = GetItem<Floyd>();
+        floyd.IsOn = true;
+        floyd.HasEverBeenOn = true;
+
+        var chat = new Mock<IChatWithFloyd>();
+        chat.Setup(s => s.AskFloydAsync(It.IsAny<string>()))
+            .ReturnsAsync(new CompanionResponse("CHAT-SHOULD-NOT-HAPPEN", null));
+        floyd.ChatWithFloyd = chat.Object;
+
+        return chat;
+    }
+
+    [TestCase("floyd, give me the diary")]
+    [TestCase("floyd, give the diary to me")]
+    [TestCase("floyd, hand me the diary")]
+    [TestCase("floyd, give it back")]
+    [TestCase("floyd, can i have the diary")]
+    [TestCase("floyd, give me the diary, please")]
+    public async Task AskFloydForWhatHeHolds_HandsItOver(string request)
+    {
+        var target = GetTarget();
+        StartHere<RobotShop>();
+        Take<Diary>();
+        var chat = FloydHoldingTheDiary();
+        await target.GetResponse("give the diary to floyd");
+
+        var response = await target.GetResponse(request);
+
+        response.Should().Contain("handing you the diary");
+        response.Should().NotContain("CHAT-SHOULD-NOT-HAPPEN");
+        target.Context.HasItem<Diary>().Should().BeTrue();
+        GetItem<Floyd>().ItemBeingHeld.Should().BeNull();
+        chat.Verify(s => s.AskFloydAsync(It.IsAny<string>()), Times.Never);
+    }
+
+    [TestCase("floyd, drop the diary")]
+    [TestCase("floyd, put down the diary")]
+    [TestCase("floyd, drop it")]
+    public async Task TellFloydToDropWhatHeHolds_HeDropsIt(string request)
+    {
+        var target = GetTarget();
+        StartHere<RobotShop>();
+        Take<Diary>();
+        var chat = FloydHoldingTheDiary();
+        await target.GetResponse("give the diary to floyd");
+
+        var response = await target.GetResponse(request);
+
+        response.Should().Contain("shrugs and drops the diary");
+        response.Should().NotContain("CHAT-SHOULD-NOT-HAPPEN");
+        target.Context.HasItem<Diary>().Should().BeFalse();
+        GetItem<Floyd>().ItemBeingHeld.Should().BeNull();
+        GetItem<Diary>().CurrentLocation.Should().Be(GetLocation<RobotShop>());
+        chat.Verify(s => s.AskFloydAsync(It.IsAny<string>()), Times.Never);
+    }
+
+    /// <summary>
+    /// The original answers a request for something Floyd hasn't got with FLOYD-NOT-HAVE
+    /// (compone.zil:2059-2060, 1922-1923), not with an improvised decline.
+    /// </summary>
+    [Test]
+    public async Task AskFloydForSomethingHeDoesNotHold_HeSaysHeDoesNotHaveIt()
+    {
+        var target = GetTarget();
+        StartHere<RobotShop>();
+        Take<Diary>();
+        FloydHoldingTheDiary();
+
+        var response = await target.GetResponse("floyd, give me the diary");
+
+        response.Should().Contain("Floyd does not one of those have!");
+        target.Context.HasItem<Diary>().Should().BeTrue();
+    }
+
+    /// <summary>
+    /// Only what is in Floyd's HAND is his to hand over. The lower elevator access card sits in his
+    /// compartments until he reveals it (or the player searches the switched-off robot); in the
+    /// original it is not inside him at all until then - FLOYD-REVEAL-CARD-F moves it to him when the
+    /// daemon fires (globals.zil:1459) - so ASK-FOR could never produce it early. Reaching into his
+    /// compartments here would skip that puzzle entirely.
+    /// </summary>
+    [Test]
+    public async Task AskFloydForTheCardBeforeHeRevealsIt_DoesNotHandItOver()
+    {
+        var target = GetTarget();
+        StartHere<RobotShop>();
+        FloydHoldingTheDiary();
+
+        var response = await target.GetResponse("floyd, give me the lower elevator card");
+
+        target.Context.HasItem<LowerElevatorAccessCard>().Should().BeFalse();
+        response.Should().NotContain("handing you");
+    }
+
+    /// <summary>
+    /// The original's give branch requires the recipient to be the player
+    /// (&lt;EQUAL? ,PRSI ,ME&gt;, compone.zil:1855-1859). Handing his toy to a third party is not that
+    /// mechanic, so it stays Floyd's own business - and his conversational voice.
+    /// </summary>
+    [Test]
+    public async Task TellFloydToGiveWhatHeHoldsToSomeoneElse_StaysConversational()
+    {
+        var target = GetTarget();
+        StartHere<RobotShop>();
+        Take<Diary>();
+        var chat = FloydHoldingTheDiary();
+        chat.Setup(s => s.AskFloydAsync(It.IsAny<string>()))
+            .ReturnsAsync(new CompanionResponse("Floyd hugs the diary.", null));
+        await target.GetResponse("give the diary to floyd");
+
+        var response = await target.GetResponse("floyd, give the diary to the ambassador");
+
+        response.Should().Contain("Floyd hugs the diary");
+        GetItem<Floyd>().ItemBeingHeld.Should().Be(GetItem<Diary>());
+    }
+
+    /// <summary>
+    /// A request that names nothing Floyd could be holding is not this mechanic. It must keep reaching
+    /// the conversation service, or the bridge would eat Floyd's jokes.
+    /// </summary>
+    [Test]
+    public async Task AskFloydForSomethingThatIsNotAnObject_StaysConversational()
+    {
+        var target = GetTarget();
+        StartHere<RobotShop>();
+        Take<Diary>();
+        var chat = FloydHoldingTheDiary();
+        chat.Setup(s => s.AskFloydAsync(It.IsAny<string>()))
+            .ReturnsAsync(new CompanionResponse("Floyd gives you an enormous hug.", null));
+        await target.GetResponse("give the diary to floyd");
+
+        var response = await target.GetResponse("floyd, give me a hug");
+
+        response.Should().Contain("enormous hug");
+        GetItem<Floyd>().ItemBeingHeld.Should().Be(GetItem<Diary>());
+    }
+
+    /// <summary>
+    /// The original's own grammar for this is TELL/ASK &lt;actor&gt; FOR &lt;object&gt;
+    /// (syntax.zil:341-342 - V-ASK-FOR), which reaches Floyd as an ordinary multi-noun command rather
+    /// than as speech, so it needs the same bridge on that side too.
+    /// </summary>
+    [Test]
+    public async Task AskFloydForTheDiaryAsACommand_HandsItOver()
+    {
+        var target = GetTarget();
+        StartHere<RobotShop>();
+        Take<Diary>();
+        FloydHoldingTheDiary();
+        await target.GetResponse("give the diary to floyd");
+
+        var response = await target.GetResponse("ask floyd for the diary");
+
+        response.Should().Contain("handing you the diary");
+        target.Context.HasItem<Diary>().Should().BeTrue();
+        GetItem<Floyd>().ItemBeingHeld.Should().BeNull();
+    }
+
+    /// <summary>
+    /// "it"/"that" point at the thing in his hand only when they are the OBJECT of the request. The same
+    /// words in front of a real noun are determiners, and "give me that joke" asks for a joke - handing
+    /// over the diary there would be a worse bug than the one #521 reports.
+    /// </summary>
+    [TestCase("floyd, give it to me", true)]
+    [TestCase("floyd, drop it now", true)]
+    [TestCase("floyd, give me that joke", false)]
+    [TestCase("floyd, tell me this story", false)]
+    public async Task APronounOnlyMeansTheHeldItemWhenItIsTheObject(string request, bool handsItOver)
+    {
+        var target = GetTarget();
+        StartHere<RobotShop>();
+        Take<Diary>();
+        var chat = FloydHoldingTheDiary();
+        chat.Setup(s => s.AskFloydAsync(It.IsAny<string>()))
+            .ReturnsAsync(new CompanionResponse("Floyd tells a joke about a squeaky wheel.", null));
+        await target.GetResponse("give the diary to floyd");
+
+        var response = await target.GetResponse(request);
+
+        if (handsItOver)
+        {
+            GetItem<Floyd>().ItemBeingHeld.Should().BeNull();
+            response.Should().NotContain("squeaky wheel");
+        }
+        else
+        {
+            GetItem<Floyd>().ItemBeingHeld.Should().Be(GetItem<Diary>());
+            response.Should().Contain("squeaky wheel");
+        }
+    }
+
+    /// <summary>
+    /// The command form answers for a real object he hasn't got with the original's flat refusal, but a
+    /// noun that is no object at all ("ask floyd for help") is not this mechanic - it must reach the
+    /// engine's ordinary handling of an unresolvable noun instead of a canned denial about a non-thing.
+    /// </summary>
+    [Test]
+    public async Task AskFloydForARealThingHeDoesNotHold_RefusesButForANonObject_FallsThrough()
+    {
+        var target = GetTarget();
+        StartHere<RobotShop>();
+        Take<Diary>();
+        FloydHoldingTheDiary();
+
+        var refusal = await target.GetResponse("ask floyd for the diary");
+        refusal.Should().Contain("Floyd does not one of those have!");
+
+        var fallThrough = await target.GetResponse("ask floyd for help");
+        fallThrough.Should().NotContain("Floyd does not one of those have!");
+    }
+
+    /// <summary>
+    /// A forbidding request is the opposite of an action. The companion service's own prompt is careful
+    /// about this ("don't go north" is never movement); a deterministic bridge has to be just as
+    /// careful, or telling Floyd to hang on to something would make him put it down.
+    /// </summary>
+    [TestCase("floyd, don't drop the diary")]
+    [TestCase("floyd, never give me the diary")]
+    public async Task ForbiddingFloydToDropOrHandOver_DoesNeitherAndStaysConversational(string request)
+    {
+        var target = GetTarget();
+        StartHere<RobotShop>();
+        Take<Diary>();
+        var chat = FloydHoldingTheDiary();
+        chat.Setup(s => s.AskFloydAsync(It.IsAny<string>()))
+            .ReturnsAsync(new CompanionResponse("Floyd holds the diary tighter and nods seriously.", null));
+        await target.GetResponse("give the diary to floyd");
+
+        var response = await target.GetResponse(request);
+
+        response.Should().Contain("holds the diary tighter");
+        GetItem<Floyd>().ItemBeingHeld.Should().Be(GetItem<Diary>());
+        target.Context.HasItem<Diary>().Should().BeFalse();
+    }
+
+    /// <summary>
+    /// Floyd dropping an item must not leave the take-callback stamped on it. That callback nulls
+    /// ItemBeingHeld whoever takes the item and whenever - so a brush left carrying it, picked up off
+    /// the floor later while Floyd holds something else, would silently strip Floyd of THAT item and
+    /// orphan it (CurrentLocation still Floyd, in neither his Items nor his hand: out of scope for
+    /// good).
+    /// </summary>
+    [Test]
+    public async Task AfterFloydDropsIt_TakingItLaterDoesNotStripHimOfSomethingElse()
+    {
+        var target = GetTarget();
+        StartHere<RobotShop>();
+        Take<Diary>();
+        Take<Brush>();
+        FloydHoldingTheDiary();
+        await target.GetResponse("give the diary to floyd");
+        await target.GetResponse("floyd, drop the diary");
+
+        // He is now holding the brush instead; picking the dropped diary back up must not disturb it.
+        await target.GetResponse("give the brush to floyd");
+        await target.GetResponse("take diary");
+
+        GetItem<Floyd>().ItemBeingHeld.Should().Be(GetItem<Brush>());
+    }
+
+    #endregion
+
 }

--- a/Planetfall.Tests/LiveParserShapeTests.cs
+++ b/Planetfall.Tests/LiveParserShapeTests.cs
@@ -4,12 +4,15 @@ using Model.Interface;
 using Moq;
 using OpenAI.Chat;
 using Planetfall.GlobalCommand;
+using Planetfall.Item.Feinstein;
 using Planetfall.Item.Kalamontee;
 using Planetfall.Item.Kalamontee.Admin;
 using Planetfall.Item.Kalamontee.Mech;
+using Planetfall.Item.Kalamontee.Mech.FloydPart;
 using Planetfall.Item.Lawanda;
 using Planetfall.Location.Computer;
 using Planetfall.Location.Kalamontee;
+using Planetfall.Location.Kalamontee.Mech;
 using Planetfall.Location.Lawanda;
 using ZorkAI.OpenAI;
 
@@ -401,5 +404,39 @@ public class LiveParserShapeTests : EngineTestsBase
         response.Should().Contain("The warning lights go out");
         GetItem<LargeMetalCube>().HasItem<GoodBedistor>().Should().BeTrue();
         GetLocation<CourseControl>().Fixed.Should().BeTrue();
+    }
+
+    /// <summary>
+    ///     Issue #521. "ask floyd for the diary" is the original's own grammar for being handed
+    ///     something back (<c>TELL/ASK &lt;actor&gt; FOR &lt;object&gt;</c> -> <c>V-ASK-FOR</c>,
+    ///     planetfall-source/syntax.zil:341-342). It is the one phrasing of this mechanic that does NOT
+    ///     reach Floyd as speech - it leads with the verb rather than his name, so direct-address
+    ///     detection never fires - which makes the real parser's shape for it load-bearing rather than
+    ///     incidental. <c>base-mappings.json</c> stubs the same command for the handler tests; this pins
+    ///     the parser that has to produce it in production.
+    /// </summary>
+    [Test]
+    public async Task AskFloydForTheDiary_WithTheRealParser_StillGetsItBack()
+    {
+        var target = GetTarget(ParserReturning("""
+                                               <intent>act</intent>
+                                               <verb>ask</verb>
+                                               <noun>floyd</noun>
+                                               <noun>diary</noun>
+                                               <preposition>for</preposition>
+                                               """));
+        StartHere<RobotShop>();
+        var floyd = GetItem<Floyd>();
+        floyd.IsOn = true;
+        floyd.HasEverBeenOn = true;
+        floyd.ItemBeingHeld = Take<Diary>();
+        Context.RemoveItem(GetItem<Diary>());
+        GetItem<Diary>().CurrentLocation = floyd;
+
+        var response = await target.GetResponse("ask floyd for the diary");
+
+        response.Should().Contain("handing you the diary");
+        Context.HasItem<Diary>().Should().BeTrue();
+        floyd.ItemBeingHeld.Should().BeNull();
     }
 }

--- a/Planetfall/Item/Kalamontee/Mech/FloydPart/Floyd.cs
+++ b/Planetfall/Item/Kalamontee/Mech/FloydPart/Floyd.cs
@@ -18,6 +18,7 @@ public class Floyd : QuirkyCompanion, IAmANamedPerson, ICanHoldItems, ICanBeGive
     private readonly FloydInventoryManager _inventoryManager;
     private readonly FloydSocialResponses _socialResponses;
     private readonly FloydMovementManager _movementManager;
+    private readonly FloydItemRequests _itemRequests;
 
     public Floyd()
     {
@@ -26,6 +27,7 @@ public class Floyd : QuirkyCompanion, IAmANamedPerson, ICanHoldItems, ICanBeGive
         _inventoryManager = new FloydInventoryManager(this);
         _socialResponses = new FloydSocialResponses(this);
         _movementManager = new FloydMovementManager(this);
+        _itemRequests = new FloydItemRequests(this);
     }
 
     // This is the thing that he is holding, literally in his hand. 
@@ -239,6 +241,15 @@ public class Floyd : QuirkyCompanion, IAmANamedPerson, ICanHoldItems, ICanBeGive
         if (!IsOn)
             return "The robot doesn't respond - it appears to be turned off.";
 
+        // Asking him to hand back or put down the thing in his hand is a real mechanic in the original,
+        // not conversation (compone.zil:2053-2060 and 1912-1923). Bridged BEFORE the chat service, which
+        // is instructed to decline every physical request in character and so answered these with a
+        // refusal that "take <item>" contradicted on the very next turn (issue #521). Returns null for
+        // everything else, which is almost everything, and that falls through to the service as before.
+        var itemRequest = _itemRequests.HandleSpokenRequest(text, context);
+        if (itemRequest is not null)
+            return itemRequest;
+
         try
         {
             CompanionResponse response = await ChatWithFloyd.AskFloydAsync(text);
@@ -407,6 +418,14 @@ public class Floyd : QuirkyCompanion, IAmANamedPerson, ICanHoldItems, ICanBeGive
             action.MatchPreposition(["with"]) &&
             Repository.GetItemInScope(action.NounTwo, context) is OilCan && context.IsCarrying<OilCan>())
             return new PositiveInteractionResult(FloydConstants.Oil);
+
+        // "ask floyd for the diary" - the original's own grammar for being handed something
+        // (syntax.zil:341-342 -> V-ASK-FOR). It arrives as a command rather than as speech, since it
+        // leads with the verb instead of his name, so the conversational bridge in OnBeingTalkedTo
+        // never sees it (issue #521).
+        var askForResult = _itemRequests.HandleAskFor(action, context);
+        if (askForResult is not null)
+            return askForResult;
 
         // SHOW is handled before GIVE: in the original, "show <x> to floyd" drives several reactions
         // (FLOYD-F SHOW branch, compone.zil:2022-2047) that GIVE does not — the printout/computer-concern

--- a/Planetfall/Item/Kalamontee/Mech/FloydPart/FloydConstants.cs
+++ b/Planetfall/Item/Kalamontee/Mech/FloydPart/FloydConstants.cs
@@ -93,6 +93,22 @@ public static class FloydConstants
         "Floyd giggles and pushes you away. \"You're tickling Floyd!\" He clutches at his " +
         "side panels, laughing hysterically. Oil drops stream from his eyes. ";
 
+    // V-ASK-FOR's success branch (compone.zil:2054-2058). Asking nicely always works - there is no
+    // dice roll on this one, unlike the drop below.
+    internal const string HandsYouTheItem =
+        "\"Okay,\" says Floyd, handing you the {0}, \"but only because you're Floyd's best friend.\" ";
+
+    // V?DROP's success branch (compone.zil:1913-1917). The original rolls PROB 50 and otherwise has
+    // Floyd clutch the thing and refuse; he always complies here (see FloydItemRequests.LetGoOf for
+    // why that divergence is deliberate), so the refusal line has no constant.
+    internal const string ShrugsAndDrops =
+        "Floyd shrugs and drops the {0}. ";
+
+    // FLOYD-NOT-HAVE (compone.zil:2121-2122), the original's answer for asking him to hand over or
+    // drop something he has not got. Verbatim, broken grammar and all - it is one of his.
+    internal const string DoesNotHaveThat =
+        "\"Floyd does not one of those have!\" ";
+
     internal const string ThanksYouForGivingItem =
         "\"Neat!\" exclaims Floyd. He thanks you profusely. ";
 

--- a/Planetfall/Item/Kalamontee/Mech/FloydPart/FloydItemRequests.cs
+++ b/Planetfall/Item/Kalamontee/Mech/FloydPart/FloydItemRequests.cs
@@ -1,0 +1,264 @@
+using System.Text.RegularExpressions;
+using GameEngine;
+
+namespace Planetfall.Item.Kalamontee.Mech.FloydPart;
+
+/// <summary>
+///     Asking Floyd to hand back, or to put down, the thing he is holding. Both are real mechanics in
+///     the original — <c>V?ASK-FOR</c> (<c>compone.zil:2053-2060</c>) and <c>V?DROP</c>
+///     (<c>compone.zil:1912-1923</c>) in the "Floyd is the WINNER" half of <c>FLOYD-F</c> — but the
+///     port only ever routed them to the conversation service, which is instructed to decline every
+///     physical request in character. So Floyd confidently claimed he "cannot drop things" while
+///     <c>take &lt;item&gt;</c> retrieved it from him on the very next turn (issue #521).
+///     <para>
+///     This is a DETERMINISTIC, pre-LLM bridge on purpose. Metadata was the other option, but the
+///     companion Lambda emits no intent for these requests (its prompt classifies give/drop as
+///     "just declines"), and the self-hosted path returns no metadata at all
+///     (<see cref="Planetfall.AI.LocalCompanionChat" />), so a metadata bridge would fix neither
+///     backend today. Matching the player's own words costs no round-trip and works in both.
+///     </para>
+///     <para>
+///     Everything unrecognized returns null and falls through to the conversation service exactly as
+///     before, so this can only ever add behavior. That fall-through is load-bearing, not laziness:
+///     "floyd, give me a hug" must stay a joke, not become a handover.
+///     </para>
+/// </summary>
+public class FloydItemRequests(Floyd floyd)
+{
+    /// <summary>
+    ///     The "hand it over" verbs, with their -ing forms, because a spoken request is free-form prose
+    ///     rather than a parsed verb ("would you mind GIVING me the diary"). Matched as whole words.
+    /// </summary>
+    private static readonly string[] HandBackVerbs =
+        ["give", "giving", "hand", "handing", "pass", "passing", "return", "returning", "gimme"];
+
+    /// <summary>
+    ///     The recipient must be the PLAYER. The original's give branch fires only on
+    ///     <c>&lt;EQUAL? ,PRSI ,ME&gt;</c> (<c>compone.zil:1855-1859</c>), so "floyd, give the diary to
+    ///     the ambassador" is not this mechanic and stays Floyd's own business.
+    /// </summary>
+    private static readonly string[] RecipientIsThePlayer = ["me", "myself", "back"];
+
+    /// <summary>
+    ///     Polite requests that carry no give verb at all. These are the phrasings a player reaches for
+    ///     most often, and the original's own grammar for them is ASK ... FOR (<c>syntax.zil:341-342</c>).
+    /// </summary>
+    private static readonly string[] HandBackIdioms =
+        ["can i have", "could i have", "may i have", "let me have", "hand over", "i want", "i'd like"];
+
+    /// <summary>
+    ///     The "put it down" verbs. "leave" is deliberately absent: "floyd, leave it alone" is a
+    ///     forbidding, not a request to drop (the negation guard below would catch that phrasing, but
+    ///     the verb list should not be reaching for it in the first place).
+    /// </summary>
+    private static readonly string[] DropVerbs =
+        ["drop", "dropping", "put down", "putting down", "set down", "let go of", "release"];
+
+    /// <summary>
+    ///     Words that make the held item the object without naming it ("give it back", "drop that").
+    ///     Only consulted when Floyd actually has something in his hand, which is the only thing they
+    ///     could be pointing at.
+    /// </summary>
+    private static readonly string[] PronounsForTheHeldItem = ["it", "that", "this", "them", "those"];
+
+    /// <summary>
+    ///     Words that may follow the pronoun while it is still the OBJECT of the request ("give it
+    ///     back", "give it to me", "drop it now"). Anything else following one means it was a
+    ///     determiner in front of a real noun instead — "give me that joke", "tell me this story" —
+    ///     which is not a request for the thing in his hand and must keep reaching the chat service.
+    /// </summary>
+    private static readonly string[] PronounTails = ["back", "down", "to", "over", "please", "now", "here"];
+
+    /// <summary>
+    ///     A negated or forbidding request is never an action — "don't drop the diary" is the opposite
+    ///     of a drop. Cheap to check and expensive to get wrong, so it gates both mechanics.
+    /// </summary>
+    private static readonly string[] Negations =
+        ["don't", "do not", "dont", "never", "stop", "please don't", "no need", "instead of"];
+
+    /// <summary>
+    ///     Bridges a spoken request to the mechanic behind it. Returns null — the common case — when the
+    ///     utterance is not a request for the thing in Floyd's hand, leaving it for the conversation
+    ///     service.
+    /// </summary>
+    internal string? HandleSpokenRequest(string text, IContext context)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+            return null;
+
+        // Sentence punctuation becomes whitespace so it cannot weld itself to a word the tests below
+        // are looking for - without this, "give me the diary, please" carries "diary," and matches no
+        // noun at all. Hyphens and apostrophes survive, because item nouns and contractions need them
+        // ("multi-purpose scrub brush", "don't"). Then pad, so every containment test is a whole-word
+        // one: " it " must not fire inside "wait".
+        var said = $" {Regex.Replace(text.ToLowerInvariant(), "[.,!?;:\"]+", " ").Trim()} ";
+        said = Regex.Replace(said, @"\s+", " ");
+
+        if (Negations.Any(n => said.Contains($" {n} ")))
+            return null;
+
+        var wantsItBack = (HandBackVerbs.Any(v => said.Contains($" {v} ")) &&
+                           RecipientIsThePlayer.Any(r => said.Contains($" {r} "))) ||
+                          HandBackIdioms.Any(i => said.Contains($" {i} "));
+
+        var wantsItDropped = DropVerbs.Any(v => said.Contains($" {v} "));
+
+        if (!wantsItBack && !wantsItDropped)
+            return null;
+
+        var requested = ResolveRequestedItem(said, context);
+        if (requested is null)
+            return null;
+
+        return Speak(requested == floyd.ItemBeingHeld
+            ? wantsItBack ? HandOver(requested, context) : LetGoOf(requested, context)
+            : FloydConstants.DoesNotHaveThat, context);
+    }
+
+    /// <summary>
+    ///     The original's own command grammar for this: <c>TELL/ASK &lt;actor&gt; FOR &lt;object&gt;</c>
+    ///     (<c>syntax.zil:341-342</c>, routed to <c>V-ASK-FOR</c>). It reaches Floyd as an ordinary
+    ///     multi-noun command rather than as speech, because the utterance leads with the verb instead
+    ///     of his name and so is never detected as direct address.
+    ///     <para>
+    ///     The player named an object outright here, so a real object Floyd is not holding gets the
+    ///     original's flat <c>FLOYD-NOT-HAVE</c> (<c>compone.zil:2059-2060</c>) instead of the spoken
+    ///     path's silent fall-through. A noun that resolves to no object at all still falls through.
+    ///     </para>
+    /// </summary>
+    internal InteractionResult? HandleAskFor(MultiNounIntent action, IContext context)
+    {
+        if (!action.MatchVerb(Verbs.AskForVerbs) || !action.MatchNounOne(floyd.NounsForMatching) ||
+            !action.MatchPreposition(["for"]))
+            return null;
+
+        var held = floyd.ItemBeingHeld;
+
+        if (held is not null && NounMatch.CouldName(held, action.NounTwo))
+            return new PositiveInteractionResult(Speak(HandOver(held, context), context));
+
+        // Named something real that simply isn't in his hand: the original's flat refusal. A noun we
+        // cannot resolve at all ("ask floyd for help") is not an object and so not this mechanic - fall
+        // through and let the engine answer an unresolvable noun the way it answers any other, rather
+        // than have Floyd deny owning a thing that was never a thing.
+        if (Repository.GetItemInScope(action.NounTwo, context) is not null)
+            return new PositiveInteractionResult(Speak(FloydConstants.DoesNotHaveThat, context));
+
+        return null;
+    }
+
+    /// <summary>
+    ///     Which item is this request about? In order: the thing in Floyd's hand if it is named or
+    ///     pointed at, then anything else in scope the player named (which earns the original's "Floyd
+    ///     does not one of those have!"), and otherwise nothing at all — a request that names no object
+    ///     is not this mechanic.
+    ///     <para>
+    ///     Deliberately confined to <see cref="Model.Interface.ICanHoldItems.ItemBeingHeld" /> — what is
+    ///     literally in his hand — and never his compartments. The lower elevator access card lives in
+    ///     those until he reveals it, and in the original it is not inside him at all until the reveal
+    ///     daemon moves it there (<c>globals.zil:1456-1463</c>), so ASK-FOR could not produce it early.
+    ///     Reaching in here would hand the player a puzzle's answer on turn one.
+    ///     </para>
+    /// </summary>
+    private IItem? ResolveRequestedItem(string said, IContext context)
+    {
+        var held = floyd.ItemBeingHeld;
+
+        // NounMatch.CouldName, not HasMatchingNoun: the container-derived items override the latter
+        // into exact equality, which no free-form sentence will ever satisfy.
+        if (held is not null && (NounMatch.CouldName(held, said) || PointsAtItWithoutNaming(said)))
+            return held;
+
+        // Candidate order mirrors Repository.GetPreciseMatchInScope: room before inventory.
+        var candidates = new List<IItem>();
+        if (context.CurrentLocation is ICanContainItems here)
+            candidates.AddRange(here.GetAllItemsRecursively ?? []);
+        candidates.AddRange(context.GetAllItemsRecursively ?? []);
+
+        return candidates.FirstOrDefault(candidate => NounMatch.CouldName(candidate, said));
+    }
+
+    /// <summary>
+    ///     Does the request point at the held item with a bare pronoun rather than naming it? True only
+    ///     when the pronoun is the OBJECT of the request — the last word, or followed by one of the
+    ///     tails that can trail it. The distinction is the whole point: "give it back" and "give it to
+    ///     me" are this mechanic, while "give me that joke" and "tell me this story" use the same words
+    ///     as determiners in front of something that is not an object at all, and handing over the
+    ///     diary because the player asked for a joke would be worse than the bug being fixed.
+    /// </summary>
+    private static bool PointsAtItWithoutNaming(string said)
+    {
+        var words = said.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+
+        for (var i = 0; i < words.Length; i++)
+        {
+            if (!PronounsForTheHeldItem.Contains(words[i]))
+                continue;
+
+            if (i == words.Length - 1 || PronounTails.Contains(words[i + 1]))
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    ///     V-ASK-FOR's success branch (<c>compone.zil:2054-2058</c>): the item goes straight into the
+    ///     player's hands, by the same <c>Context.Take</c> the direct "take &lt;item&gt;" command uses.
+    /// </summary>
+    private string HandOver(IItem item, IContext context)
+    {
+        ReleaseFromHisHand(item);
+        context.Take(item);
+
+        return string.Format(FloydConstants.HandsYouTheItem, item.Name);
+    }
+
+    /// <summary>
+    ///     V?DROP's success branch (<c>compone.zil:1913-1917</c>): the item lands on the floor.
+    ///     <para>
+    ///     Deliberate divergence: the original rolls <c>PROB 50</c> and half the time has Floyd clutch
+    ///     the object and refuse ("Floyd won't," he says defiantly). He always complies here — owner's
+    ///     call. A coin-flip refusal reads as the same stonewalling this issue is about to a player who
+    ///     has no way of knowing that asking twice would work.
+    ///     </para>
+    /// </summary>
+    private string LetGoOf(IItem item, IContext context)
+    {
+        ReleaseFromHisHand(item);
+        context.CurrentLocation.ItemPlacedHere(item);
+
+        return string.Format(FloydConstants.ShrugsAndDrops, item.Name);
+    }
+
+    /// <summary>
+    ///     Takes the item out of Floyd's hand, and retires the take-callback stamp that put it there.
+    ///     <para>
+    ///     The stamp matters. <see cref="FloydInventoryManager.OfferItem" /> writes
+    ///     "Floyd,BeingTakenCallback" onto the item and nothing ever clears it, and that callback nulls
+    ///     <c>ItemBeingHeld</c> whoever picks the item up and whenever. An item Floyd once held, left
+    ///     lying on the floor, would therefore strip him of whatever he is holding LATER when the player
+    ///     picks it up — orphaning that second item with its CurrentLocation still pointing at Floyd but
+    ///     in neither his hand nor his compartments, which is out of scope for good. Clearing his grip
+    ///     here rather than leaning on the callback keeps that stamp from outliving its one use.
+    ///     </para>
+    /// </summary>
+    private void ReleaseFromHisHand(IItem item)
+    {
+        floyd.ItemBeingHeld = null;
+        item.OnBeingTakenCallback = null;
+    }
+
+    /// <summary>
+    ///     Finishes a bridged turn: remembers what Floyd said, so his idle chatter can refer back to it,
+    ///     and stops him acting again this turn. The original sets <c>FLOYD-SPOKE</c> for every command
+    ///     addressed to him (<c>compone.zil:1854</c>) for exactly that reason, and the Repair Room
+    ///     bridges already do the same.
+    /// </summary>
+    private string Speak(string line, IContext context)
+    {
+        floyd.LastTurnsOutput.Push(line);
+        floyd.SkipActingThisTurn(context);
+        return line;
+    }
+}

--- a/UnitTests/IntentMappings/base-mappings.json
+++ b/UnitTests/IntentMappings/base-mappings.json
@@ -304,6 +304,13 @@
     { "inputs": ["give the plate to floyd", "give plate to floyd"], "verb": "give", "nounOne": "plate", "nounTwo": "floyd", "preposition": "to", "originalInput": "give the plate to floyd" },
     { "inputs": ["give the breastplate to floyd", "give breastplate to floyd"], "verb": "give", "nounOne": "breastplate", "nounTwo": "floyd", "preposition": "to", "originalInput": "give the breastplate to floyd" },
     { "inputs": ["give id card to floyd", "give the id card to floyd"], "verb": "give", "nounOne": "id card", "nounTwo": "floyd", "preposition": "to", "originalInput": "give id card to floyd" },
+    { "inputs": ["give the brush to floyd", "give brush to floyd"], "verb": "give", "nounOne": "brush", "nounTwo": "floyd", "preposition": "to", "originalInput": "give the brush to floyd" },
+
+    // The original's own grammar for asking a companion to hand something over: TELL/ASK <actor> FOR
+    // <object> (Planetfall syntax.zil:341-342, V-ASK-FOR). Reaches Floyd as a multi-noun command, not
+    // as speech, because the leading word is the verb rather than his name (issue #521).
+    { "inputs": ["ask floyd for the diary", "ask floyd for diary"], "verb": "ask", "nounOne": "floyd", "nounTwo": "diary", "preposition": "for", "originalInput": "ask floyd for the diary" },
+    { "inputs": ["ask floyd for help"], "verb": "ask", "nounOne": "floyd", "nounTwo": "help", "preposition": "for", "originalInput": "ask floyd for help" },
     { "inputs": ["show printout to floyd", "show the printout to floyd"], "verb": "show", "nounOne": "printout", "nounTwo": "floyd", "preposition": "to", "originalInput": "show printout to floyd" },
     { "inputs": ["show id card to floyd", "show the id card to floyd"], "verb": "show", "nounOne": "id card", "nounTwo": "floyd", "preposition": "to", "originalInput": "show id card to floyd" },
     { "inputs": ["show kitchen card to floyd"], "verb": "show", "nounOne": "kitchen card", "nounTwo": "floyd", "preposition": "to", "originalInput": "show kitchen card to floyd" },


### PR DESCRIPTION
Closes #521.

## The bug

Ask Floyd for something he is holding and he refuses with confidence — *"Floyd wonders if brushing is fun, but he cannot drop things, sorry."* Then `take brush` retrieves it from him instantly, proving the claim false. A player who took him at his word would reasonably conclude the item was stuck with him forever.

## What the original does

Both are real mechanics in `FLOYD-F`, and fully specified:

| Request | ZIL | Behavior |
|---|---|---|
| `floyd, give me the X` | `V?ASK-FOR`, `compone.zil:2053-2060` | Item goes straight into inventory: *"Okay," says Floyd, handing you the X, "but only because you're Floyd's best friend."* |
| `floyd, drop the X` | `V?DROP`, `compone.zil:1912-1923` | Item lands on the floor: *Floyd shrugs and drops the X.* |
| either, for something he hasn't got | `FLOYD-NOT-HAVE`, `compone.zil:2121-2122` | *"Floyd does not one of those have!"* |

`compone.zil:1855-1864` also shows `GIVE`/`SGIVE` with the player as recipient re-performing as `ASK-FOR`, so *"give me the brush"* and *"give the brush to me"* are one mechanic — and the recipient must be the player (`<EQUAL? ,PRSI ,ME>`).

## Root cause, on both sides

`Floyd.OnBeingTalkedTo` sent everything conversational to the chat service, and only `FloydLocationBehaviors` bridged anything back to game state (Repair Room, two scripted actions). The other half is worth recording: the companion Lambda's prompt **instructs** this refusal — it lists `"floyd, give me the brush"` as a canonical decline example, supplies *"a brush got stuck once and made a big mess"* as flavor, and says classification is `"NOT for drop / put / give / hold -- those are just declines"`. The false blanket claim was prompt-directed, not improvised.

## The fix

A new `FloydItemRequests` bridges both mechanics **deterministically, before the chat call**.

Metadata was the issue's other suggestion and cannot work today: the Lambda emits no intent for these requests, and the self-hosted path (`LocalCompanionChat`) returns no metadata at all — so a metadata bridge would fix neither backend. Matching the player's own words costs no round-trip and works in both.

Anything unrecognized returns `null` and reaches the service exactly as before, so this can only add behavior — `floyd, give me a hug` stays a joke. Hand-over reuses the same `Context.Take` the working `take <item>` path uses, and a bridged turn sets `SkipActingThisTurn`, the port's equivalent of the `FLOYD-SPOKE` the original sets for every command addressed to him (`compone.zil:1854`).

Also wires the original's own command grammar, `ASK <actor> FOR <object>` (`syntax.zil:341-342`), which reaches Floyd as a multi-noun command rather than as speech because it leads with the verb instead of his name.

## Two deliberate calls

- **Drop always complies.** The original rolls `PROB 50` and otherwise has Floyd clutch the object defiantly. A coin-flip refusal reads as the same stonewalling this issue is about to a player with no way of knowing that asking twice works.
- **Only what is in his hand, never his compartments.** The lower elevator access card sits there until he reveals it, and in the original it is not inside him at all until the reveal daemon moves it (`globals.zil:1456-1463`), so `ASK-FOR` could never produce it early. Reaching in would hand over a puzzle's answer on turn one.

## Traps closed on the way, each pinned by a test

- **Negation.** `floyd, don't drop the diary` is the opposite of a drop. Verified load-bearing: with the guard removed, that command drops the diary and `never give me the diary` hands it over.
- **Pronoun as determiner.** `it`/`that` mean the held item only when they are the *object* of the request. Without this, `floyd, give me that joke` handed over the diary — a worse bug than the one being fixed.
- **Punctuation.** Sentence punctuation is normalized before noun matching, or `give me the diary, please` carries `"diary,"` and matches no noun.
- **Stale take-callback.** Releasing the item retires the `OnBeingTakenCallback` stamp, which nothing otherwise clears. An item Floyd once held, left on the floor, would strip him of whatever he held *later* when the player picked it up — orphaning that second item with `CurrentLocation` still pointing at Floyd but in neither his hand nor his compartments, out of scope for good.

## Tests

TDD throughout: 11 new `FloydTests` were red first, each failing because the chat sentinel answered instead of the mechanic — the bug itself. Plus a `LiveParserShapeTests` case pinning the real parser's shape for `ask floyd for the diary`, since that phrasing is the one that never arrives as speech, and `base-mappings.json` only models the parser.

All suites green, run separately: Planetfall 4054, UnitTests 1350, ZorkOne 1782, Stationfall 132, EscapeRoom 9, Console 26.

## Not in this PR

- `FloydPowerManager.Deactivate` does not drop what Floyd is carrying, though `compone.zil:1944-1956` explicitly does (*", dropping what he was carrying."*). The release helper added here is what a fix would reuse.
- The companion Lambda's prompt in `arsindelve/Floyd` still describes give/drop as things Floyd cannot do. The bridge means the model never sees the matched phrasings, so it is now cosmetic — but wrong for whatever the matcher misses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)